### PR TITLE
feat(api): rest v2 rerun from step

### DIFF
--- a/cmd/apiv2cli/cmd.go
+++ b/cmd/apiv2cli/cmd.go
@@ -234,7 +234,22 @@ func endpointFlags(ep endpoint) []cli.Flag {
 			category = "Body"
 		}
 
+		if ep.name == "rerun" && flagName == "from-step" {
+			flags = append(flags, &cli.StringFlag{
+				Category: category,
+				Name:     flagName,
+				Usage:    "Step name to rerun from.",
+			})
+			continue
+		}
 		flags = append(flags, flagForField(category, flagName, field))
+	}
+	if ep.name == "rerun" {
+		flags = append(flags, &cli.StringFlag{
+			Category: "Body",
+			Name:     "input",
+			Usage:    "Optional replacement step input as a JSON array.",
+		})
 	}
 
 	return flags
@@ -693,6 +708,11 @@ func requestBody(cmd *cli.Command, ep endpoint) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if ep.name == "rerun" {
+		if err := addRerunFromStepBody(cmd, body); err != nil {
+			return nil, err
+		}
+	}
 
 	fields := ep.input.Fields()
 	for i := 0; i < fields.Len(); i++ {
@@ -703,6 +723,9 @@ func requestBody(cmd *cli.Command, ep endpoint) (map[string]any, error) {
 		}
 
 		flagName := kebab(name)
+		if ep.name == "rerun" && flagName == "from-step" {
+			continue
+		}
 		if !cmd.IsSet(flagName) {
 			continue
 		}
@@ -719,6 +742,30 @@ func requestBody(cmd *cli.Command, ep endpoint) (map[string]any, error) {
 	}
 
 	return body, nil
+}
+
+func addRerunFromStepBody(cmd *cli.Command, body map[string]any) error {
+	if !cmd.IsSet("from-step") {
+		if cmd.IsSet("input") {
+			return errors.New("--input requires --from-step")
+		}
+		return nil
+	}
+
+	fromStep := map[string]any{"stepId": cmd.String("from-step")}
+
+	if cmd.IsSet("input") {
+		var input []any
+		if err := json.Unmarshal([]byte(cmd.String("input")), &input); err != nil {
+			return fmt.Errorf("--input must be a valid JSON array: %w", err)
+		}
+		if input == nil {
+			return errors.New("--input must be a valid JSON array")
+		}
+		fromStep["input"] = input
+	}
+	body["fromStep"] = fromStep
+	return nil
 }
 
 func rawBody(cmd *cli.Command) (map[string]any, error) {

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -160,6 +160,27 @@ func TestEndpointFlagsUseProtoFieldDescriptions(t *testing.T) {
 	require.Contains(t, byName["idempotency-key"].String(), "Optional idempotency key")
 }
 
+func TestRerunFromStepFlagDescribesJSONShape(t *testing.T) {
+	var rerun endpoint
+	for _, ep := range discoverEndpoints() {
+		if ep.name == "rerun" {
+			rerun = ep
+			break
+		}
+	}
+	require.NotEmpty(t, rerun.name)
+
+	flags := endpointFlags(rerun)
+	byName := map[string]cli.Flag{}
+	for _, flag := range flags {
+		byName[flag.Names()[0]] = flag
+	}
+
+	require.Contains(t, byName["from-step"].String(), `{"stepId":"5b8ee3806d3f5184753c00662758aaaf831cabf5","input":[{"foo":"bar"}]}`)
+	require.Contains(t, byName["from-step"].String(), "Use the stepId from get-function-trace, not the step name")
+	require.Contains(t, byName["from-step"].String(), "input field is optional and must be an array")
+}
+
 func TestEndpointDescriptionReferencesValidFlags(t *testing.T) {
 	var invoke endpoint
 	for _, ep := range discoverEndpoints() {

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -160,7 +160,7 @@ func TestEndpointFlagsUseProtoFieldDescriptions(t *testing.T) {
 	require.Contains(t, byName["idempotency-key"].String(), "Optional idempotency key")
 }
 
-func TestRerunFromStepFlagDescribesJSONShape(t *testing.T) {
+func TestRerunFromStepFlagsDescribeSimpleShape(t *testing.T) {
 	var rerun endpoint
 	for _, ep := range discoverEndpoints() {
 		if ep.name == "rerun" {
@@ -176,9 +176,8 @@ func TestRerunFromStepFlagDescribesJSONShape(t *testing.T) {
 		byName[flag.Names()[0]] = flag
 	}
 
-	require.Contains(t, byName["from-step"].String(), `{"stepId":"5b8ee3806d3f5184753c00662758aaaf831cabf5","input":[{"foo":"bar"}]}`)
-	require.Contains(t, byName["from-step"].String(), "Use the stepId from get-function-trace, not the step name")
-	require.Contains(t, byName["from-step"].String(), "input field is optional and must be an array")
+	require.Contains(t, byName["from-step"].String(), "Step name to rerun from")
+	require.Contains(t, byName["input"].String(), "replacement step input as a JSON array")
 }
 
 func TestEndpointDescriptionReferencesValidFlags(t *testing.T) {
@@ -250,6 +249,53 @@ func TestCommandCallsGeneratedEndpoint(t *testing.T) {
 		"idempotencyKey": "idem-1",
 	}, gotBody)
 	require.Contains(t, out.String(), `"runId": "01J00000000000000000000000"`)
+}
+
+func TestCommandBuildsRerunFromStepBody(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"runId":"01J00000000000000000000000"}}`))
+	}))
+	defer srv.Close()
+
+	cmd := Command()
+	cmd.Writer = &bytes.Buffer{}
+	err := cmd.Run(context.Background(), []string{
+		"api",
+		"--api-host", srv.URL,
+		"rerun",
+		"01J00000000000000000000001",
+		"--from-step", "step 2",
+		"--input", `[{"foo":"bar"}]`,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		"fromStep": map[string]any{
+			"stepId": "step 2",
+			"input":  []any{map[string]any{"foo": "bar"}},
+		},
+	}, gotBody)
+
+	cmd = Command()
+	cmd.Writer = &bytes.Buffer{}
+	err = cmd.Run(context.Background(), []string{
+		"api",
+		"--api-host", srv.URL,
+		"rerun",
+		"01J00000000000000000000001",
+		"--body", `{"fromStep":{"stepId":"step 3","input":[1]}}`,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{
+		"fromStep": map[string]any{
+			"stepId": "step 3",
+			"input":  []any{float64(1)},
+		},
+	}, gotBody)
 }
 
 func TestCommandUsesQueryParamsForGetEndpoint(t *testing.T) {

--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -239,6 +239,10 @@ func (s *Service) Rerun(ctx context.Context, req *apiv2.RerunRequest) (*apiv2.Re
 			return nil, s.base.NewError(http.StatusNotFound, apiv2base.ErrorNotFound, "Run not found")
 		case errors.Is(err, ErrCronRerunNotSupported):
 			return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Rerunning cron-triggered runs is not yet supported")
+		case errors.Is(err, ErrRerunStepNotFound):
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidRequest, "Step not found in original run")
+		case errors.Is(err, ErrRerunStepAmbiguous):
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidRequest, "Step name matches multiple steps in original run")
 		}
 		return nil, s.base.NewError(http.StatusInternalServerError, apiv2base.ErrorInternalError, "Unable to rerun run")
 	}

--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -214,12 +214,25 @@ func (s *Service) Rerun(ctx context.Context, req *apiv2.RerunRequest) (*apiv2.Re
 		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Run ID must be a valid ULID")
 	}
 
+	reqOpts := RerunOpts{}
 	if req.FromStep != nil {
-		// TODO: Re-enable once rerun from step reconstruction is fully implemented.
-		return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Rerun from step is not yet implemented")
+		if req.FromStep.StepId == "" {
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorMissingField, "Step ID is required")
+		}
+
+		fromStep := &RerunFromStep{StepID: req.FromStep.StepId}
+		if req.FromStep.Input != nil {
+			input, err := json.Marshal(req.FromStep.Input.AsSlice())
+			if err != nil {
+				return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Step input must be a valid JSON array")
+			}
+			fromStep.Input = input
+		}
+
+		reqOpts.FromStep = fromStep
 	}
 
-	newRunID, err := s.runs.Rerun(ctx, runID, RerunOpts{})
+	newRunID, err := s.runs.Rerun(ctx, runID, reqOpts)
 	if err != nil {
 		switch {
 		case errors.Is(err, ErrRunNotFound):

--- a/pkg/api/v2/errors.go
+++ b/pkg/api/v2/errors.go
@@ -7,6 +7,8 @@ var (
 	ErrAppNotFound           = errors.New("app not found")
 	ErrRunNotFound           = errors.New("run not found")
 	ErrCronRerunNotSupported = errors.New("cron rerun is not supported")
+	ErrRerunStepNotFound     = errors.New("rerun step not found")
+	ErrRerunStepAmbiguous    = errors.New("rerun step name is ambiguous")
 
 	// ErrScoresNotEnabled is returned by ScoreProvider implementations when
 	// score submission is not enabled for the authenticated account.

--- a/pkg/api/v2/http_test.go
+++ b/pkg/api/v2/http_test.go
@@ -266,9 +266,10 @@ func TestHTTPGateway_Rerun(t *testing.T) {
 	require.Equal(t, newRunID.String(), data["runId"])
 }
 
-func TestHTTPGateway_RerunFromStepNotImplemented(t *testing.T) {
+func TestHTTPGateway_RerunFromStep(t *testing.T) {
 	ctx := context.Background()
 	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")
+	newRunID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4d0")
 	body, err := json.Marshal(map[string]any{
 		"fromStep": map[string]any{
 			"stepId": "step-1",
@@ -280,6 +281,12 @@ func TestHTTPGateway_RerunFromStepNotImplemented(t *testing.T) {
 	require.NoError(t, err)
 
 	rerun := &mockRunProvider{}
+	rerun.On("Rerun", mock.Anything, runID, RerunOpts{
+		FromStep: &RerunFromStep{
+			StepID: "step-1",
+			Input:  json.RawMessage(`[{"foo":"bar"}]`),
+		},
+	}).Return(newRunID, nil).Once()
 	handler, err := newTestHTTPHandler(ctx, ServiceOptions{Runs: rerun}, HTTPHandlerOptions{})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -293,13 +300,12 @@ func TestHTTPGateway_RerunFromStepNotImplemented(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	require.Equal(t, http.StatusNotImplemented, rec.Code)
+	require.Equal(t, http.StatusOK, rec.Code)
 
-	var response errorResponse
+	var response map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
-	require.Len(t, response.Errors, 1)
-	require.Equal(t, apiv2base.ErrorNotImplemented, response.Errors[0].Code)
-	require.Equal(t, "Rerun from step is not yet implemented", response.Errors[0].Message)
+	data := response["data"].(map[string]any)
+	require.Equal(t, newRunID.String(), data["runId"])
 }
 
 func TestHTTPGateway_GetApp(t *testing.T) {

--- a/pkg/api/v2/http_test.go
+++ b/pkg/api/v2/http_test.go
@@ -1,6 +1,7 @@
 package apiv2
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -306,6 +307,49 @@ func TestHTTPGateway_RerunFromStep(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
 	data := response["data"].(map[string]any)
 	require.Equal(t, newRunID.String(), data["runId"])
+}
+
+func TestHTTPGateway_RerunFromStepErrors(t *testing.T) {
+	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")
+	tests := []struct {
+		name    string
+		stepID  string
+		err     error
+		message string
+	}{
+		{name: "missing step", stepID: "missing", err: ErrRerunStepNotFound, message: "Step not found in original run"},
+		{name: "ambiguous step", stepID: "duplicate", err: ErrRerunStepAmbiguous, message: "Step name matches multiple steps in original run"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rerun := &mockRunProvider{}
+			rerun.On("Rerun", mock.Anything, runID, RerunOpts{
+				FromStep: &RerunFromStep{StepID: tt.stepID},
+			}).Return(ulid.ULID{}, tt.err).Once()
+			t.Cleanup(func() {
+				rerun.AssertExpectations(t)
+			})
+
+			handler, err := newTestHTTPHandler(context.Background(), ServiceOptions{Runs: rerun}, HTTPHandlerOptions{})
+			require.NoError(t, err)
+			body, err := json.Marshal(map[string]any{
+				"fromStep": map[string]any{"stepId": tt.stepID},
+			})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v2/runs/"+runID.String()+"/rerun", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			var response errorResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+			require.Equal(t, apiv2base.ErrorInvalidRequest, response.Errors[0].Code)
+			require.Equal(t, tt.message, response.Errors[0].Message)
+		})
+	}
 }
 
 func TestHTTPGateway_GetApp(t *testing.T) {

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -1425,6 +1425,42 @@ func TestService_Rerun(t *testing.T) {
 		require.ErrorContains(t, err, "Rerunning cron-triggered runs is not yet supported")
 	})
 
+	t.Run("maps missing rerun step", func(t *testing.T) {
+		opts := RerunOpts{FromStep: &RerunFromStep{StepID: "missing"}}
+		rerun := &mockRunProvider{}
+		rerun.On("Rerun", mock.Anything, runID, opts).Return(ulid.ULID{}, ErrRerunStepNotFound).Once()
+		t.Cleanup(func() {
+			rerun.AssertExpectations(t)
+		})
+
+		service := NewService(ServiceOptions{Runs: rerun})
+		resp, err := service.Rerun(context.Background(), &apiv2.RerunRequest{
+			RunId:    runID.String(),
+			FromStep: &apiv2.RerunFromStep{StepId: "missing"},
+		})
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "Step not found in original run")
+	})
+
+	t.Run("maps ambiguous rerun step", func(t *testing.T) {
+		opts := RerunOpts{FromStep: &RerunFromStep{StepID: "duplicate"}}
+		rerun := &mockRunProvider{}
+		rerun.On("Rerun", mock.Anything, runID, opts).Return(ulid.ULID{}, ErrRerunStepAmbiguous).Once()
+		t.Cleanup(func() {
+			rerun.AssertExpectations(t)
+		})
+
+		service := NewService(ServiceOptions{Runs: rerun})
+		resp, err := service.Rerun(context.Background(), &apiv2.RerunRequest{
+			RunId:    runID.String(),
+			FromStep: &apiv2.RerunFromStep{StepId: "duplicate"},
+		})
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "Step name matches multiple steps in original run")
+	})
+
 	t.Run("applies rate limit", func(t *testing.T) {
 		rateLimiter := &mockRateLimitProvider{}
 		rateLimiter.On("CheckRateLimit", mock.Anything, apiv2.V2_Rerun_FullMethodName).

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -1336,11 +1336,17 @@ func TestService_Rerun(t *testing.T) {
 		require.NotNil(t, resp.Metadata.FetchedAt)
 	})
 
-	t.Run("rejects from step opts", func(t *testing.T) {
+	t.Run("reruns from step", func(t *testing.T) {
 		input, err := structpb.NewList([]any{map[string]any{"foo": "bar"}})
 		require.NoError(t, err)
 
 		rerun := &mockRunProvider{}
+		rerun.On("Rerun", mock.Anything, runID, RerunOpts{
+			FromStep: &RerunFromStep{
+				StepID: "step-1",
+				Input:  json.RawMessage(`[{"foo":"bar"}]`),
+			},
+		}).Return(newRunID, nil).Once()
 		t.Cleanup(func() {
 			rerun.AssertExpectations(t)
 		})
@@ -1354,8 +1360,8 @@ func TestService_Rerun(t *testing.T) {
 			},
 		})
 
-		require.Nil(t, resp)
-		require.ErrorContains(t, err, "Rerun from step is not yet implemented")
+		require.NoError(t, err)
+		require.Equal(t, newRunID.String(), resp.Data.RunId)
 	})
 
 	t.Run("requires run id", func(t *testing.T) {
@@ -1384,7 +1390,7 @@ func TestService_Rerun(t *testing.T) {
 		})
 
 		require.Nil(t, resp)
-		require.ErrorContains(t, err, "Rerun from step is not yet implemented")
+		require.ErrorContains(t, err, "Step ID is required")
 	})
 
 	t.Run("maps missing run", func(t *testing.T) {

--- a/pkg/devserver/run_provider.go
+++ b/pkg/devserver/run_provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/executor"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
@@ -185,6 +186,12 @@ func (p *runProvider) Rerun(ctx context.Context, runID ulid.ULID, opts apiv2.Rer
 		PreventRateLimit: true,
 	})
 	if err != nil {
+		switch {
+		case errors.Is(err, executor.ErrRerunStepNotFound):
+			return ulid.ULID{}, apiv2.ErrRerunStepNotFound
+		case errors.Is(err, executor.ErrRerunStepAmbiguous):
+			return ulid.ULID{}, apiv2.ErrRerunStepAmbiguous
+		}
 		return ulid.ULID{}, err
 	}
 	if newRunID == nil {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -647,6 +647,9 @@ func rerunFromStepEdge(req execution.ScheduleRequest, memoizedSteps []state.Memo
 	if req.FromStep == nil || req.FromStep.StepID == "" {
 		return inngest.SourceEdge
 	}
+	if result == nil || result.fromStepID == "" {
+		panic("rerun from step reconstruction result is required")
+	}
 
 	edge := inngest.Edge{
 		Incoming: inngest.TriggerName,
@@ -654,10 +657,7 @@ func rerunFromStepEdge(req execution.ScheduleRequest, memoizedSteps []state.Memo
 	if shouldTargetRerunFromStep(result) {
 		//
 		// Runnable steps should execute directly with any FromStep input override.
-		edge.IncomingGeneratorStep = req.FromStep.StepID
-		if result != nil && result.fromStepID != "" {
-			edge.IncomingGeneratorStep = result.fromStepID
-		}
+		edge.IncomingGeneratorStep = result.fromStepID
 	}
 	if len(memoizedSteps) > 0 {
 		//

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -655,6 +655,9 @@ func rerunFromStepEdge(req execution.ScheduleRequest, memoizedSteps []state.Memo
 		//
 		// Runnable steps should execute directly with any FromStep input override.
 		edge.IncomingGeneratorStep = req.FromStep.StepID
+		if result != nil && result.fromStepID != "" {
+			edge.IncomingGeneratorStep = result.fromStepID
+		}
 	}
 	if len(memoizedSteps) > 0 {
 		//

--- a/pkg/execution/executor/reconstruct.go
+++ b/pkg/execution/executor/reconstruct.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -13,6 +14,11 @@ import (
 	"github.com/inngest/inngest/pkg/execution/state"
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing/meta"
+)
+
+var (
+	ErrRerunStepNotFound  = errors.New("rerun step not found")
+	ErrRerunStepAmbiguous = errors.New("rerun step name is ambiguous")
 )
 
 type reconstructResult struct {
@@ -115,11 +121,14 @@ func resolveRerunStepID(root *cqrs.OtelSpan, requested string) (string, error) {
 		}
 
 		stepID := *span.Attributes.StepID
+		//
+		// Keep accepting internal step IDs for backward compatibility when an ID
+		// happens to match another step's user-defined name.
 		if stepID == requested {
 			matchingIDs = map[string]struct{}{stepID: {}}
 			return
 		}
-		if span.GetStepName() == requested {
+		if span.Attributes.StepName != nil && *span.Attributes.StepName == requested {
 			matchingIDs[stepID] = struct{}{}
 		}
 	})
@@ -128,15 +137,15 @@ func resolveRerunStepID(root *cqrs.OtelSpan, requested string) (string, error) {
 		return requested, nil
 	}
 	if len(matchingIDs) == 0 {
-		return "", fmt.Errorf("step to run from not found in original run")
+		return "", ErrRerunStepNotFound
 	}
 	if len(matchingIDs) > 1 {
-		return "", fmt.Errorf("step name matches multiple steps in original run")
+		return "", ErrRerunStepAmbiguous
 	}
 	for stepID := range matchingIDs {
 		return stepID, nil
 	}
-	return "", fmt.Errorf("step to run from not found in original run")
+	return "", ErrRerunStepNotFound
 }
 
 type reconstructStepsResult []reconstructStep

--- a/pkg/execution/executor/reconstruct.go
+++ b/pkg/execution/executor/reconstruct.go
@@ -16,6 +16,7 @@ import (
 )
 
 type reconstructResult struct {
+	fromStepID string
 	fromStepOp *enums.Opcode
 }
 
@@ -28,22 +29,24 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 		return nil, fmt.Errorf("original run trace not found")
 	}
 
-	//
-	// executor.step spans identify completed step order and output IDs.
-	stepsToCopy, foundStepToRunFrom := reconstructSteps(root, req.FromStep.StepID)
-
-	if !foundStepToRunFrom {
-		return nil, fmt.Errorf("step to run from not found in original run")
+	fromStepID, err := resolveRerunStepID(root, req.FromStep.StepID)
+	if err != nil {
+		return nil, err
 	}
 
+	//
+	// executor.step spans identify completed step order and output IDs.
+	stepsToCopy, _ := reconstructSteps(root, fromStepID)
+
 	result := &reconstructResult{
+		fromStepID: fromStepID,
 		fromStepOp: stepsToCopy.fromStepOp(),
 	}
 
 	steps := []state.MemoizedStep{}
 
 	for _, step := range stepsToCopy {
-		if step.id == req.FromStep.StepID {
+		if step.id == fromStepID {
 			break
 		}
 
@@ -91,13 +94,49 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 		// Rerun from step can alter input for FromStep, so keep it out of completed step output.
 		newState.StepInputs = []state.MemoizedStep{
 			{
-				ID:   req.FromStep.StepID,
+				ID:   fromStepID,
 				Data: req.FromStep.Input,
 			},
 		}
 	}
 
 	return result, nil
+}
+
+func resolveRerunStepID(root *cqrs.OtelSpan, requested string) (string, error) {
+	matchingIDs := map[string]struct{}{}
+
+	walkOtelSpans(root, func(span *cqrs.OtelSpan) {
+		if span == nil || span.Attributes == nil || span.Name != meta.SpanNameStep {
+			return
+		}
+		if span.Attributes.StepID == nil || *span.Attributes.StepID == "" {
+			return
+		}
+
+		stepID := *span.Attributes.StepID
+		if stepID == requested {
+			matchingIDs = map[string]struct{}{stepID: {}}
+			return
+		}
+		if span.GetStepName() == requested {
+			matchingIDs[stepID] = struct{}{}
+		}
+	})
+
+	if _, ok := matchingIDs[requested]; ok {
+		return requested, nil
+	}
+	if len(matchingIDs) == 0 {
+		return "", fmt.Errorf("step to run from not found in original run")
+	}
+	if len(matchingIDs) > 1 {
+		return "", fmt.Errorf("step name matches multiple steps in original run")
+	}
+	for stepID := range matchingIDs {
+		return stepID, nil
+	}
+	return "", fmt.Errorf("step to run from not found in original run")
 }
 
 type reconstructStepsResult []reconstructStep

--- a/pkg/execution/executor/reconstruct_test.go
+++ b/pkg/execution/executor/reconstruct_test.go
@@ -255,7 +255,25 @@ func TestReconstructRejectsAmbiguousStepName(t *testing.T) {
 		},
 	}, &sv2.CreateState{})
 
-	require.ErrorContains(t, err, "step name matches multiple steps")
+	require.ErrorIs(t, err, ErrRerunStepAmbiguous)
+}
+
+func TestReconstructDoesNotUseSpanNameAsStepName(t *testing.T) {
+	runID := ulid.Make()
+	root := &cqrs.OtelSpan{
+		Children: []*cqrs.OtelSpan{
+			executorStepSpan("internal-step-id", time.UnixMilli(1), nil, nil),
+		},
+	}
+
+	_, err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
+		OriginalRunID: &runID,
+		FromStep: &execution.ScheduleRequestFromStep{
+			StepID: meta.SpanNameStep,
+		},
+	}, &sv2.CreateState{})
+
+	require.ErrorIs(t, err, ErrRerunStepNotFound)
 }
 
 func TestRerunFromStepEdgeTargetsRunnableStep(t *testing.T) {
@@ -287,6 +305,7 @@ func TestRerunFromStepEdgeDoesNotTargetPlannedStep(t *testing.T) {
 	}, []state.MemoizedStep{
 		{ID: "step-1"},
 	}, &reconstructResult{
+		fromStepID: "sleep-step",
 		fromStepOp: &stepOp,
 	})
 
@@ -298,13 +317,21 @@ func TestRerunFromStepEdgeDoesNotTargetPlannedStep(t *testing.T) {
 func TestRerunFromStepEdgeTargetsFirstStep(t *testing.T) {
 	edge := rerunFromStepEdge(execution.ScheduleRequest{
 		FromStep: &execution.ScheduleRequestFromStep{
-			StepID: "step-1",
+			StepID: "external-step-name",
 		},
-	}, nil, nil)
+	}, nil, &reconstructResult{fromStepID: "internal-step-id"})
 
 	require.Empty(t, edge.Outgoing)
 	require.Equal(t, "$trigger", edge.Incoming)
-	require.Equal(t, "step-1", edge.IncomingGeneratorStep)
+	require.Equal(t, "internal-step-id", edge.IncomingGeneratorStep)
+}
+
+func TestRerunFromStepEdgeRequiresReconstructionResult(t *testing.T) {
+	require.Panics(t, func() {
+		rerunFromStepEdge(execution.ScheduleRequest{
+			FromStep: &execution.ScheduleRequestFromStep{StepID: "step-1"},
+		}, nil, nil)
+	})
 }
 
 func TestRerunFromStepEdgeDefaultsToSource(t *testing.T) {

--- a/pkg/execution/executor/reconstruct_test.go
+++ b/pkg/execution/executor/reconstruct_test.go
@@ -215,6 +215,49 @@ func TestReconstructPreservesFromStepInput(t *testing.T) {
 	require.JSONEq(t, `[6,false]`, string(newState.StepInputs[0].Data.(json.RawMessage)))
 }
 
+func TestReconstructResolvesStepName(t *testing.T) {
+	runID := ulid.Make()
+	fromStepID := "internal-step-id"
+	fromStepName := "step 2"
+	root := &cqrs.OtelSpan{
+		Children: []*cqrs.OtelSpan{
+			executorStepSpan(fromStepID, time.UnixMilli(1), nil, nil, withStepName(fromStepName)),
+		},
+	}
+
+	newState := &sv2.CreateState{}
+	result, err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
+		OriginalRunID: &runID,
+		FromStep: &execution.ScheduleRequestFromStep{
+			StepID: fromStepName,
+			Input:  json.RawMessage(`[{"foo":"bar"}]`),
+		},
+	}, newState)
+
+	require.NoError(t, err)
+	require.Equal(t, fromStepID, result.fromStepID)
+	require.Equal(t, fromStepID, newState.StepInputs[0].ID)
+}
+
+func TestReconstructRejectsAmbiguousStepName(t *testing.T) {
+	runID := ulid.Make()
+	root := &cqrs.OtelSpan{
+		Children: []*cqrs.OtelSpan{
+			executorStepSpan("internal-step-1", time.UnixMilli(1), nil, nil, withStepName("duplicate")),
+			executorStepSpan("internal-step-2", time.UnixMilli(2), nil, nil, withStepName("duplicate")),
+		},
+	}
+
+	_, err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
+		OriginalRunID: &runID,
+		FromStep: &execution.ScheduleRequestFromStep{
+			StepID: "duplicate",
+		},
+	}, &sv2.CreateState{})
+
+	require.ErrorContains(t, err, "step name matches multiple steps")
+}
+
 func TestRerunFromStepEdgeTargetsRunnableStep(t *testing.T) {
 	stepOp := enums.OpcodeStepRun
 	edge := rerunFromStepEdge(execution.ScheduleRequest{
@@ -226,6 +269,7 @@ func TestRerunFromStepEdgeTargetsRunnableStep(t *testing.T) {
 		{ID: "step-2"},
 		{ID: "step-3"},
 	}, &reconstructResult{
+		fromStepID: "step-4",
 		fromStepOp: &stepOp,
 	})
 
@@ -298,6 +342,12 @@ func withSpanID(spanID string) stepSpanOption {
 func withAttempt(attempt int) stepSpanOption {
 	return func(span *cqrs.OtelSpan) {
 		span.Attributes.StepAttempt = &attempt
+	}
+}
+
+func withStepName(stepName string) stepSpanOption {
+	return func(span *cqrs.OtelSpan) {
+		span.Attributes.StepName = &stepName
 	}
 }
 

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -2015,7 +2015,11 @@ message GetEventRunsResponse {
 
 message RerunRequest {
   string run_id = 1;
-  optional RerunFromStep from_step = 2;
+  optional RerunFromStep from_step = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Step rerun options as JSON, for example {\"stepId\":\"5b8ee3806d3f5184753c00662758aaaf831cabf5\",\"input\":[{\"foo\":\"bar\"}]}. Use the stepId from get-function-trace, not the step name. The input field is optional and must be an array."
+    }
+  ];
 }
 
 message RerunFromStep {

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -2017,7 +2017,7 @@ message RerunRequest {
   string run_id = 1;
   optional RerunFromStep from_step = 2 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Step rerun options as JSON, for example {\"stepId\":\"5b8ee3806d3f5184753c00662758aaaf831cabf5\",\"input\":[{\"foo\":\"bar\"}]}. Use the stepId from get-function-trace, not the step name. The input field is optional and must be an array."
+      description: "Step rerun options. stepId is the user-defined step name. The optional input field must be an array."
     }
   ];
 }
@@ -2025,7 +2025,7 @@ message RerunRequest {
 message RerunFromStep {
   string step_id = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Step ID to rerun from"
+      description: "User-defined step name to rerun from"
       example: "\"step-1\""
     }
   ];

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -8593,14 +8593,14 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14GetEventRunsResponse\x12'\n" +
 	"\x04data\x18\x01 \x03(\v2\x13.api.v2.FunctionRunR\x04data\x124\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\x12 \n" +
-	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"\xda\x02\n" +
+	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"\xd8\x01\n" +
 	"\fRerunRequest\x12\x15\n" +
-	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\xa4\x02\n" +
-	"\tfrom_step\x18\x02 \x01(\v2\x15.api.v2.RerunFromStepB\xea\x01\x92A\xe6\x012\xe3\x01Step rerun options as JSON, for example {\"stepId\":\"5b8ee3806d3f5184753c00662758aaaf831cabf5\",\"input\":[{\"foo\":\"bar\"}]}. Use the stepId from get-function-trace, not the step name. The input field is optional and must be an array.H\x00R\bfromStep\x88\x01\x01B\f\n" +
+	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\xa2\x01\n" +
+	"\tfrom_step\x18\x02 \x01(\v2\x15.api.v2.RerunFromStepBi\x92Af2dStep rerun options. stepId is the user-defined step name. The optional input field must be an array.H\x00R\bfromStep\x88\x01\x01B\f\n" +
 	"\n" +
-	"_from_step\"\xd7\x01\n" +
-	"\rRerunFromStep\x12=\n" +
-	"\astep_id\x18\x01 \x01(\tB$\x92A!2\x15Step ID to rerun fromJ\b\"step-1\"R\x06stepId\x12}\n" +
+	"_from_step\"\xe6\x01\n" +
+	"\rRerunFromStep\x12L\n" +
+	"\astep_id\x18\x01 \x01(\tB3\x92A02$User-defined step name to rerun fromJ\b\"step-1\"R\x06stepId\x12}\n" +
 	"\x05input\x18\x02 \x01(\v2\x1a.google.protobuf.ListValueBF\x92AC2/Optional replacement step input as a JSON arrayJ\x10[{\"foo\": \"bar\"}]H\x00R\x05input\x88\x01\x01B\b\n" +
 	"\x06_input\"l\n" +
 	"\rRerunResponse\x12%\n" +

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -8593,10 +8593,10 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14GetEventRunsResponse\x12'\n" +
 	"\x04data\x18\x01 \x03(\v2\x13.api.v2.FunctionRunR\x04data\x124\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\x12 \n" +
-	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"l\n" +
+	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"\xda\x02\n" +
 	"\fRerunRequest\x12\x15\n" +
-	"\x06run_id\x18\x01 \x01(\tR\x05runId\x127\n" +
-	"\tfrom_step\x18\x02 \x01(\v2\x15.api.v2.RerunFromStepH\x00R\bfromStep\x88\x01\x01B\f\n" +
+	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\xa4\x02\n" +
+	"\tfrom_step\x18\x02 \x01(\v2\x15.api.v2.RerunFromStepB\xea\x01\x92A\xe6\x012\xe3\x01Step rerun options as JSON, for example {\"stepId\":\"5b8ee3806d3f5184753c00662758aaaf831cabf5\",\"input\":[{\"foo\":\"bar\"}]}. Use the stepId from get-function-trace, not the step name. The input field is optional and must be an array.H\x00R\bfromStep\x88\x01\x01B\f\n" +
 	"\n" +
 	"_from_step\"\xd7\x01\n" +
 	"\rRerunFromStep\x12=\n" +


### PR DESCRIPTION
## Description

Enables rerun from step in v2 rest rerun api and cli. 

## Release note

`POST /v2/runs/{run_id}/rerun`

with payload:
```json
{
  "fromStep": {
    "stepId": "fetch-user",
    "input": [
      {
        "userId": "user_123"
      }
    ]
  }
}
```

CLI equivalent:
```
inngest api --prod rerun <run_id> \
  --from-step "step 2" \
  --input '[{"foo":"bar"}]'
```

## Migration note

None