### PR TITLE
fix: use snapshots to handle map race access

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"runtime/debug"
 	"slices"
@@ -586,8 +587,9 @@ func (e *executor) runEventLifecycles(ctx context.Context, fn func(context.Conte
 }
 
 func (e *executor) RunFunctionMatchLifecycle(ctx context.Context, req execution.ScheduleRequest) {
+	reqSnapshot := cloneScheduleRequest(req)
 	e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-		l.OnFunctionMatch(ctx, req)
+		l.OnFunctionMatch(ctx, reqSnapshot)
 	})
 }
 
@@ -953,8 +955,9 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 
 	switch {
 	case errors.Is(err, ErrFunctionRateLimited):
+		reqSnapshot := cloneScheduleRequest(req)
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-			l.OnRateLimited(ctx, req)
+			l.OnRateLimited(ctx, reqSnapshot)
 		})
 	case errors.Is(err, ErrFunctionSkippedIdempotency),
 		errors.Is(err, state.ErrIdentifierExists),
@@ -965,18 +968,31 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		if errors.Is(err, ErrFunctionSkippedIdempotency) {
 			skip.ExistingRunID = runID
 		}
+		reqSnapshot := cloneScheduleRequest(req)
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-			l.OnFunctionSkippedIdempotency(ctx, req, skip)
+			l.OnFunctionSkippedIdempotency(ctx, reqSnapshot, skip)
 		})
 	case errors.Is(err, ErrFunctionDebounced), errors.Is(err, ErrFunctionSkipped), err == nil:
 		// Handled by more specific lifecycle hooks inside schedule.
 	default:
+		reqSnapshot := cloneScheduleRequest(req)
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-			l.OnFunctionScheduleFailed(ctx, req, err)
+			l.OnFunctionScheduleFailed(ctx, reqSnapshot, err)
 		})
 	}
 
 	return runID, md, err
+}
+
+func cloneScheduleRequest(req execution.ScheduleRequest) execution.ScheduleRequest {
+	req.Context = maps.Clone(req.Context)
+	req.Events = slices.Clone(req.Events)
+	return req
+}
+
+func cloneMetadata(md sv2.Metadata) sv2.Metadata {
+	md.Config.Context = maps.Clone(md.Config.Context)
+	return md
 }
 
 func (e *executor) now() time.Time {
@@ -1004,6 +1020,9 @@ func (e *executor) schedule(
 	if req.AppID == uuid.Nil {
 		return nil, nil, fmt.Errorf("app ID is required to schedule a run")
 	}
+
+	req = cloneScheduleRequest(req)
+	reqSnapshot := cloneScheduleRequest(req)
 
 	ctx, span := e.conditionalTracer.NewUserSpan(ctx, "executor.schedule", req.AccountID, req.WorkspaceID, req.Function.ID)
 	defer span.End()
@@ -1110,7 +1129,7 @@ func (e *executor) schedule(
 		span.End()
 
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-			l.OnDebounced(ctx, req, item, debounceID)
+			l.OnDebounced(ctx, reqSnapshot, item, debounceID)
 		})
 
 		return nil, nil, ErrFunctionDebounced
@@ -1349,7 +1368,7 @@ func (e *executor) schedule(
 						l.ReportError(err, "error canceling singleton run")
 					}
 					e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-						l.OnSingletonCancelled(ctx, req, runID)
+						l.OnSingletonCancelled(ctx, reqSnapshot, runID)
 					})
 
 				default:
@@ -1552,7 +1571,7 @@ func (e *executor) schedule(
 	// If the function is being skipped, send spans and handle skip.
 	if skipReason != enums.SkipReasonNone {
 		sendSpans()
-		return e.handleFunctionSkipped(ctx, req, metadata, evts, skipReason)
+		return e.handleFunctionSkipped(ctx, reqSnapshot, metadata, evts, skipReason)
 	}
 
 	if req.BatchID == nil {
@@ -1643,8 +1662,9 @@ func (e *executor) schedule(
 		for _, e := range e.lifecycles {
 			go e.OnFunctionScheduled(context.WithoutCancel(ctx), metadata, item, req.Events)
 		}
+		metadataSnapshot := cloneMetadata(metadata)
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-			l.OnFunctionScheduled(ctx, metadata, req.Events)
+			l.OnFunctionScheduled(ctx, metadataSnapshot, reqSnapshot.Events)
 		})
 		return &metadata.ID.RunID, &metadata, nil
 	}
@@ -1740,7 +1760,7 @@ func (e *executor) schedule(
 		if deleteErr != nil {
 			l.ReportError(deleteErr, "error deleting function state, this has likely leaked state")
 		}
-		return e.handleFunctionSkipped(ctx, req, metadata, evts, enums.SkipReasonSingleton)
+		return e.handleFunctionSkipped(ctx, reqSnapshot, metadata, evts, enums.SkipReasonSingleton)
 
 	default:
 		return nil, nil, fmt.Errorf("error enqueueing source edge '%v': %w", queueKey, err)
@@ -1750,8 +1770,9 @@ func (e *executor) schedule(
 	for _, e := range e.lifecycles {
 		go e.OnFunctionScheduled(context.WithoutCancel(ctx), metadata, item, req.Events)
 	}
+	metadataSnapshot := cloneMetadata(metadata)
 	e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-		l.OnFunctionScheduled(ctx, metadata, req.Events)
+		l.OnFunctionScheduled(ctx, metadataSnapshot, reqSnapshot.Events)
 	})
 
 	return &metadata.ID.RunID, &metadata, nil
@@ -1813,8 +1834,10 @@ func (e *executor) updateInvokeSpanWithInvokedRunID(ctx context.Context, l logge
 }
 
 func (e *executor) handleFunctionSkipped(ctx context.Context, req execution.ScheduleRequest, metadata sv2.Metadata, evts []json.RawMessage, reason enums.SkipReason) (*ulid.ULID, *sv2.Metadata, error) {
+	reqSnapshot := cloneScheduleRequest(req)
+	metadataSnapshot := cloneMetadata(metadata)
 	e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-		l.OnFunctionSkipped(ctx, req, metadata, reason)
+		l.OnFunctionSkipped(ctx, reqSnapshot, metadataSnapshot, reason)
 	})
 
 	for _, e := range e.lifecycles {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1022,7 +1022,6 @@ func (e *executor) schedule(
 	}
 
 	req = cloneScheduleRequest(req)
-	reqSnapshot := cloneScheduleRequest(req)
 
 	ctx, span := e.conditionalTracer.NewUserSpan(ctx, "executor.schedule", req.AccountID, req.WorkspaceID, req.Function.ID)
 	defer span.End()
@@ -1128,6 +1127,7 @@ func (e *executor) schedule(
 		}
 		span.End()
 
+		reqSnapshot := cloneScheduleRequest(req)
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
 			l.OnDebounced(ctx, reqSnapshot, item, debounceID)
 		})
@@ -1232,6 +1232,10 @@ func (e *executor) schedule(
 	carrier := itrace.NewTraceCarrier(itrace.WithTraceCarrierSpanID(&spanID))
 	itrace.UserTracer().Propagator().Inject(ctx, propagation.MapCarrier(carrier.Context))
 	config.SetFunctionTrace(carrier)
+
+	// Event lifecycles that run after scheduling should observe the fully
+	// enriched request context, not just the caller-provided fields.
+	reqSnapshot := cloneScheduleRequest(req)
 
 	metadata := sv2.Metadata{
 		ID: sv2.ID{

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -932,6 +932,8 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		requestTime = req.Events[0].GetReceivedAt()
 	}
 
+	callbackReq := cloneScheduleRequest(req)
+
 	// Check constraints and acquire lease
 	md, err := WithConstraints(
 		ctx,
@@ -948,16 +950,15 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 					md  *sv2.Metadata
 					err error
 				)
-				runID, md, err = e.schedule(ctx, req, *runID, key, performChecks)
+				runID, md, err = e.schedule(ctx, req, *runID, key, performChecks, &callbackReq)
 				return md, err
 			}, util.WithBoundaries(2*time.Second))
 		})
 
 	switch {
 	case errors.Is(err, ErrFunctionRateLimited):
-		reqSnapshot := cloneScheduleRequest(req)
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-			l.OnRateLimited(ctx, reqSnapshot)
+			l.OnRateLimited(ctx, callbackReq)
 		})
 	case errors.Is(err, ErrFunctionSkippedIdempotency),
 		errors.Is(err, state.ErrIdentifierExists),
@@ -968,16 +969,14 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		if errors.Is(err, ErrFunctionSkippedIdempotency) {
 			skip.ExistingRunID = runID
 		}
-		reqSnapshot := cloneScheduleRequest(req)
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-			l.OnFunctionSkippedIdempotency(ctx, reqSnapshot, skip)
+			l.OnFunctionSkippedIdempotency(ctx, callbackReq, skip)
 		})
 	case errors.Is(err, ErrFunctionDebounced), errors.Is(err, ErrFunctionSkipped), err == nil:
 		// Handled by more specific lifecycle hooks inside schedule.
 	default:
-		reqSnapshot := cloneScheduleRequest(req)
 		e.runEventLifecycles(ctx, func(ctx context.Context, l execution.EventLifecycleListener) {
-			l.OnFunctionScheduleFailed(ctx, reqSnapshot, err)
+			l.OnFunctionScheduleFailed(ctx, callbackReq, err)
 		})
 	}
 
@@ -1016,12 +1015,16 @@ func (e *executor) schedule(
 	// performChecks determines whether constraint checks must be performed
 	// This may be false when the Constraint API was used to enforce constraints.
 	performChecks bool,
+	callbackReq *execution.ScheduleRequest,
 ) (*ulid.ULID, *sv2.Metadata, error) {
 	if req.AppID == uuid.Nil {
 		return nil, nil, fmt.Errorf("app ID is required to schedule a run")
 	}
 
 	req = cloneScheduleRequest(req)
+	if callbackReq != nil {
+		*callbackReq = cloneScheduleRequest(req)
+	}
 
 	ctx, span := e.conditionalTracer.NewUserSpan(ctx, "executor.schedule", req.AccountID, req.WorkspaceID, req.Function.ID)
 	defer span.End()
@@ -1236,6 +1239,9 @@ func (e *executor) schedule(
 	// Event lifecycles that run after scheduling should observe the fully
 	// enriched request context, not just the caller-provided fields.
 	reqSnapshot := cloneScheduleRequest(req)
+	if callbackReq != nil {
+		*callbackReq = reqSnapshot
+	}
 
 	metadata := sv2.Metadata{
 		ID: sv2.ID{

--- a/pkg/execution/executor/lifecycle_snapshot_test.go
+++ b/pkg/execution/executor/lifecycle_snapshot_test.go
@@ -1,0 +1,153 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunFunctionMatchLifecycleSnapshotsRequestContextForAsyncListeners(t *testing.T) {
+	listener := &requestContextRaceLifecycle{
+		ready:   make(chan struct{}),
+		start:   make(chan struct{}),
+		release: make(chan struct{}),
+		done:    make(chan any, 1),
+	}
+	e := &executor{
+		evtLifecycles: []execution.EventLifecycleListener{listener},
+	}
+
+	req := execution.ScheduleRequest{
+		Context: map[string]any{
+			"stable": "before",
+		},
+	}
+
+	e.RunFunctionMatchLifecycle(context.Background(), req)
+
+	select {
+	case <-listener.ready:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lifecycle listener")
+	}
+
+	req.Context["stable"] = "after"
+	close(listener.start)
+
+	for i := 0; i < 1_000; i++ {
+		req.Context[fmt.Sprintf("key-%d", i)] = i
+		runtime.Gosched()
+	}
+	close(listener.release)
+
+	select {
+	case observed := <-listener.done:
+		require.Equal(t, "before", observed)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lifecycle listener to finish")
+	}
+}
+
+func TestHandleFunctionSkippedSnapshotsMetadataContextForAsyncListeners(t *testing.T) {
+	listener := &metadataContextRaceLifecycle{
+		ready:   make(chan struct{}),
+		start:   make(chan struct{}),
+		release: make(chan struct{}),
+		done:    make(chan any, 1),
+	}
+	e := &executor{
+		evtLifecycles: []execution.EventLifecycleListener{listener},
+	}
+
+	metadata := sv2.Metadata{
+		Config: *sv2.InitConfig(&sv2.Config{
+			Context: map[string]any{
+				"stable": "before",
+			},
+		}),
+	}
+
+	_, _, err := e.handleFunctionSkipped(context.Background(), execution.ScheduleRequest{}, metadata, nil, enums.SkipReasonFunctionPaused)
+	require.ErrorIs(t, err, ErrFunctionSkipped)
+
+	select {
+	case <-listener.ready:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lifecycle listener")
+	}
+
+	metadata.Config.Context["stable"] = "after"
+	close(listener.start)
+
+	for i := 0; i < 1_000; i++ {
+		metadata.Config.Context[fmt.Sprintf("key-%d", i)] = i
+		runtime.Gosched()
+	}
+	close(listener.release)
+
+	select {
+	case observed := <-listener.done:
+		require.Equal(t, "before", observed)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lifecycle listener to finish")
+	}
+}
+
+type requestContextRaceLifecycle struct {
+	execution.NoopEventLifecycleListener
+
+	ready   chan struct{}
+	start   chan struct{}
+	release chan struct{}
+	done    chan any
+}
+
+func (r *requestContextRaceLifecycle) OnFunctionMatch(_ context.Context, req execution.ScheduleRequest) {
+	close(r.ready)
+	<-r.start
+
+	observed := req.Context["stable"]
+	for {
+		select {
+		case <-r.release:
+			r.done <- observed
+			return
+		default:
+			_ = req.Context["stable"]
+			runtime.Gosched()
+		}
+	}
+}
+
+type metadataContextRaceLifecycle struct {
+	execution.NoopEventLifecycleListener
+
+	ready   chan struct{}
+	start   chan struct{}
+	release chan struct{}
+	done    chan any
+}
+
+func (r *metadataContextRaceLifecycle) OnFunctionSkipped(_ context.Context, _ execution.ScheduleRequest, metadata sv2.Metadata, _ enums.SkipReason) {
+	close(r.ready)
+	<-r.start
+
+	observed := metadata.Config.Context["stable"]
+	for {
+		select {
+		case <-r.release:
+			r.done <- observed
+			return
+		default:
+			_ = metadata.Config.Context["stable"]
+			runtime.Gosched()
+		}
+	}
+}

--- a/pkg/execution/executor/schedule_event_lifecycle_context_test.go
+++ b/pkg/execution/executor/schedule_event_lifecycle_context_test.go
@@ -1,0 +1,77 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/logger"
+	telemetrytrace "github.com/inngest/inngest/pkg/telemetry/trace"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScheduleSkippedEventLifecycleReceivesEnrichedRequestContext(t *testing.T) {
+	listener := &skippedRequestContextLifecycle{
+		done: make(chan any, 1),
+	}
+
+	e := &executor{
+		log:               logger.From(context.Background()),
+		tracerProvider:    newRecordingTracerProvider(),
+		conditionalTracer: telemetrytrace.NoopConditionalTracer(),
+		evtLifecycles:     []execution.EventLifecycleListener{listener},
+	}
+
+	eventID := ulid.Make()
+	pausedAt := time.Now().Add(-time.Minute)
+	req := execution.ScheduleRequest{
+		AccountID:   uuid.New(),
+		WorkspaceID: uuid.New(),
+		AppID:       uuid.New(),
+		URL:         "https://example.com/api/inngest",
+		Function: inngest.Function{
+			ID:              uuid.New(),
+			FunctionVersion: 1,
+			Name:            "Send Weekly Email",
+		},
+		FunctionPausedAt: &pausedAt,
+		Events: []event.TrackedEvent{
+			event.InternalEvent{
+				ID: eventID,
+				Event: event.Event{
+					ID:        eventID.String(),
+					Name:      "test/schedule",
+					Timestamp: time.Now().UnixMilli(),
+					Data:      map[string]any{},
+				},
+			},
+		},
+	}
+
+	_, _, err := e.schedule(context.Background(), req, ulid.Make(), "test-key", false)
+	require.ErrorIs(t, err, ErrFunctionSkipped)
+
+	select {
+	case observed := <-listener.done:
+		require.Equal(t, req.URL, observed)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event lifecycle listener")
+	}
+}
+
+type skippedRequestContextLifecycle struct {
+	execution.NoopEventLifecycleListener
+
+	done chan any
+}
+
+func (l *skippedRequestContextLifecycle) OnFunctionSkipped(_ context.Context, req execution.ScheduleRequest, _ sv2.Metadata, _ enums.SkipReason) {
+	l.done <- req.Context["url"]
+}

--- a/pkg/execution/executor/schedule_event_lifecycle_context_test.go
+++ b/pkg/execution/executor/schedule_event_lifecycle_context_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
+	execstate "github.com/inngest/inngest/pkg/execution/state"
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
@@ -55,8 +56,56 @@ func TestScheduleSkippedEventLifecycleReceivesEnrichedRequestContext(t *testing.
 		},
 	}
 
-	_, _, err := e.schedule(context.Background(), req, ulid.Make(), "test-key", false)
+	_, _, err := e.schedule(context.Background(), req, ulid.Make(), "test-key", false, nil)
 	require.ErrorIs(t, err, ErrFunctionSkipped)
+
+	select {
+	case observed := <-listener.done:
+		require.Equal(t, req.URL, observed)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event lifecycle listener")
+	}
+}
+
+func TestScheduleIdempotencySkippedEventLifecycleReceivesEnrichedRequestContext(t *testing.T) {
+	listener := &idempotencySkippedRequestContextLifecycle{
+		done: make(chan any, 1),
+	}
+
+	e := &executor{
+		log:               logger.From(context.Background()),
+		smv2:              tombstoneRunService{},
+		tracerProvider:    newRecordingTracerProvider(),
+		conditionalTracer: telemetrytrace.NoopConditionalTracer(),
+		evtLifecycles:     []execution.EventLifecycleListener{listener},
+	}
+
+	eventID := ulid.Make()
+	req := execution.ScheduleRequest{
+		AccountID:   uuid.New(),
+		WorkspaceID: uuid.New(),
+		AppID:       uuid.New(),
+		URL:         "https://example.com/api/inngest",
+		Function: inngest.Function{
+			ID:              uuid.New(),
+			FunctionVersion: 1,
+			Name:            "Send Weekly Email",
+		},
+		Events: []event.TrackedEvent{
+			event.InternalEvent{
+				ID: eventID,
+				Event: event.Event{
+					ID:        eventID.String(),
+					Name:      "test/schedule",
+					Timestamp: time.Now().UnixMilli(),
+					Data:      map[string]any{},
+				},
+			},
+		},
+	}
+
+	_, _, err := e.Schedule(context.Background(), req)
+	require.ErrorIs(t, err, ErrFunctionSkippedIdempotency)
 
 	select {
 	case observed := <-listener.done:
@@ -74,4 +123,22 @@ type skippedRequestContextLifecycle struct {
 
 func (l *skippedRequestContextLifecycle) OnFunctionSkipped(_ context.Context, req execution.ScheduleRequest, _ sv2.Metadata, _ enums.SkipReason) {
 	l.done <- req.Context["url"]
+}
+
+type idempotencySkippedRequestContextLifecycle struct {
+	execution.NoopEventLifecycleListener
+
+	done chan any
+}
+
+func (l *idempotencySkippedRequestContextLifecycle) OnFunctionSkippedIdempotency(_ context.Context, req execution.ScheduleRequest, _ execution.IdempotencySkip) {
+	l.done <- req.Context["url"]
+}
+
+type tombstoneRunService struct {
+	sv2.RunService
+}
+
+func (t tombstoneRunService) Create(_ context.Context, s sv2.CreateState) (sv2.State, error) {
+	return sv2.State{Metadata: s.Metadata}, execstate.ErrIdentifierTombstone
 }

--- a/pkg/execution/executor/schedule_span_test.go
+++ b/pkg/execution/executor/schedule_span_test.go
@@ -49,7 +49,7 @@ func TestScheduleRunSpanIncludesFunctionMetadata(t *testing.T) {
 		},
 	}
 
-	_, _, err := e.schedule(context.Background(), req, ulid.Make(), "test-key", false)
+	_, _, err := e.schedule(context.Background(), req, ulid.Make(), "test-key", false, nil)
 	require.ErrorIs(t, err, ErrFunctionSkipped)
 
 	var runSpan *createSpanCall


### PR DESCRIPTION
## Description

`ScheduleRequest` have read/write concurrent access to the embedded maps so creating snapshots to avoid that for now.

We can revisit this later to make it more elegant.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
