### PR TITLE
fix(cli): improve cli timestamp arg handling

### DIFF
--- a/cmd/apiv2cli/cmd.go
+++ b/cmd/apiv2cli/cmd.go
@@ -70,6 +70,7 @@ func Command() *cli.Command {
 			"Beta: this command is under active development and may change.",
 			"By default, the command targets the local dev server.",
 			"Set --prod to target Inngest Cloud Production, or --api-host/--api-port to target a custom API server.",
+			"Authentication: https://api-docs.inngest.com/authentication",
 		}, "\n"),
 		Flags:    commonFlags(),
 		Commands: endpointCommands(),
@@ -334,13 +335,15 @@ func endpointDescription(ep endpoint) string {
 	lines = append(lines,
 		fmt.Sprintf("Endpoint: %s %s", ep.method, ep.path),
 		"",
-		"Target, auth, and output flags are inherited from `inngest alpha api`:",
+		"Target, auth, and output flags are inherited from `inngest api`:",
 		"  --prod                  Target Inngest Cloud Production",
 		"  --api-host, --api-port  Target a custom API server; host may include /api/v2 or /v2",
 		"  --api-key               API key, or INNGEST_API_KEY",
 		"  --signing-key           Signing key, or INNGEST_SIGNING_KEY",
 		"  --env                   Environment name, or INNGEST_ENV",
 		"  --raw                   Print the response body without formatting",
+		"",
+		"Authentication: https://api-docs.inngest.com/authentication",
 	)
 
 	return strings.Join(lines, "\n")

--- a/cmd/apiv2cli/cmd.go
+++ b/cmd/apiv2cli/cmd.go
@@ -821,6 +821,14 @@ func fieldValue(cmd *cli.Command, field protoreflect.FieldDescriptor, flagName s
 	case protoreflect.EnumKind:
 		return cmd.String(flagName), nil
 	case protoreflect.MessageKind, protoreflect.GroupKind:
+		if field.Message().FullName() == "google.protobuf.Timestamp" {
+			value, err := parseTimestamp(cmd.String(flagName))
+			if err != nil {
+				return nil, fmt.Errorf("--%s must be an RFC 3339 timestamp: %w", flagName, err)
+			}
+			return value, nil
+		}
+
 		var value any
 		if err := json.Unmarshal([]byte(cmd.String(flagName)), &value); err != nil {
 			return nil, fmt.Errorf("--%s must be valid JSON: %w", flagName, err)
@@ -831,6 +839,20 @@ func fieldValue(cmd *cli.Command, field protoreflect.FieldDescriptor, flagName s
 	default:
 		return nil, fmt.Errorf("unsupported field type for --%s", flagName)
 	}
+}
+
+func parseTimestamp(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, `"`) {
+		if err := json.Unmarshal([]byte(trimmed), &value); err != nil {
+			return "", err
+		}
+	}
+
+	if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		return "", err
+	}
+	return value, nil
 }
 
 func authToken(cmd *cli.Command) (string, error) {

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -257,6 +257,62 @@ func TestCommandUsesQueryParamsForGetEndpoint(t *testing.T) {
 	require.Equal(t, "includeOutput=true", gotQuery)
 }
 
+func TestCommandAcceptsRFC3339TimestampQueryFlags(t *testing.T) {
+	var gotQuery url.Values
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"metadata":{},"page":{}}`))
+	}))
+	defer srv.Close()
+
+	cmd := Command()
+	cmd.Writer = &bytes.Buffer{}
+
+	err := cmd.Run(context.Background(), []string{
+		"api",
+		"--api-host", srv.URL,
+		"get-function-runs",
+		"--status", "FAILED",
+		"--from", "2026-07-20T00:00:00-04:00",
+		"--until", "2026-07-20T23:59:59.999999999-04:00",
+		"--time-field", "queuedAt",
+		"--order", "DESC",
+		"--limit", "20",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"FAILED"}, gotQuery["status"])
+	require.Equal(t, "2026-07-20T00:00:00-04:00", gotQuery.Get("from"))
+	require.Equal(t, "2026-07-20T23:59:59.999999999-04:00", gotQuery.Get("until"))
+	require.Equal(t, "queuedAt", gotQuery.Get("timeField"))
+	require.Equal(t, "DESC", gotQuery.Get("order"))
+	require.Equal(t, "20", gotQuery.Get("limit"))
+}
+
+func TestParseTimestamp(t *testing.T) {
+	t.Run("plain RFC 3339", func(t *testing.T) {
+		value, err := parseTimestamp("2026-07-20T00:00:00-04:00")
+
+		require.NoError(t, err)
+		require.Equal(t, "2026-07-20T00:00:00-04:00", value)
+	})
+
+	t.Run("JSON string", func(t *testing.T) {
+		value, err := parseTimestamp(`"2026-07-20T00:00:00-04:00"`)
+
+		require.NoError(t, err)
+		require.Equal(t, "2026-07-20T00:00:00-04:00", value)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := parseTimestamp("yesterday")
+
+		require.Error(t, err)
+	})
+}
+
 func TestCommandAcceptsPositionalPathParams(t *testing.T) {
 	var gotPath string
 	var gotQuery string

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -64,6 +64,7 @@ func TestCommandHelpUsesTopLevelAPIAndBetaLabel(t *testing.T) {
 	require.Contains(t, out.String(), "inngest api [target/auth flags] <endpoint> [endpoint flags]")
 	require.Contains(t, out.String(), "Call Inngest REST API v2 endpoints (beta)")
 	require.Contains(t, out.String(), "Beta: this command is under active development and may change.")
+	require.Contains(t, out.String(), "Authentication: https://api-docs.inngest.com/authentication")
 	require.NotContains(t, out.String(), "inngest alpha api [target/auth flags]")
 }
 
@@ -96,6 +97,8 @@ func TestEndpointCommandsIncludeOperationAndInheritedFlagHelp(t *testing.T) {
 	require.Contains(t, invoke.Description, "INNGEST_API_KEY")
 	require.Contains(t, invoke.Description, "INNGEST_ENV")
 	require.Contains(t, invoke.Description, "/v2")
+	require.Contains(t, invoke.Description, "Authentication: https://api-docs.inngest.com/authentication")
+	require.NotContains(t, invoke.Description, "inngest alpha api")
 }
 
 func TestCommandTelemetryContextIncludesEndpointAndFlagNamesOnly(t *testing.T) {


### PR DESCRIPTION
## Description

cli previously required json/quoted timestamp args like `--from '"2026-07-20T00:00:00-04:00"'`, this make it so we can just do `--from '2026-07-20T00:00:00-04:00'`,

## Release note

## Migration note

None