### PR TITLE
fix(api): clarify run list commands and docs

### DIFF
--- a/cmd/apiv2cli/cmd.go
+++ b/cmd/apiv2cli/cmd.go
@@ -43,6 +43,11 @@ var pathParamPattern = regexp.MustCompile(`\{([^}=]+)(=[^}]*)?}`)
 var hiddenEndpointMethods = map[string]struct{}{
 	"CreatePartnerAccount": {},
 	"FetchPartnerAccounts": {},
+	"ListFunctionRuns":     {},
+}
+
+var endpointCommandNames = map[string]string{
+	"ListRuns": "get-function-runs",
 }
 
 type endpoint struct {
@@ -356,6 +361,10 @@ func methodHelp(method protoreflect.MethodDescriptor) (string, string) {
 }
 
 func endpointCommandName(methodName string) string {
+	if name, ok := endpointCommandNames[methodName]; ok {
+		return name
+	}
+
 	name := kebab(methodName)
 	for _, prefix := range []string{"fetch-", "list-"} {
 		if strings.HasPrefix(name, prefix) {

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -37,12 +37,16 @@ func TestDiscoverEndpointsFromProto(t *testing.T) {
 	require.Equal(t, []string{"app_id", "function_id"}, byName["invoke-function"].pathParams)
 	require.Equal(t, http.MethodGet, byName["get-function-trace"].method)
 	require.Equal(t, "/runs/{run_id}/trace", byName["get-function-trace"].path)
+	require.NotContains(t, byName, "get-runs")
+	require.Equal(t, "/runs", byName["get-function-runs"].path)
+	require.Empty(t, byName["get-function-runs"].pathParams)
 }
 
 func TestEndpointCommandNameNormalizesReadVerbs(t *testing.T) {
 	require.Equal(t, "get-account", endpointCommandName("FetchAccount"))
 	require.Equal(t, "get-webhooks", endpointCommandName("ListWebhooks"))
 	require.Equal(t, "get-function-run", endpointCommandName("GetFunctionRun"))
+	require.Equal(t, "get-function-runs", endpointCommandName("ListRuns"))
 	require.Equal(t, "create-env", endpointCommandName("CreateEnv"))
 }
 

--- a/docs/api-docs/scripts/generate-docs.ts
+++ b/docs/api-docs/scripts/generate-docs.ts
@@ -8,7 +8,9 @@ const appRoot = resolve(import.meta.dirname, '..');
 const repoRoot = resolve(appRoot, '../..');
 
 type Operation = {
+  description?: string;
   requestBody?: { content?: Record<string, unknown> };
+  summary?: string;
   tags?: string[];
   [extension: `x-${string}`]: unknown;
 };
@@ -21,6 +23,25 @@ type OpenAPIDocument = {
 };
 
 const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace'];
+
+const OPERATION_DOC_OVERRIDES: Record<string, Pick<Operation, 'description' | 'summary'>> = {
+  'GET /apps/{appId}/functions/{functionId}/experiments': {
+    description: 'Lists observed experiments for one function in the authenticated environment.',
+    summary: 'List experiments for a function',
+  },
+};
+
+function applyOperationDocOverrides(doc: OpenAPIDocument): OpenAPIDocument {
+  for (const [path, pathItem] of Object.entries(doc.paths ?? {})) {
+    for (const method of HTTP_METHODS) {
+      const op = pathItem[method];
+      if (!op) continue;
+      const override = OPERATION_DOC_OVERRIDES[`${method.toUpperCase()} ${path}`];
+      if (override) Object.assign(op, override);
+    }
+  }
+  return doc;
+}
 
 /**
  * Operations tagged with any of these names are stripped from the spec before
@@ -176,7 +197,9 @@ async function main() {
   );
   const v2Doc = preserveSpacedTagDisplayNames(
     applySoftTags(
-      hideTaggedOperations(JSON.parse(readFileSync(v2SpecPath, 'utf8')) as OpenAPIDocument)
+      applyOperationDocOverrides(
+        hideTaggedOperations(JSON.parse(readFileSync(v2SpecPath, 'utf8')) as OpenAPIDocument)
+      )
     )
   );
 

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -964,10 +964,10 @@ service V2 {
       get: "/runs"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "List function runs"
+      summary: "List runs"
       tags: "Runs"
       tags: "Beta"
-      description: "Lists function runs in the authenticated environment"
+      description: "Lists runs in the authenticated environment, optionally filtered by app and function IDs"
       security: {
         security_requirement: {
           key: "BearerAuth"
@@ -982,10 +982,10 @@ service V2 {
       get: "/apps/{app_id}/functions/{function_id}/runs"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-      summary: "List function runs"
+      summary: "List runs for a function"
       tags: "Runs"
       tags: "Beta"
-      description: "Lists runs for a function in the authenticated environment"
+      description: "Lists runs for one function in the authenticated environment"
       security: {
         security_requirement: {
           key: "BearerAuth"
@@ -1689,7 +1689,7 @@ service V2 {
       summary: "List experiments"
       tags: "Experiments"
       tags: "Beta"
-      description: "Lists observed experiments in the authenticated environment."
+      description: "Lists observed experiments in the authenticated environment. Use the nested app and function route to scope results to one function."
       security: {
         security_requirement: {
           key: "BearerAuth"

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -9229,7 +9229,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05ERROR\x10\x01\x12\v\n" +
 	"\aWARNING\x10\x02\x12\b\n" +
-	"\x04INFO\x10\x032\x88\x83\x01\n" +
+	"\x04INFO\x10\x032\xf7\x83\x01\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -9483,16 +9483,16 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x04Beta\x12\x10Get function run\x1a;Fetches the canonical run summary for a single function runb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x10\x12\x0e/runs/{run_id}\x12\xb7\x01\n" +
-	"\bListRuns\x12\x17.api.v2.ListRunsRequest\x1a\x18.api.v2.ListRunsResponse\"x\x92Ah\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x10\x12\x0e/runs/{run_id}\x12\xd4\x01\n" +
+	"\bListRuns\x12\x17.api.v2.ListRunsRequest\x1a\x18.api.v2.ListRunsResponse\"\x94\x01\x92A\x83\x01\n" +
 	"\x04Runs\n" +
-	"\x04Beta\x12\x12List function runs\x1a4Lists function runs in the authenticated environmentb\x10\n" +
+	"\x04Beta\x12\tList runs\x1aXLists runs in the authenticated environment, optionally filtered by app and function IDsb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\a\x12\x05/runs\x12\xfc\x01\n" +
-	"\x10ListFunctionRuns\x12\x1f.api.v2.ListFunctionRunsRequest\x1a .api.v2.ListFunctionRunsResponse\"\xa4\x01\x92An\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\a\x12\x05/runs\x12\x84\x02\n" +
+	"\x10ListFunctionRuns\x12\x1f.api.v2.ListFunctionRunsRequest\x1a .api.v2.ListFunctionRunsResponse\"\xac\x01\x92Av\n" +
 	"\x04Runs\n" +
-	"\x04Beta\x12\x12List function runs\x1a:Lists runs for a function in the authenticated environmentb\x10\n" +
+	"\x04Beta\x12\x18List runs for a function\x1a<Lists runs for one function in the authenticated environmentb\x10\n" +
 	"\x0e\n" +
 	"\n" +
 	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02-\x12+/apps/{app_id}/functions/{function_id}/runs\x12\xcf\x01\n" +
@@ -9697,10 +9697,10 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/insights/query\x12\x97\x02\n" +
-	"\x0fListExperiments\x12\x1e.api.v2.ListExperimentsRequest\x1a\x1f.api.v2.ListExperimentsResponse\"\xc2\x01\x92Au\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/insights/query\x12\xe1\x02\n" +
+	"\x0fListExperiments\x12\x1e.api.v2.ListExperimentsRequest\x1a\x1f.api.v2.ListExperimentsResponse\"\x8c\x02\x92A\xbe\x01\n" +
 	"\vExperiments\n" +
-	"\x04Beta\x12\x10List experiments\x1a<Lists observed experiments in the authenticated environment.b\x10\n" +
+	"\x04Beta\x12\x10List experiments\x1a\x84\x01Lists observed experiments in the authenticated environment. Use the nested app and function route to scope results to one function.b\x10\n" +
 	"\x0e\n" +
 	"\n" +
 	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02DZ4\x122/apps/{app_id}/functions/{function_id}/experiments\x12\f/experiments\x12\xb5\x02\n" +


### PR DESCRIPTION
## Description

Generate API docs had duplicated nav entries for our two ways of calling the runs api (`/runs` and `/apps/{id}/function/{id}/runs`) this dedupes those and a similar case for experiments. Also noticed the same two runs api paths bled out into two runs cli commands. I deduped those as well. 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
