### PR TITLE
internal(defers): improve defer validation

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -105,6 +105,19 @@ const (
 	// the parent run.
 	MaxDeferInputAggregateSize = 1024 * 1024 * 4 // 4MB
 
+	// MaxEventMetaSize is the maximum size, in bytes, of a raw event-meta blob
+	// carried opaquely on an op that persists it before validation.
+	//
+	// Currently, only DeferAdd validates. Other uses of EventMeta perform other
+	// validation before persistence.
+	//
+	// Sized from the sessions worst case: two full session layers
+	// (MaxEventSessions entries each at MaxEventSessionKeyLength +
+	// MaxEventSessionIDLength ≈ 3.2KB per layer) plus a null tombstone for every
+	// inheritable key (~0.7KB) is ~7KB, so 32KB leaves ~4.5x headroom for real
+	// tombstone use and modest future meta fields.
+	MaxEventMetaSize = 32 * 1024 // 32KB
+
 	// MaxConcurrencyLimits limits the max concurrency constraints for a specific function.
 	MaxConcurrencyLimits = 2
 

--- a/pkg/execution/defers/defers.go
+++ b/pkg/execution/defers/defers.go
@@ -57,6 +57,8 @@ func SaveFromOp(
 	if err != nil {
 		if errors.Is(err, state.ErrDeferInputTooLarge) {
 			rejectReason = "per_defer_size"
+		} else if errors.Is(err, state.ErrDeferMetaTooLarge) {
+			rejectReason = "meta_size"
 		} else if errors.Is(err, state.ErrDeferInputInvalid) {
 			rejectReason = "invalid_input"
 		} else {

--- a/pkg/execution/defers/defers.go
+++ b/pkg/execution/defers/defers.go
@@ -59,6 +59,8 @@ func SaveFromOp(
 			rejectReason = "per_defer_size"
 		} else if errors.Is(err, state.ErrDeferMetaTooLarge) {
 			rejectReason = "meta_size"
+		} else if errors.Is(err, state.ErrDeferMetaInvalid) {
+			rejectReason = "invalid_meta"
 		} else if errors.Is(err, state.ErrDeferInputInvalid) {
 			rejectReason = "invalid_input"
 		} else {

--- a/pkg/execution/defers/defers_test.go
+++ b/pkg/execution/defers/defers_test.go
@@ -60,6 +60,7 @@ func deferAddOp(t *testing.T, hashedID string, opts state.DeferAddOpts) state.Ge
 func TestSaveFromOp_Rejected(t *testing.T) {
 	validInput := json.RawMessage(`{"x":1}`)
 	oversizedInput := json.RawMessage(`{"msg": "` + strings.Repeat("a", consts.MaxDeferInputSize+1) + `"}`)
+	oversizedMeta := json.RawMessage(`{"sessions": {"k": "` + strings.Repeat("a", consts.MaxEventMetaSize) + `"}}`)
 
 	cases := []struct {
 		name           string
@@ -72,6 +73,31 @@ func TestSaveFromOp_Rejected(t *testing.T) {
 		{
 			name:          "oversized input writes Rejected sentinel",
 			opts:          state.DeferAddOpts{FnSlug: "child-fn", Input: oversizedInput},
+			wantSaveCalls: 1,
+			wantStatus:    enums.DeferStatusRejected,
+		},
+		{
+			// Non-object Meta is caught at op receipt rather than at finalize,
+			// where a bad blob could only be dropped silently. The sentinel means
+			// that if the SDK sends the same defer again, it will dedupe rather than
+			// re-rejecting.
+			name: "non-object meta writes Rejected sentinel",
+			opts: state.DeferAddOpts{
+				FnSlug: "child-fn",
+				Input:  validInput,
+				// Wrap with an array, rather than a top-level object
+				Meta: json.RawMessage(`[{"sessions":{}}]`),
+			},
+			wantSaveCalls: 1,
+			wantStatus:    enums.DeferStatusRejected,
+		},
+		{
+			name: "oversized meta writes Rejected sentinel",
+			opts: state.DeferAddOpts{
+				FnSlug: "child-fn",
+				Input:  validInput,
+				Meta:   oversizedMeta,
+			},
 			wantSaveCalls: 1,
 			wantStatus:    enums.DeferStatusRejected,
 		},

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -23,6 +23,7 @@ var (
 	ErrStepOutputTooLarge = fmt.Errorf("step output size is greater than the limit")
 	ErrDeferInputTooLarge = fmt.Errorf("defer input size is greater than the limit")
 	ErrDeferInputInvalid  = fmt.Errorf("defer input is not a valid JSON object")
+	ErrDeferMetaTooLarge  = fmt.Errorf("defer meta size is greater than the limit")
 )
 
 type GeneratorOpcode struct {
@@ -445,6 +446,18 @@ func (d *DeferAddOpts) Validate() error {
 		// Redis (per defer × per run) and inflating them into the
 		// deferred.schedule event bus on Finalize.
 		return ErrDeferInputTooLarge
+	}
+	if len(d.Meta) > consts.MaxEventMetaSize {
+		// Meta is persisted as a raw, unparsed blob until the parent run
+		// finalizes (up to a year, x MaxDefersPerRun), so this byte cap is its
+		// only bound before then. A raw length check avoids parsing here,
+		// keeping the tombstone single-hop invariant intact; shape and size of
+		// the sessions themselves are validated post-merge at finalize. The
+		// sibling primitives don't need this cap: invoke materializes and
+		// validates its payload at op receipt and resolves in-request, and
+		// sendEvent meta rides inside the event, bounded by the event-size
+		// caps at API ingest.
+		return ErrDeferMetaTooLarge
 	}
 	return nil
 }

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -24,6 +25,7 @@ var (
 	ErrDeferInputTooLarge = fmt.Errorf("defer input size is greater than the limit")
 	ErrDeferInputInvalid  = fmt.Errorf("defer input is not a valid JSON object")
 	ErrDeferMetaTooLarge  = fmt.Errorf("defer meta size is greater than the limit")
+	ErrDeferMetaInvalid   = fmt.Errorf("defer meta is not a valid JSON object")
 )
 
 type GeneratorOpcode struct {
@@ -446,6 +448,17 @@ func (d *DeferAddOpts) Validate() error {
 		// Redis (per defer × per run) and inflating them into the
 		// deferred.schedule event bus on Finalize.
 		return ErrDeferInputTooLarge
+	}
+	// Meta is optional. A literal `null` is accepted as a special case.
+	if meta := bytes.TrimSpace(d.Meta); len(meta) > 0 && !bytes.Equal(meta, []byte("null")) {
+		if !util.IsJSONObject(meta) {
+			// Object shape is checked here rather than left to finalize: a
+			// non-object Meta (`3`, `"x"`, `[1]`) would persist happily and only fail
+			// in buildDeferEvents, after the parent run has finished, where the
+			// deferred run can only be dropped. Rejecting at op receipt turns it
+			// into a rejectReason with the existing metric and rejected span.
+			return ErrDeferMetaInvalid
+		}
 	}
 	if len(d.Meta) > consts.MaxEventMetaSize {
 		// Meta is persisted as a raw, unparsed blob until the parent run

--- a/pkg/execution/state/opcode_test.go
+++ b/pkg/execution/state/opcode_test.go
@@ -273,6 +273,77 @@ func TestDeferAddOpts_Validate(t *testing.T) {
 		opts := DeferAddOpts{FnSlug: "fn", Input: json.RawMessage(atLimit)}
 		require.NoError(t, opts.Validate())
 	})
+
+	t.Run("accepts object Meta", func(t *testing.T) {
+		opts := DeferAddOpts{
+			FnSlug: "fn",
+			Input:  json.RawMessage(`{}`),
+			Meta:   json.RawMessage(`{"sessions":{"conversation_id":"conversation_1234"}}`),
+		}
+		require.NoError(t, opts.Validate())
+	})
+
+	t.Run("accepts a whole-field sessions tombstone", func(t *testing.T) {
+		// `sessions: null` clears every inherited session (RFC 7386). The
+		// envelope is still an object, so it must pass the shape check.
+		opts := DeferAddOpts{
+			FnSlug: "fn",
+			Input:  json.RawMessage(`{}`),
+			Meta:   json.RawMessage(`{"sessions":null}`),
+		}
+		require.NoError(t, opts.Validate())
+	})
+
+	t.Run("accepts absent and null Meta", func(t *testing.T) {
+		// Meta is optional, and a literal `null` is equivalent to absent.
+		for _, meta := range []json.RawMessage{nil, json.RawMessage(`null`), json.RawMessage(" null ")} {
+			opts := DeferAddOpts{FnSlug: "fn", Input: json.RawMessage(`{}`), Meta: meta}
+			require.NoError(t, opts.Validate(), "Meta %q must be treated as absent", meta)
+		}
+	})
+
+	t.Run("rejects non-object Meta", func(t *testing.T) {
+		// Valid JSON that isn't an object would persist fine and then fail to
+		// unmarshal into event.EventMeta at finalize, where the only remaining
+		// outcome is silently dropping the deferred run. Reject at op receipt so
+		// it becomes a soft rejection the caller can see.
+		for _, meta := range []string{`3`, `"sessions"`, `[{"sessions":{}}]`, `true`} {
+			opts := DeferAddOpts{
+				FnSlug: "fn",
+				Input:  json.RawMessage(`{}`),
+				Meta:   json.RawMessage(meta),
+			}
+			require.ErrorIs(t, opts.Validate(), ErrDeferMetaInvalid,
+				"non-object Meta %s must be rejected at validation, not dropped at finalize", meta)
+		}
+	})
+
+	t.Run("rejects Meta larger than MaxEventMetaSize", func(t *testing.T) {
+		oversized, _ := json.Marshal(map[string]any{
+			"sessions": map[string]string{"k": string(bytes.Repeat([]byte("x"), consts.MaxEventMetaSize))},
+		})
+		opts := DeferAddOpts{
+			FnSlug: "fn",
+			Input:  json.RawMessage(`{}`),
+			Meta:   json.RawMessage(oversized),
+		}
+		require.ErrorIs(t, opts.Validate(), ErrDeferMetaTooLarge,
+			"Meta is persisted unparsed until finalize, so the byte cap is its only bound")
+	})
+
+	t.Run("accepts Meta at exactly MaxEventMetaSize", func(t *testing.T) {
+		// Boundary: equal-to-limit must pass; only strictly greater fails.
+		envelope := `{"sessions":{"k":""}}`
+		atLimit := json.RawMessage(`{"sessions":{"k":"` +
+			string(bytes.Repeat([]byte("x"), consts.MaxEventMetaSize-len(envelope))) + `"}}`)
+		require.Equal(t, consts.MaxEventMetaSize, len(atLimit))
+		opts := DeferAddOpts{
+			FnSlug: "fn",
+			Input:  json.RawMessage(`{}`),
+			Meta:   json.RawMessage(atLimit),
+		}
+		require.NoError(t, opts.Validate())
+	})
 }
 
 // TestInvokeFunctionOptsPreservesSessionNulls pins that RFC 7386 null

--- a/pkg/execution/state/v2/interfaces.go
+++ b/pkg/execution/state/v2/interfaces.go
@@ -235,4 +235,8 @@ var (
 	// ErrDeferMetaTooLarge re-exports the v1 error so v2 callers can match
 	// without importing v1.
 	ErrDeferMetaTooLarge = state.ErrDeferMetaTooLarge
+
+	// ErrDeferMetaInvalid re-exports the v1 error so v2 callers can match
+	// without importing v1.
+	ErrDeferMetaInvalid = state.ErrDeferMetaInvalid
 )

--- a/pkg/execution/state/v2/interfaces.go
+++ b/pkg/execution/state/v2/interfaces.go
@@ -231,4 +231,8 @@ var (
 	// ErrDeferInputTooLarge re-exports the v1 error so v2 callers can match
 	// without importing v1.
 	ErrDeferInputTooLarge = state.ErrDeferInputTooLarge
+
+	// ErrDeferMetaTooLarge re-exports the v1 error so v2 callers can match
+	// without importing v1.
+	ErrDeferMetaTooLarge = state.ErrDeferMetaTooLarge
 )


### PR DESCRIPTION
## Description

- Before persisting an event's session meta, let's ensure we aren't stuffing in too much data
- With other session entry points, we do our resolved validation before persisting, which would catch wildly large sessions. With defers however, we persist once before resolving and then persisting again as the triggering event. We add this new validation to protect our first persistence.
- We also check for a valid JSON shape before persistence
- EXE-2035
<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>