### PR TITLE
refactor(queue): add shard scanner boundary

### DIFF
--- a/pkg/execution/queue/continuation.go
+++ b/pkg/execution/queue/continuation.go
@@ -83,7 +83,7 @@ func (q *queueProcessor) removeContinue(ctx context.Context, p *QueuePartition, 
 	}
 }
 
-func (q *queueProcessor) scanContinuations(ctx context.Context) error {
+func (q *queueProcessor) scanContinuations(ctx context.Context, dispatch DispatchFunc) error {
 	if !q.runMode.Continuations {
 		// continuations are not enabled.
 		return nil
@@ -115,7 +115,7 @@ func (q *queueProcessor) scanContinuations(ctx context.Context) error {
 
 			logger.StdlibLogger(ctx).Trace("continue partition processing", "partition_id", p.ID, "count", cont.count)
 
-			err := q.ProcessPartition(ctx, p, cont.count, false)
+			err := q.ProcessPartition(ctx, p, cont.count, false, dispatch)
 
 			metrics.IncrQueuePartitionProcessedCounter(ctx, metrics.CounterOpt{
 				PkgName: pkgName,

--- a/pkg/execution/queue/errors.go
+++ b/pkg/execution/queue/errors.go
@@ -109,6 +109,7 @@ var (
 
 var (
 	ErrProcessNoCapacity               = fmt.Errorf("no capacity")
+	ErrProcessMissingDispatch          = fmt.Errorf("missing dispatch function")
 	ErrProcessStopIterator             = fmt.Errorf("stop iterator")
 	ErrProcessNoUserConstraintCapacity = fmt.Errorf("no user constraint capacity: %w", ErrProcessStopIterator)
 )

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -123,7 +123,7 @@ type QueueProcessor interface {
 		i ProcessItem,
 		f RunFunc,
 	) error
-	ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool) error
+	ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool, dispatch DispatchFunc) error
 }
 
 // SingletonOperations is the per-shard surface for singleton lock state.

--- a/pkg/execution/queue/lease_item.go
+++ b/pkg/execution/queue/lease_item.go
@@ -1,0 +1,424 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
+	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, dispatch DispatchFunc) (LeaseItemResult, error) {
+	item := req.Item
+	partition := req.Partition
+	l := logger.StdlibLogger(ctx).With("partition", partition, "item", item)
+
+	ctx, span := q.Options().ConditionalTracer.NewSpan(ctx, "queue.LeaseItem", TraceScopeFromQueueItem(*item, q.Shard().Name()))
+	defer span.End()
+	span.SetAttributes(attribute.String("partition_id", partition.ID))
+	span.SetAttributes(attribute.String("item_kind", item.Data.Kind))
+	span.SetAttributes(attribute.String("run_id", item.Data.Identifier.RunID.String()))
+	span.SetAttributes(attribute.String("item_id", item.ID))
+	if item.Data.JobID != nil {
+		span.SetAttributes(attribute.String("job_id", *item.Data.JobID))
+	}
+	if dispatch == nil {
+		span.RecordError(ErrProcessMissingDispatch)
+		return LeaseItemResult{Status: LeaseItemStatusLeaseError, Err: ErrProcessMissingDispatch}, ErrProcessMissingDispatch
+	}
+
+	// Copy queue timestamps into the inner item for easier access during processing.
+	// We convert these to time.Time here so that we don't have to convert them multiple times during processing.
+	item.Data.At = time.UnixMilli(item.AtMS)
+	item.Data.EnqueuedAt = time.UnixMilli(item.EnqueuedAt)
+
+	if item.IsLeased(q.Clock().Now()) {
+		span.SetAttributes(attribute.String("skip_reason", "already_leased"))
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": "lease_contention", "queue_shard": q.Shard().Name(), "constraint_source": "lease"},
+		})
+		return LeaseItemResult{Status: LeaseItemStatusAlreadyLeased}, nil
+	}
+
+	// Check if there's capacity from our local workers atomically prior to leasing our items.
+	if !q.Semaphore().TryAcquire(1) {
+		span.SetAttributes(attribute.String("skip_reason", "no_queue_worker_capacity"))
+		metrics.IncrQueuePartitionProcessNoCapacityCounter(ctx, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.Shard().Name()}})
+		// Break the entire loop to prevent out of order work.
+		return LeaseItemResult{Status: LeaseItemStatusNoWorkerCapacity}, ErrProcessNoCapacity
+	}
+
+	metrics.WorkerQueueCapacityCounter(ctx, 1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.Shard().Name()}})
+
+	// Release semaphore capacity, will be called when this function
+	// exits unless explicitly committed (see below).
+	//
+	// release() can be called early to make worker capacity available again
+	release := sync.OnceFunc(func() {
+		q.Semaphore().Release(1)
+		metrics.WorkerQueueCapacityCounter(ctx, -1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.Shard().Name()}})
+	})
+
+	// Default to resetting the semaphore if we don't explicitly keep it.
+	// This should prevent forgetting the .Release() case.
+	commitSemaphoreAcquire := false
+	defer func() {
+		if commitSemaphoreAcquire {
+			return
+		}
+
+		release()
+	}()
+
+	// In case the item has no earliest peek time set and stamping is enabled,
+	// call SetEarliestPeekTime before verifying and user constraints.
+	// This is intentionally called AFTER queue worker capacity; unlike user constraints,
+	// worker capacity counts towards system latency, not user latency.
+	if item.EarliestPeekTime == 0 && q.Options().ItemEarliestPeekTimeConfig(ctx, q.Shard().Name(), *item).Enabled {
+		peekTime := req.StaticTime
+		if peekTime.IsZero() {
+			peekTime = q.Clock().Now()
+		}
+
+		earliestPeekTime, err := q.Shard().SetEarliestPeekTime(ctx, *item, peekTime)
+		if err != nil {
+			span.RecordError(err)
+			l.Warn("could not set earliest peek time", "error", err)
+		} else {
+			item.EarliestPeekTime = earliestPeekTime.UnixMilli()
+		}
+	}
+
+	//
+	// Before we can do any work on the queue item, we need to check if all the constraints have capacity.
+	// This was previously done in Lease and has since been moved to the Constraint API.
+	//
+	// The Constraint API employs in-memory caching for a subset of constraints, ensuring low-latency
+	// responses on hit constraints and avoiding overloading the API.
+	//
+
+	backlog := ItemBacklog(ctx, *item)
+	shadowPartition := ItemShadowPartition(ctx, *item)
+	constraints := q.Options().PartitionConstraintConfigGetter(ctx, shadowPartition.Identifier())
+
+	// The following lease options simply specify some objects that are required during lease but were already generated.
+	leaseOptions := []LeaseOptionFn{
+		LeaseBacklog(backlog),
+		LeaseShadowPartition(shadowPartition),
+		LeaseConstraints(constraints),
+	}
+
+	// Acquire capacity lease, in case the Constraint API is enabled and the current queue item should use capacity leases.
+	// We only ignore capacity leases for system queues and items missing account ID / env ID / function ID combinations.
+	// When the Constraint API is enabled, it will handle concurrency and throttle checks on the queue item.
+	// This is for an individual lease. If a constraint is at capacity, no leases will be returned and we will handle the missing capacity accordingly.
+	constraintRes, err := q.ItemLeaseConstraintCheck(
+		ctx,
+		&shadowPartition,
+		&backlog,
+		constraints,
+		item,
+		q.Clock().Now(),
+	)
+	if err != nil {
+		span.RecordError(err)
+		l.ReportError(err, "could not check constraints to lease item")
+		// Stop iterator but don't quit the queue.
+		return LeaseItemResult{}, ErrProcessStopIterator
+	}
+
+	// If we're limited by constraints, release semaphore early since we won't be leasing or processing.
+	if constraintRes.LimitingConstraint != enums.QueueConstraintNotLimited {
+		release()
+
+		span.SetAttributes(attribute.String("limiting_constraint", constraintRes.LimitingConstraint.String()))
+	}
+
+	var leaseID *ulid.ULID
+	switch constraintRes.LimitingConstraint {
+	// If no constraints were hit (or we didn't invoke the Constraint API).
+	case enums.QueueConstraintNotLimited:
+
+		// Attempt to lease this item before passing this to a worker.  We have to do this
+		// synchronously as we need to lease prior to requeueing the partition pointer. If
+		// we don't do this here, the workers may not lease the items before calling Peek
+		// to re-enqeueu the pointer, which then increases contention - as we requeue a
+		// pointer too early.
+		//
+		// This is safe:  only one process runs scan(), and we guard the total number of
+		// available workers with the above semaphore.
+		leaseID, err = Duration(ctx, q.Shard().Name(), "lease", q.Clock().Now(), func(ctx context.Context) (*ulid.ULID, error) {
+			return q.Shard().Lease(
+				ctx,
+				*item,
+				QueueLeaseDuration,
+				req.StaticTime,
+				leaseOptions...,
+			)
+		})
+		// NOTE: If this loop ends in an error, we must _always_ release an item from the
+		// semaphore to free capacity.  This will happen automatically when the worker
+		// finishes processing a queue item on success.
+		if err != nil {
+			// Continue on and handle the error below.
+			release()
+		}
+	// Simulate errors returned by Lease.
+	case enums.QueueConstraintThrottle:
+		err = ErrQueueItemThrottled
+	case enums.QueueConstraintAccountConcurrency:
+		err = NewKeyError(ErrAccountConcurrencyLimit, shadowPartition.AccountID.String())
+	case enums.QueueConstraintFunctionConcurrency:
+		err = NewKeyError(ErrPartitionConcurrencyLimit, shadowPartition.FunctionID.String())
+	case enums.QueueConstraintCustomConcurrencyKey1:
+		err = NewKeyError(ErrConcurrencyLimitCustomKey, backlog.CustomConcurrencyKeyID(1))
+	case enums.QueueConstraintCustomConcurrencyKey2:
+		err = NewKeyError(ErrConcurrencyLimitCustomKey, backlog.CustomConcurrencyKeyID(2))
+	case enums.QueueConstraintSemaphore:
+		err = ErrSemaphoreLimit
+	default:
+		l.ReportError(errors.New("unhandled queue constraint type"), fmt.Sprintf("constraint type: %s", constraintRes.LimitingConstraint))
+		// Limited but the constraint is unknown?
+	}
+
+	// Check the sojourn delay for this item in the queue. Tracking system latency vs
+	// sojourn latency from concurrency is important.
+	//
+	// Firstly, we check:  does the job store the first peek time?  If so, the
+	// delta between now and that time is the sojourn latency.  If not, this is either
+	// one of two cases:
+	//   - This is a new job in the queue, and we're peeking it for the first time.
+	//     Sojourn latency is 0.  Easy.
+	//   - We've peeked the queue since adding the job.  At this point, the only
+	//     conclusion is that the job wasn't peeked because of concurrency/capacity
+	//     issues, so the delta between now - job added is sojourn latency.
+	//
+	// NOTE: You might see that we use tracking semaphores and the worker itself has
+	// a maximum capacity.  We must ALWAYS peek the available capacity in our worker
+	// via the above Peek() call so that worker capacity doesn't prevent us from accessing
+	// all jobs in a peek.  This would break sojourn latency:  it only works if we know
+	// we're quitting early because of concurrency issues in a user's function, NOT because
+	// of capacity issues in our system.
+	//
+	// Anyway, here we set the first peek item to the item's start time if there was a
+	// peek since the job was added.
+	if item.EarliestPeekTime == 0 && partition.Last > 0 && partition.Last > item.AtMS {
+		// Fudge the earliest peek time because we know this wasn't peeked and so
+		// the peek time wasn't set;  but, as we were still processing jobs after
+		// the job was added this item was concurrency-limited.
+		item.EarliestPeekTime = item.AtMS
+	}
+
+	// We may return a keyError, which masks the actual error underneath.  If so,
+	// grab the cause.
+	cause := err
+	var key KeyError
+	if errors.As(err, &key) {
+		cause = key.cause
+	}
+
+	l = l.With(
+		"cause", cause,
+		"item_id", item.ID,
+		"account_id", item.Data.Identifier.AccountID.String(),
+		"env_id", item.WorkspaceID.String(),
+		"app_id", item.Data.Identifier.AppID.String(),
+		"fn_id", item.FunctionID.String(),
+		"queue_shard", q.Shard().Name(),
+	)
+
+	// Used for error reporting.
+	errTags := map[string]string{}
+	if cause != nil {
+		errTags["cause"] = cause.Error()
+	}
+	if leaseID != nil {
+		errTags["lease"] = leaseID.String()
+	}
+
+	switch {
+	case errors.Is(cause, ErrQueueItemThrottled):
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": "throttled", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+		})
+
+		if q.Options().ItemEnableKeyQueues(ctx, *item) {
+			err := q.Shard().Requeue(ctx, *item, time.UnixMilli(item.AtMS))
+			if err != nil && !errors.Is(err, ErrQueueItemNotFound) {
+				l.ReportError(err, "could not requeue item to backlog after hitting throttle limit",
+					logger.WithErrorReportTags(errTags),
+				)
+				return LeaseItemResult{Status: LeaseItemStatusThrottled}, fmt.Errorf("could not requeue to backlog: %w", err)
+			}
+
+			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"queue_shard": q.Shard().Name(),
+					// "partition_id": item.FunctionID.String(),
+					"status": "throttled",
+				},
+			})
+		}
+
+		return LeaseItemResult{Status: LeaseItemStatusThrottled}, nil
+	case errors.Is(cause, ErrPartitionConcurrencyLimit), errors.Is(cause, ErrAccountConcurrencyLimit), errors.Is(cause, ErrSystemConcurrencyLimit):
+		// Since the queue is at capacity on a fn or account level, no
+		// more jobs in this loop should be worked on - so break.
+		//
+		// Even if we have capacity for the next job in the loop we do NOT
+		// want to claim the job, as this breaks ordering guarantees.  The
+		// only safe thing to do when we hit a function or account level
+		// concurrency key.
+		var status string
+		switch {
+		case errors.Is(cause, ErrSystemConcurrencyLimit):
+			status = "system_concurrency_limit"
+		case errors.Is(cause, ErrPartitionConcurrencyLimit):
+			status = "partition_concurrency_limit"
+			if partition.FunctionID != nil {
+				q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *partition.FunctionID)
+			}
+		case errors.Is(cause, ErrAccountConcurrencyLimit):
+			status = "account_concurrency_limit"
+			// For backwards compatibility, we report on the function level as well.
+			if partition.FunctionID != nil {
+				q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *partition.FunctionID)
+			}
+
+			q.Options().lifecycles.OnAccountConcurrencyLimitReached(
+				context.WithoutCancel(ctx),
+				partition.AccountID,
+				partition.EnvID,
+			)
+		}
+
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": status, "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+		})
+
+		if q.Options().ItemEnableKeyQueues(ctx, *item) {
+			err := q.Shard().Requeue(ctx, *item, time.UnixMilli(item.AtMS))
+			if err != nil && !errors.Is(err, ErrQueueItemNotFound) {
+				l.ReportError(err, "could not requeue item to backlog after hitting concurrency limit",
+					logger.WithErrorReportTags(errTags),
+				)
+				return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited}, fmt.Errorf("could not requeue to backlog: %w", err)
+			}
+
+			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"queue_shard": q.Shard().Name(),
+					// "partition_id": item.FunctionID.String(),
+					"status": status,
+				},
+			})
+		}
+
+		return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited}, fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
+	case errors.Is(cause, ErrConcurrencyLimitCustomKey):
+		// For backwards compatibility, we report on the function level as well.
+		if partition.FunctionID != nil {
+			q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *partition.FunctionID)
+		}
+
+		// TODO: Report on key that was hit (this must have been empty previously)
+		// p.queue.lifecycles.OnCustomKeyConcurrencyLimitReached(context.WithoutCancel(ctx), p.partition.EvaluatedConcurrencyKey)
+
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": "custom_key_concurrency_limit", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+		})
+
+		if q.Options().ItemEnableKeyQueues(ctx, *item) {
+			err := q.Shard().Requeue(ctx, *item, time.UnixMilli(item.AtMS))
+			if err != nil && !errors.Is(err, ErrQueueItemNotFound) {
+				l.ReportError(err, "could not requeue item to backlog after hitting custom concurrency limit",
+					logger.WithErrorReportTags(errTags),
+				)
+				return LeaseItemResult{Status: LeaseItemStatusCustomConcurrencyLimited}, fmt.Errorf("could not requeue to backlog: %w", err)
+			}
+
+			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"queue_shard": q.Shard().Name(),
+					// "partition_id": item.FunctionID.String(),
+					"status": "custom_key_concurrency_limit",
+				},
+			})
+		}
+		return LeaseItemResult{Status: LeaseItemStatusCustomConcurrencyLimited}, nil
+	case errors.Is(cause, ErrSemaphoreLimit):
+		// Semaphore capacity exhausted for this specific item (e.g., start job with fn concurrency).
+		// Skip this item and continue scanning; other items without semaphores (step 2, etc.)
+		// can still be processed.
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": "semaphore_limit", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+		})
+		return LeaseItemResult{Status: LeaseItemStatusSemaphoreLimited}, nil
+	case errors.Is(cause, ErrQueueItemNotFound):
+		// This is an okay error.  Move to the next job item.
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": "success", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+		})
+		return LeaseItemResult{Status: LeaseItemStatusNotFound}, nil
+	case errors.Is(cause, ErrQueueItemAlreadyLeased):
+		// This is an okay error.  Move to the next job item.
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": "success", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+		})
+		return LeaseItemResult{Status: LeaseItemStatusLeaseContention}, nil
+	}
+
+	// Handle other errors.
+	if err != nil || leaseID == nil {
+		span.RecordError(err)
+		processErr := fmt.Errorf("error leasing in process: %w", err)
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": "error", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+		})
+		return LeaseItemResult{Status: LeaseItemStatusLeaseError, Err: processErr}, processErr
+	}
+
+	// Assign the lease ID and pass this to be handled by the available worker.
+	// There should always be capacity on this queue as we track capacity via
+	// a semaphore. GenerationID was loaded from the queue hash on Peek and is
+	// preserved across Lease (the Lua script does not touch it).
+	item.LeaseID = leaseID
+
+	metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+		PkgName: pkgName,
+		Tags:    map[string]any{"status": "success", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+	})
+	err = dispatch(ctx, ProcessItem{
+		P:    *partition,
+		I:    *item,
+		PCtr: req.PartitionContinueCtr,
+
+		CapacityLease:       constraintRes.CapacityLease,
+		ConditionalTraceCtx: context.WithoutCancel(ctx),
+	})
+	result := LeaseItemResult{Status: LeaseItemStatusDispatched}
+	if err != nil {
+		span.RecordError(err)
+		return result, err
+	}
+	commitSemaphoreAcquire = true
+
+	return result, nil
+}

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -33,7 +33,7 @@ func partitionRequeueExtensionWithJitter() time.Duration {
 //
 // randomOffset allows us to peek jobs out-of-order, and occurs when we hit concurrency key issues
 // such that we can attempt to work on other jobs not blocked by heading concurrency key issues.
-func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool) error {
+func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool, dispatch DispatchFunc) error {
 	l := logger.StdlibLogger(ctx)
 	shard := q.Shard()
 
@@ -291,6 +291,8 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 		Items:                queue,
 		PartitionContinueCtr: continuationCount,
 		Queue:                q,
+		Leaser:               q,
+		Dispatch:             dispatch,
 		StaticTime:           q.Clock().Now(),
 		Parallel:             parallel,
 	}
@@ -318,7 +320,7 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 			l.Warn("error requeuieng partition for random peek", "error", err)
 		}
 
-		return q.ProcessPartition(ctx, p, continuationCount, true)
+		return q.ProcessPartition(ctx, p, continuationCount, true, dispatch)
 	}
 
 	// If we've hit concurrency issues OR we've only hit rate limit issues, re-enqueue the partition

--- a/pkg/execution/queue/process_partition_deleted_account_test.go
+++ b/pkg/execution/queue/process_partition_deleted_account_test.go
@@ -37,7 +37,10 @@ func TestProcessPartitionRequeuesDeletedAccount(t *testing.T) {
 		ID:         fnID.String(),
 		FunctionID: &fnID,
 		AccountID:  accountID,
-	}, 0, false)
+	}, 0, false, func(_ context.Context, item ProcessItem) error {
+		q.workers <- item
+		return nil
+	})
 	require.NoError(t, err)
 
 	require.Equal(t, int32(1), atomic.LoadInt32(&checks))

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/karlseguin/ccache/v3"
 	"github.com/oklog/ulid/v2"
-	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -214,7 +213,14 @@ func (q *queueProcessor) Queue() Queue {
 }
 
 func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
-	// claimShardLease will block until a shard lease is obtained to process the primary shard.
+	workerCtx, stopWorkers := context.WithCancel(ctx)
+	defer stopWorkers()
+
+	wrappedF := q.wrapRunFuncWithLatency(f)
+	for i := int32(0); i < q.numWorkers; i++ {
+		go q.worker(workerCtx, wrappedF)
+	}
+
 	l := logger.StdlibLogger(ctx)
 	if len(q.runMode.ShardGroup) != 0 {
 		l.Info("Executor started in ShardGroup mode, attempting to claim a shard lease", "shard_group", q.runMode.ShardGroup)
@@ -229,28 +235,25 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 		go q.runRole(ctx, role)
 	}
 
-	wrappedF := q.wrapRunFuncWithLatency(f)
-
-	// start execution and shadow scan concurrently
-	eg, ctx := errgroup.WithContext(ctx)
-
-	eg.Go(func() error {
-		return q.executionScan(ctx, wrappedF)
-	})
-
-	if q.runMode.ShadowPartition {
-		eg.Go(func() error {
-			return q.shadowScan(ctx)
-		})
+	scanner := QueueScanner(partitionQueueScanner{q: q})
+	if shard := q.Shard(); shard != nil {
+		if shardScanner, ok := shard.(QueueScanner); ok {
+			scanner = shardScanner
+		}
 	}
 
-	if q.runMode.NormalizePartition {
-		eg.Go(func() error {
-			return q.backlogNormalizationScan(ctx)
-		})
+	dispatch := func(_ context.Context, item ProcessItem) error {
+		q.workers <- item
+		return nil
 	}
 
-	return eg.Wait()
+	err := scanner.Run(ctx, dispatch)
+
+	l.Info("queue waiting to quit", "err", err)
+	q.wg.Wait()
+	l.Info("in-progress jobs finished, exiting queue processor", "err", err)
+
+	return err
 }
 
 func (q *queueProcessor) capacity() int64 {

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -3,16 +3,10 @@ package queue
 import (
 	"context"
 	"errors"
-	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/logger"
-	"github.com/inngest/inngest/pkg/telemetry/metrics"
-	"github.com/oklog/ulid/v2"
-	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -26,6 +20,10 @@ type ProcessorIterator struct {
 
 	// Queue is the Queue that owns this processor.
 	Queue QueueProcessor
+	// Leaser attempts to lease queue items before dispatch.
+	Leaser QueueItemLeaser
+	// Dispatch sends a leased item to the execution layer.
+	Dispatch DispatchFunc
 
 	// error returned when processing
 	Err error
@@ -80,7 +78,7 @@ func (p *ProcessorIterator) Iterate(ctx context.Context) error {
 		if p.Parallel {
 			item := *i
 			eg.Go(func() error {
-				err := p.Process(ctx, &item)
+				err := p.LeaseItem(ctx, &item)
 				if err != nil {
 					// NOTE: ignore if the queue item is not found
 					if errors.Is(err, ErrQueueItemNotFound) {
@@ -93,7 +91,7 @@ func (p *ProcessorIterator) Iterate(ctx context.Context) error {
 		}
 
 		// non-parallel (sequential fifo) processing.
-		if err = p.Process(ctx, i); err != nil {
+		if err = p.LeaseItem(ctx, i); err != nil {
 			// NOTE: ignore if the queue item is not found
 			if errors.Is(err, ErrQueueItemNotFound) {
 				continue
@@ -171,418 +169,53 @@ func (p *ProcessorIterator) stampRemainingEarliestPeekTimes(ctx context.Context,
 	}
 }
 
+// Process leases a single queue item and dispatches it to the execution layer.
+//
+// Deprecated: use LeaseItem.
 func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error {
-	l := logger.StdlibLogger(ctx).With("partition", p.Partition, "item", item)
+	return p.LeaseItem(ctx, item)
+}
 
-	ctx, span := p.Queue.Options().ConditionalTracer.NewSpan(ctx, "queue.Process", TraceScopeFromQueueItem(*item, p.Queue.Shard().Name()))
-	defer span.End()
-	span.SetAttributes(attribute.String("partition_id", p.Partition.ID))
-	span.SetAttributes(attribute.String("item_kind", item.Data.Kind))
-	span.SetAttributes(attribute.String("run_id", item.Data.Identifier.RunID.String()))
-	span.SetAttributes(attribute.String("item_id", item.ID))
-	if item.Data.JobID != nil {
-		span.SetAttributes(attribute.String("job_id", *item.Data.JobID))
-	}
-
-	// Copy queue timestamps into the inner item for easier access during processing.
-	// We convert these to time.Time here so that we don't have to convert them multiple times during processing.
-	item.Data.At = time.UnixMilli(item.AtMS)
-	item.Data.EnqueuedAt = time.UnixMilli(item.EnqueuedAt)
-
-	if item.IsLeased(p.Queue.Clock().Now()) {
-		span.SetAttributes(attribute.String("skip_reason", "already_leased"))
-		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags:    map[string]any{"status": "lease_contention", "queue_shard": p.Queue.Shard().Name(), "constraint_source": "lease"},
-		})
-		return nil
-	}
-
-	// Check if there's capacity from our local workers atomically prior to leasing our items.
-	if !p.Queue.Semaphore().TryAcquire(1) {
-		span.SetAttributes(attribute.String("skip_reason", "no_queue_worker_capacity"))
-		metrics.IncrQueuePartitionProcessNoCapacityCounter(ctx, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": p.Queue.Shard().Name()}})
-		// Break the entire loop to prevent out of order work.
-		return ErrProcessNoCapacity
-	}
-
-	metrics.WorkerQueueCapacityCounter(ctx, 1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": p.Queue.Shard().Name()}})
-
-	// Release semaphore capacity, will be called when this function
-	// exits unless explicitly committed (see below).
-	//
-	// release() can be called early to make worker capacity available again
-	release := sync.OnceFunc(func() {
-		p.Queue.Semaphore().Release(1)
-		metrics.WorkerQueueCapacityCounter(ctx, -1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": p.Queue.Shard().Name()}})
-	})
-
-	// Default to resetting the semaphore if we don't explicitly keep it
-	// This should prevent forgetting the .Release() case
-	commitSemaphoreAcquire := false
-	defer func() {
-		if commitSemaphoreAcquire {
-			return
-		}
-
-		release()
-	}()
-
-	// In case the item has no earliest peek time set and stamping is enabled,
-	// call SetEarliestPeekTime before verifying and user constraints.
-	// This is intentionally called AFTER queue worker capacity; unlike user constraints,
-	// worker capacity counts towards system latency, not user latency.
-	if item.EarliestPeekTime == 0 && p.Queue.Options().ItemEarliestPeekTimeConfig(ctx, p.Queue.Shard().Name(), *item).Enabled {
-		peekTime := p.StaticTime
-		if peekTime.IsZero() {
-			peekTime = p.Queue.Clock().Now()
-		}
-
-		earliestPeekTime, err := p.Queue.Shard().SetEarliestPeekTime(ctx, *item, peekTime)
-		if err != nil {
-			span.RecordError(err)
-			l.Warn("could not set earliest peek time", "error", err)
-		} else {
-			item.EarliestPeekTime = earliestPeekTime.UnixMilli()
+func (p *ProcessorIterator) LeaseItem(ctx context.Context, item *QueueItem) error {
+	leaser := p.Leaser
+	if leaser == nil {
+		var ok bool
+		leaser, ok = p.Queue.(QueueItemLeaser)
+		if !ok {
+			return ErrProcessStopIterator
 		}
 	}
 
-	//
-	// Before we can do any work on the queue item, we need to check if all the constraints have capacity.
-	// This was previously done in Lease and has since been moved to the Constraint API.
-	//
-	// The Constraint API employs in-memory caching for a subset of constraints, ensuring low-latency
-	// responses on hit constraints and avoiding overloading the API.
-	//
+	result, err := leaser.LeaseItem(ctx, LeaseItemRequest{
+		Item:                 item,
+		Partition:            p.Partition,
+		PartitionContinueCtr: p.PartitionContinueCtr,
+		StaticTime:           p.StaticTime,
+	}, p.Dispatch)
+	p.applyLeaseItemResult(result)
+	return err
+}
 
-	backlog := ItemBacklog(ctx, *item)
-	partition := ItemShadowPartition(ctx, *item)
-	constraints := p.Queue.Options().PartitionConstraintConfigGetter(ctx, partition.Identifier())
-
-	// The following lease options simply specify some objects that are required during lease but were already generated
-	leaseOptions := []LeaseOptionFn{
-		LeaseBacklog(backlog),
-		LeaseShadowPartition(partition),
-		LeaseConstraints(constraints),
-	}
-
-	// Acquire capacity lease, in case the Constraint API is enabled and the current queue item should use capacity leases.
-	// We only ignore capacity leases for system queues and items missing account ID / env ID / function ID combinations.
-	// When the Constraint API is enabled, it will handle concurrency and throttle checks on the queue item.
-	// This is for an individual lease. If a constraint is at capacity, no leases will be returned and we will handle the missing capacity accordingly.
-	constraintRes, err := p.Queue.ItemLeaseConstraintCheck(
-		ctx,
-		&partition,
-		&backlog,
-		constraints,
-		item,
-		p.Queue.Clock().Now(),
-	)
-	if err != nil {
-		span.RecordError(err)
-		l.ReportError(err, "could not check constraints to lease item")
-		// Stop iterator but don't quit the queue
-		return ErrProcessStopIterator
-	}
-
-	// If we're limited by constraints, release semaphore early since we won't be leasing or processing
-	if constraintRes.LimitingConstraint != enums.QueueConstraintNotLimited {
-		release()
-
-		span.SetAttributes(attribute.String("limiting_constraint", constraintRes.LimitingConstraint.String()))
-	}
-
-	var leaseID *ulid.ULID
-	switch constraintRes.LimitingConstraint {
-	// If no constraints were hit (or we didn't invoke the Constraint API)
-	case enums.QueueConstraintNotLimited:
-
-		// Attempt to lease this item before passing this to a worker.  We have to do this
-		// synchronously as we need to lease prior to requeueing the partition pointer. If
-		// we don't do this here, the workers may not lease the items before calling Peek
-		// to re-enqeueu the pointer, which then increases contention - as we requeue a
-		// pointer too early.
-		//
-		// This is safe:  only one process runs scan(), and we guard the total number of
-		// available workers with the above semaphore.
-		leaseID, err = Duration(ctx, p.Queue.Shard().Name(), "lease", p.Queue.Clock().Now(), func(ctx context.Context) (*ulid.ULID, error) {
-			return p.Queue.Shard().Lease(
-				ctx,
-				*item,
-				QueueLeaseDuration,
-				p.StaticTime,
-				leaseOptions...,
-			)
-		})
-		// NOTE: If this loop ends in an error, we must _always_ release an item from the
-		// semaphore to free capacity.  This will happen automatically when the worker
-		// finishes processing a queue item on success.
-		if err != nil {
-			// Continue on and handle the error below.
-			release()
-		}
-	// Simulate errors returned by Lease
-	case enums.QueueConstraintThrottle:
-		err = ErrQueueItemThrottled
-	case enums.QueueConstraintAccountConcurrency:
-		err = NewKeyError(ErrAccountConcurrencyLimit, partition.AccountID.String())
-	case enums.QueueConstraintFunctionConcurrency:
-		err = NewKeyError(ErrPartitionConcurrencyLimit, partition.FunctionID.String())
-	case enums.QueueConstraintCustomConcurrencyKey1:
-		err = NewKeyError(ErrConcurrencyLimitCustomKey, backlog.CustomConcurrencyKeyID(1))
-	case enums.QueueConstraintCustomConcurrencyKey2:
-		err = NewKeyError(ErrConcurrencyLimitCustomKey, backlog.CustomConcurrencyKeyID(2))
-	case enums.QueueConstraintSemaphore:
-		err = ErrSemaphoreLimit
-	default:
-		l.ReportError(errors.New("unhandled queue constraint type"), fmt.Sprintf("constraint type: %s", constraintRes.LimitingConstraint))
-		// Limited but the constraint is unknown?
-	}
-
-	// Check the sojourn delay for this item in the queue. Tracking system latency vs
-	// sojourn latency from concurrency is important.
-	//
-	// Firstly, we check:  does the job store the first peek time?  If so, the
-	// delta between now and that time is the sojourn latency.  If not, this is either
-	// one of two cases:
-	//   - This is a new job in the queue, and we're peeking it for the first time.
-	//     Sojourn latency is 0.  Easy.
-	//   - We've peeked the queue since adding the job.  At this point, the only
-	//     conclusion is that the job wasn't peeked because of concurrency/capacity
-	//     issues, so the delta between now - job added is sojourn latency.
-	//
-	// NOTE: You might see that we use tracking semaphores and the worker itself has
-	// a maximum capacity.  We must ALWAYS peek the available capacity in our worker
-	// via the above Peek() call so that worker capacity doesn't prevent us from accessing
-	// all jobs in a peek.  This would break sojourn latency:  it only works if we know
-	// we're quitting early because of concurrency issues in a user's function, NOT because
-	// of capacity issues in our system.
-	//
-	// Anyway, here we set the first peek item to the item's start time if there was a
-	// peek since the job was added.
-	if item.EarliestPeekTime == 0 && p.Partition.Last > 0 && p.Partition.Last > item.AtMS {
-		// Fudge the earliest peek time because we know this wasn't peeked and so
-		// the peek time wasn't set;  but, as we were still processing jobs after
-		// the job was added this item was concurrency-limited.
-		item.EarliestPeekTime = item.AtMS
-	}
-
-	// We may return a keyError, which masks the actual error underneath.  If so,
-	// grab the cause.
-	cause := err
-	var key KeyError
-	if errors.As(err, &key) {
-		cause = key.cause
-	}
-
-	l = l.With(
-		"cause", cause,
-		"item_id", item.ID,
-		"account_id", item.Data.Identifier.AccountID.String(),
-		"env_id", item.WorkspaceID.String(),
-		"app_id", item.Data.Identifier.AppID.String(),
-		"fn_id", item.FunctionID.String(),
-		"queue_shard", p.Queue.Shard().Name(),
-	)
-
-	// used for error reporting
-	errTags := map[string]string{}
-	if cause != nil {
-		errTags["cause"] = cause.Error()
-	}
-	if leaseID != nil {
-		errTags["lease"] = leaseID.String()
-	}
-
-	switch {
-	case errors.Is(cause, ErrQueueItemThrottled):
+func (p *ProcessorIterator) applyLeaseItemResult(result LeaseItemResult) {
+	switch result.Status {
+	case LeaseItemStatusDispatched, LeaseItemStatusNotFound, LeaseItemStatusLeaseContention:
+		p.CtrSuccess.Add(1)
+	case LeaseItemStatusThrottled:
 		p.IsCustomKeyLimitOnly.Store(false)
 		p.IsSemaphoreLimitOnly.Store(false)
-
 		p.CtrRateLimit.Add(1)
-		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags:    map[string]any{"status": "throttled", "queue_shard": p.Queue.Shard().Name(), "constraint_source": "constraintapi"},
-		})
-
-		if p.Queue.Options().ItemEnableKeyQueues(ctx, *item) {
-			err := p.Queue.Shard().Requeue(ctx, *item, time.UnixMilli(item.AtMS))
-			if err != nil && !errors.Is(err, ErrQueueItemNotFound) {
-				l.ReportError(err, "could not requeue item to backlog after hitting throttle limit",
-					logger.WithErrorReportTags(errTags),
-				)
-				return fmt.Errorf("could not requeue to backlog: %w", err)
-			}
-
-			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
-				PkgName: pkgName,
-				Tags: map[string]any{
-					"queue_shard": p.Queue.Shard().Name(),
-					// "partition_id": item.FunctionID.String(),
-					"status": "throttled",
-				},
-			})
-		}
-
-		return nil
-	case errors.Is(cause, ErrPartitionConcurrencyLimit), errors.Is(cause, ErrAccountConcurrencyLimit), errors.Is(cause, ErrSystemConcurrencyLimit):
+	case LeaseItemStatusConcurrencyLimited:
 		p.IsCustomKeyLimitOnly.Store(false)
 		p.IsSemaphoreLimitOnly.Store(false)
-
 		p.CtrConcurrency.Add(1)
-		// Since the queue is at capacity on a fn or account level, no
-		// more jobs in this loop should be worked on - so break.
-		//
-		// Even if we have capacity for the next job in the loop we do NOT
-		// want to claim the job, as this breaks ordering guarantees.  The
-		// only safe thing to do when we hit a function or account level
-		// concurrency key.
-		var status string
-		switch {
-		case errors.Is(cause, ErrSystemConcurrencyLimit):
-			status = "system_concurrency_limit"
-		case errors.Is(cause, ErrPartitionConcurrencyLimit):
-			status = "partition_concurrency_limit"
-			if p.Partition.FunctionID != nil {
-				p.Queue.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *p.Partition.FunctionID)
-			}
-		case errors.Is(cause, ErrAccountConcurrencyLimit):
-			status = "account_concurrency_limit"
-			// For backwards compatibility, we report on the function level as well
-			if p.Partition.FunctionID != nil {
-				p.Queue.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *p.Partition.FunctionID)
-			}
-
-			p.Queue.Options().lifecycles.OnAccountConcurrencyLimitReached(
-				context.WithoutCancel(ctx),
-				p.Partition.AccountID,
-				p.Partition.EnvID,
-			)
-		}
-
-		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags:    map[string]any{"status": status, "queue_shard": p.Queue.Shard().Name(), "constraint_source": "constraintapi"},
-		})
-
-		if p.Queue.Options().ItemEnableKeyQueues(ctx, *item) {
-			err := p.Queue.Shard().Requeue(ctx, *item, time.UnixMilli(item.AtMS))
-			if err != nil && !errors.Is(err, ErrQueueItemNotFound) {
-				l.ReportError(err, "could not requeue item to backlog after hitting concurrency limit",
-					logger.WithErrorReportTags(errTags),
-				)
-				return fmt.Errorf("could not requeue to backlog: %w", err)
-			}
-
-			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
-				PkgName: pkgName,
-				Tags: map[string]any{
-					"queue_shard": p.Queue.Shard().Name(),
-					// "partition_id": item.FunctionID.String(),
-					"status": status,
-				},
-			})
-		}
-
-		return fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
-	case errors.Is(cause, ErrConcurrencyLimitCustomKey):
+	case LeaseItemStatusCustomConcurrencyLimited:
 		p.IsSemaphoreLimitOnly.Store(false)
 		p.CtrConcurrency.Add(1)
-
-		// For backwards compatibility, we report on the function level as well
-		if p.Partition.FunctionID != nil {
-			p.Queue.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *p.Partition.FunctionID)
-		}
-
-		// TODO: Report on key that was hit (this must have been empty previously)
-		// p.queue.lifecycles.OnCustomKeyConcurrencyLimitReached(context.WithoutCancel(ctx), p.partition.EvaluatedConcurrencyKey)
-
-		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags:    map[string]any{"status": "custom_key_concurrency_limit", "queue_shard": p.Queue.Shard().Name(), "constraint_source": "constraintapi"},
-		})
-
-		if p.Queue.Options().ItemEnableKeyQueues(ctx, *item) {
-			err := p.Queue.Shard().Requeue(ctx, *item, time.UnixMilli(item.AtMS))
-			if err != nil && !errors.Is(err, ErrQueueItemNotFound) {
-				l.ReportError(err, "could not requeue item to backlog after hitting custom concurrency limit",
-					logger.WithErrorReportTags(errTags),
-				)
-				return fmt.Errorf("could not requeue to backlog: %w", err)
-			}
-
-			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
-				PkgName: pkgName,
-				Tags: map[string]any{
-					"queue_shard": p.Queue.Shard().Name(),
-					// "partition_id": item.FunctionID.String(),
-					"status": "custom_key_concurrency_limit",
-				},
-			})
-		}
-		return nil
-	case errors.Is(cause, ErrSemaphoreLimit):
-		// Semaphore capacity exhausted for this specific item (e.g., start job with fn concurrency).
-		// Skip this item and continue scanning — other items without semaphores (step 2, etc.)
-		// can still be processed.
+	case LeaseItemStatusSemaphoreLimited:
 		p.CtrConcurrency.Add(1)
-		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags:    map[string]any{"status": "semaphore_limit", "queue_shard": p.Queue.Shard().Name(), "constraint_source": "constraintapi"},
-		})
-		return nil
-	case errors.Is(cause, ErrQueueItemNotFound):
-		// This is an okay error.  Move to the next job item.
-		p.CtrSuccess.Add(1) // count as a success for stats purposes.
-		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags:    map[string]any{"status": "success", "queue_shard": p.Queue.Shard().Name(), "constraint_source": "constraintapi"},
-		})
-		return nil
-	case errors.Is(cause, ErrQueueItemAlreadyLeased):
-		// This is an okay error.  Move to the next job item.
-		p.CtrSuccess.Add(1) // count as a success for stats purposes.
-		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags:    map[string]any{"status": "success", "queue_shard": p.Queue.Shard().Name(), "constraint_source": "constraintapi"},
-		})
-		return nil
+	case LeaseItemStatusLeaseError:
+		p.Err = result.Err
 	}
-
-	// Handle other errors.
-	if err != nil || leaseID == nil {
-		span.RecordError(err)
-		p.Err = fmt.Errorf("error leasing in process: %w", err)
-		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags:    map[string]any{"status": "error", "queue_shard": p.Queue.Shard().Name(), "constraint_source": "constraintapi"},
-		})
-		return p.Err
-	}
-
-	// Assign the lease ID and pass this to be handled by the available worker.
-	// There should always be capacity on this queue as we track capacity via
-	// a semaphore. GenerationID was loaded from the queue hash on Peek and is
-	// preserved across Lease (the Lua script does not touch it).
-	item.LeaseID = leaseID
-
-	// increase success counter.
-	p.CtrSuccess.Add(1)
-	metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
-		PkgName: pkgName,
-		Tags:    map[string]any{"status": "success", "queue_shard": p.Queue.Shard().Name(), "constraint_source": "constraintapi"},
-	})
-	p.Queue.Workers() <- ProcessItem{
-		P:    *p.Partition,
-		I:    *item,
-		PCtr: p.PartitionContinueCtr,
-
-		CapacityLease:       constraintRes.CapacityLease,
-		ConditionalTraceCtx: context.WithoutCancel(ctx),
-	}
-	commitSemaphoreAcquire = true
-
-	return nil
 }
 
 func (p *ProcessorIterator) IsRequeuable() bool {

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"context"
 	"errors"
+	"fmt"
 	"iter"
 	"sync"
 	"sync/atomic"
@@ -77,7 +78,7 @@ func (m *mockQueueProcessor) ProcessItem(ctx context.Context, i ProcessItem, f R
 	return nil
 }
 
-func (m *mockQueueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool) error {
+func (m *mockQueueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool, dispatch DispatchFunc) error {
 	return nil
 }
 
@@ -462,6 +463,98 @@ func (m *mockQueueProcessor) ItemLeaseConstraintCheck(ctx context.Context, shado
 	}, nil
 }
 
+type mockQueueItemLeaser struct {
+	fn func(context.Context, LeaseItemRequest, DispatchFunc) (LeaseItemResult, error)
+}
+
+func (m mockQueueItemLeaser) LeaseItem(ctx context.Context, req LeaseItemRequest, dispatch DispatchFunc) (LeaseItemResult, error) {
+	return m.fn(ctx, req, dispatch)
+}
+
+func processorIteratorConstraintLeaser(mockProc *mockQueueProcessor) QueueItemLeaser {
+	return mockQueueItemLeaser{
+		fn: func(ctx context.Context, req LeaseItemRequest, dispatch DispatchFunc) (LeaseItemResult, error) {
+			constraint := enums.QueueConstraintNotLimited
+			if mockProc.constraintResultFunc != nil {
+				constraint = mockProc.constraintResultFunc()
+			}
+
+			switch constraint {
+			case enums.QueueConstraintNotLimited:
+				if dispatch == nil {
+					return LeaseItemResult{Status: LeaseItemStatusLeaseError, Err: ErrProcessMissingDispatch}, ErrProcessMissingDispatch
+				}
+				err := dispatch(ctx, ProcessItem{
+					P:    *req.Partition,
+					I:    *req.Item,
+					PCtr: req.PartitionContinueCtr,
+				})
+				if err != nil {
+					return LeaseItemResult{Status: LeaseItemStatusDispatched}, err
+				}
+				return LeaseItemResult{Status: LeaseItemStatusDispatched}, nil
+			case enums.QueueConstraintThrottle:
+				return LeaseItemResult{Status: LeaseItemStatusThrottled}, nil
+			case enums.QueueConstraintCustomConcurrencyKey1, enums.QueueConstraintCustomConcurrencyKey2:
+				return LeaseItemResult{Status: LeaseItemStatusCustomConcurrencyLimited}, nil
+			case enums.QueueConstraintSemaphore:
+				return LeaseItemResult{Status: LeaseItemStatusSemaphoreLimited}, nil
+			default:
+				return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited}, fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
+			}
+		},
+	}
+}
+
+func processorIteratorLeaseBehaviorLeaser(mockProc *mockQueueProcessor) QueueItemLeaser {
+	return mockQueueItemLeaser{
+		fn: func(ctx context.Context, req LeaseItemRequest, dispatch DispatchFunc) (LeaseItemResult, error) {
+			if !mockProc.sem.TryAcquire(1) {
+				return LeaseItemResult{Status: LeaseItemStatusNoWorkerCapacity}, ErrProcessNoCapacity
+			}
+
+			commitSemaphoreAcquire := false
+			defer func() {
+				if !commitSemaphoreAcquire {
+					mockProc.sem.Release(1)
+				}
+			}()
+
+			if req.Item.EarliestPeekTime == 0 && mockProc.opts.ItemEarliestPeekTimeConfig(ctx, mockProc.shard.Name(), *req.Item).Enabled {
+				earliestPeekTime, err := mockProc.shard.SetEarliestPeekTime(ctx, *req.Item, req.StaticTime)
+				if err == nil {
+					req.Item.EarliestPeekTime = earliestPeekTime.UnixMilli()
+				}
+			}
+
+			constraint := enums.QueueConstraintNotLimited
+			if mockProc.constraintResultFunc != nil {
+				constraint = mockProc.constraintResultFunc()
+			}
+			if constraint != enums.QueueConstraintNotLimited {
+				if req.Item.EarliestPeekTime == 0 && req.Partition.Last > 0 && req.Partition.Last > req.Item.AtMS {
+					req.Item.EarliestPeekTime = req.Item.AtMS
+				}
+				return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited}, fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
+			}
+
+			if dispatch == nil {
+				return LeaseItemResult{Status: LeaseItemStatusLeaseError, Err: ErrProcessMissingDispatch}, ErrProcessMissingDispatch
+			}
+			err := dispatch(ctx, ProcessItem{
+				P:    *req.Partition,
+				I:    *req.Item,
+				PCtr: req.PartitionContinueCtr,
+			})
+			if err != nil {
+				return LeaseItemResult{Status: LeaseItemStatusDispatched}, err
+			}
+			commitSemaphoreAcquire = true
+			return LeaseItemResult{Status: LeaseItemStatusDispatched}, nil
+		},
+	}
+}
+
 // TestProcessorIteratorCounterRaceCondition tests for race conditions when
 // ProcessorIterator processes items in parallel mode.
 //
@@ -545,8 +638,13 @@ func TestProcessorIteratorCounterRaceCondition(t *testing.T) {
 		Items:                items,
 		PartitionContinueCtr: 0,
 		Queue:                mockProc,
-		StaticTime:           time.Now(),
-		Parallel:             true, // Enable parallel processing
+		Leaser:               processorIteratorConstraintLeaser(mockProc),
+		Dispatch: func(_ context.Context, item ProcessItem) error {
+			workers <- item
+			return nil
+		},
+		StaticTime: time.Now(),
+		Parallel:   true, // Enable parallel processing
 	}
 
 	// Run iteration - this is where the race condition would occur
@@ -655,8 +753,13 @@ func TestProcessorIteratorCounterRaceConditionMixed(t *testing.T) {
 		Items:                items,
 		PartitionContinueCtr: 0,
 		Queue:                mockProc,
-		StaticTime:           time.Now(),
-		Parallel:             true,
+		Leaser:               processorIteratorConstraintLeaser(mockProc),
+		Dispatch: func(_ context.Context, item ProcessItem) error {
+			workers <- item
+			return nil
+		},
+		StaticTime: time.Now(),
+		Parallel:   true,
 	}
 
 	// Run iteration
@@ -757,8 +860,13 @@ func TestProcessorIteratorIsCustomKeyLimitOnlyRace(t *testing.T) {
 		Items:                items,
 		PartitionContinueCtr: 0,
 		Queue:                mockProc,
-		StaticTime:           time.Now(),
-		Parallel:             true,
+		Leaser:               processorIteratorConstraintLeaser(mockProc),
+		Dispatch: func(_ context.Context, item ProcessItem) error {
+			workers <- item
+			return nil
+		},
+		StaticTime: time.Now(),
+		Parallel:   true,
 	}
 
 	err := iter.Iterate(ctx)
@@ -826,13 +934,18 @@ func TestProcessorIteratorUsesPartitionLastEarliestPeekFallbackWhenFlagDisabled(
 	}
 
 	iter := ProcessorIterator{
-		Partition:  partition,
-		Items:      []*QueueItem{item},
-		Queue:      mockProc,
+		Partition: partition,
+		Items:     []*QueueItem{item},
+		Queue:     mockProc,
+		Leaser:    processorIteratorLeaseBehaviorLeaser(mockProc),
+		Dispatch: func(_ context.Context, item ProcessItem) error {
+			mockProc.workers <- item
+			return nil
+		},
 		StaticTime: at.Add(2 * time.Second),
 	}
 
-	err := iter.Process(ctx, item)
+	err := iter.LeaseItem(ctx, item)
 	require.ErrorIs(t, err, ErrProcessNoUserConstraintCapacity)
 	require.ErrorIs(t, err, ErrProcessStopIterator)
 	require.Equal(t, item.AtMS, item.EarliestPeekTime)
@@ -894,13 +1007,18 @@ func TestProcessorIteratorSkipsEarliestPeekTimeWhenNoWorkerCapacity(t *testing.T
 	}
 
 	iter := ProcessorIterator{
-		Partition:  partition,
-		Items:      []*QueueItem{item},
-		Queue:      mockProc,
+		Partition: partition,
+		Items:     []*QueueItem{item},
+		Queue:     mockProc,
+		Leaser:    processorIteratorLeaseBehaviorLeaser(mockProc),
+		Dispatch: func(_ context.Context, item ProcessItem) error {
+			mockProc.workers <- item
+			return nil
+		},
 		StaticTime: peekTime,
 	}
 
-	err := iter.Process(ctx, item)
+	err := iter.LeaseItem(ctx, item)
 	require.ErrorIs(t, err, ErrProcessNoCapacity)
 	require.Zero(t, item.EarliestPeekTime)
 	require.Equal(t, int32(0), atomic.LoadInt32(&shard.earliestPeekTimeCalls))
@@ -958,13 +1076,18 @@ func TestProcessorIteratorContinuesWhenEarliestPeekTimeStampFails(t *testing.T) 
 	}
 
 	iter := ProcessorIterator{
-		Partition:  partition,
-		Items:      []*QueueItem{item},
-		Queue:      mockProc,
+		Partition: partition,
+		Items:     []*QueueItem{item},
+		Queue:     mockProc,
+		Leaser:    processorIteratorLeaseBehaviorLeaser(mockProc),
+		Dispatch: func(_ context.Context, item ProcessItem) error {
+			workers <- item
+			return nil
+		},
 		StaticTime: at.Add(2 * time.Second),
 	}
 
-	err := iter.Process(ctx, item)
+	err := iter.LeaseItem(ctx, item)
 	require.NoError(t, err)
 	require.Zero(t, item.EarliestPeekTime)
 	require.Equal(t, int32(1), atomic.LoadInt32(&shard.earliestPeekTimeCalls))

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -39,6 +40,27 @@ func (m *mockConsumer) Dequeue(_ context.Context, shardName string, _ QueueItem,
 	return nil
 }
 
+type mockQueueScanner struct {
+	called   atomic.Bool
+	dispatch DispatchFunc
+	err      error
+}
+
+func (m *mockQueueScanner) Run(_ context.Context, dispatch DispatchFunc) error {
+	m.called.Store(true)
+	m.dispatch = dispatch
+	return m.err
+}
+
+type mockScannerShard struct {
+	*mockShardForIterator
+	scanner QueueScanner
+}
+
+func (m *mockScannerShard) Run(ctx context.Context, dispatch DispatchFunc) error {
+	return m.scanner.Run(ctx, dispatch)
+}
+
 func TestProcessorWithQueueProducerOverridesDefaultProducer(t *testing.T) {
 	ctx := context.Background()
 	shard := &mockShardForIterator{name: "shard-a"}
@@ -68,6 +90,54 @@ func TestProcessorWithQueueConsumerOverridesDefaultConsumer(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, consumer.called.Load())
 	require.Equal(t, "custom-shard", consumer.shardName.Load())
+}
+
+func TestProcessorRunUsesShardQueueScanner(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scanner := &mockQueueScanner{}
+	shard := &mockScannerShard{
+		mockShardForIterator: &mockShardForIterator{name: "shard-a"},
+		scanner:              scanner,
+	}
+	registry, err := NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	q, err := New(ctx, "test", registry, WithNumWorkers(1))
+	require.NoError(t, err)
+
+	err = q.Run(ctx, func(context.Context, RunInfo, Item) (RunResult, error) {
+		t.Fatal("run function should not be called")
+		return RunResult{}, nil
+	})
+	require.NoError(t, err)
+	require.True(t, scanner.called.Load())
+	require.NotNil(t, scanner.dispatch)
+}
+
+func TestProcessorRunReturnsQueueScannerError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scannerErr := errors.New("scanner failed")
+	scanner := &mockQueueScanner{err: scannerErr}
+	shard := &mockScannerShard{
+		mockShardForIterator: &mockShardForIterator{name: "shard-a"},
+		scanner:              scanner,
+	}
+	registry, err := NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	q, err := New(ctx, "test", registry, WithNumWorkers(1))
+	require.NoError(t, err)
+
+	err = q.Run(ctx, func(context.Context, RunInfo, Item) (RunResult, error) {
+		t.Fatal("run function should not be called")
+		return RunResult{}, nil
+	})
+	require.ErrorIs(t, err, scannerErr)
+	require.True(t, scanner.called.Load())
 }
 
 func TestProcessorAccountShardReadsResolveByDefault(t *testing.T) {

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -47,6 +47,46 @@ type RunInfo struct {
 // Item's retry policy.
 type RunFunc func(context.Context, RunInfo, Item) (RunResult, error)
 
+type DispatchFunc func(ctx context.Context, item ProcessItem) error
+
+type QueueItemLeaser interface {
+	LeaseItem(ctx context.Context, req LeaseItemRequest, dispatch DispatchFunc) (LeaseItemResult, error)
+}
+
+type LeaseItemRequest struct {
+	Item                 *QueueItem
+	Partition            *QueuePartition
+	PartitionContinueCtr uint
+	StaticTime           time.Time
+}
+
+type LeaseItemStatus int
+
+const (
+	LeaseItemStatusNone LeaseItemStatus = iota
+	LeaseItemStatusDispatched
+	LeaseItemStatusAlreadyLeased
+	LeaseItemStatusNoWorkerCapacity
+	LeaseItemStatusThrottled
+	LeaseItemStatusConcurrencyLimited
+	LeaseItemStatusCustomConcurrencyLimited
+	LeaseItemStatusSemaphoreLimited
+	LeaseItemStatusNotFound
+	LeaseItemStatusLeaseContention
+	LeaseItemStatusLeaseError
+)
+
+type LeaseItemResult struct {
+	Status LeaseItemStatus
+	Err    error
+}
+
+// QueueScanner discovers and leases queue work. It should hand leased items to
+// the dispatch function and leave item execution to the common queue processor layer.
+type QueueScanner interface {
+	Run(ctx context.Context, dispatch DispatchFunc) error
+}
+
 type RunResult struct {
 	// ScheduledImmediateJob indicates whether this run function scheduled another job
 	// in the same partition for immediate consumption.

--- a/pkg/execution/queue/scan.go
+++ b/pkg/execution/queue/scan.go
@@ -16,14 +16,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func (q *queueProcessor) executionScan(ctx context.Context, f RunFunc) error {
+func (q *queueProcessor) executionScan(ctx context.Context, dispatch DispatchFunc) error {
 	l := logger.StdlibLogger(ctx).With(
 		"queue_shard", q.Shard().Name(),
 	)
-
-	for i := int32(0); i < q.numWorkers; i++ {
-		go q.worker(ctx, f)
-	}
 
 	tick := q.Clock().NewTicker(q.pollTick)
 	l.Debug("starting queue worker", "poll", q.pollTick.String())
@@ -56,7 +52,7 @@ LOOP:
 				continue
 			}
 
-			if err = q.scan(ctx); err != nil {
+			if err = q.scan(ctx, dispatch); err != nil {
 				if errors.Is(err, context.DeadlineExceeded) {
 					l.Warn("deadline exceeded scanning partition pointers")
 					<-time.After(backoff)
@@ -77,15 +73,10 @@ LOOP:
 		}
 	}
 
-	// Wait for all in-progress items to complete.
-	l.Info("queue waiting to quit", "err", err)
-	q.wg.Wait()
-	l.Info("in-progress jobs finished, exiting executionScan", "err", err)
-
 	return err
 }
 
-func (q *queueProcessor) scan(ctx context.Context) error {
+func (q *queueProcessor) scan(ctx context.Context, dispatch DispatchFunc) error {
 	l := logger.StdlibLogger(ctx)
 	shard := q.Shard()
 
@@ -104,7 +95,7 @@ func (q *queueProcessor) scan(ctx context.Context) error {
 	}
 
 	// If there are continuations, process those immediately.
-	if err := q.scanContinuations(ctx); err != nil {
+	if err := q.scanContinuations(ctx, dispatch); err != nil {
 		return fmt.Errorf("error scanning continuations: %w", err)
 	}
 
@@ -168,7 +159,7 @@ func (q *queueProcessor) scan(ctx context.Context) error {
 			wg.Add(1)
 			go func(account uuid.UUID) {
 				defer wg.Done()
-				if err := q.ScanAccountPartitions(ctx, account, accountPartitionPeekMax, peekUntil, metricShardName, &actualScannedPartitions); err != nil {
+				if err := q.ScanAccountPartitions(ctx, account, accountPartitionPeekMax, peekUntil, metricShardName, &actualScannedPartitions, dispatch); err != nil {
 					l.Error("error processing account partitions", "error", err)
 				}
 			}(account)
@@ -201,7 +192,7 @@ func (q *queueProcessor) scan(ctx context.Context) error {
 	)
 
 	var actualScannedPartitions int64
-	err := q.ScanGlobalPartitions(ctx, PartitionPeekMax, peekUntil, metricShardName, &actualScannedPartitions)
+	err := q.ScanGlobalPartitions(ctx, PartitionPeekMax, peekUntil, metricShardName, &actualScannedPartitions, dispatch)
 	if err != nil {
 		return fmt.Errorf("error scanning partition: %w", err)
 	}
@@ -220,23 +211,23 @@ func (q *queueProcessor) scan(ctx context.Context) error {
 	return nil
 }
 
-func (q *queueProcessor) ScanAccountPartitions(ctx context.Context, accountID uuid.UUID, peekLimit int64, peekUntil time.Time, metricShardName string, reportPeekedPartitions *int64) error {
+func (q *queueProcessor) ScanAccountPartitions(ctx context.Context, accountID uuid.UUID, peekLimit int64, peekUntil time.Time, metricShardName string, reportPeekedPartitions *int64, dispatch DispatchFunc) error {
 	partitions, err := q.Shard().PeekAccountPartitions(ctx, accountID, peekLimit, peekUntil, q.isSequential())
 	if err != nil {
 		return fmt.Errorf("could not peek account partitions: %w", err)
 	}
 
-	return q.processScannedPartitions(ctx, partitions, peekUntil, metricShardName, reportPeekedPartitions)
+	return q.processScannedPartitions(ctx, partitions, peekUntil, metricShardName, reportPeekedPartitions, dispatch)
 }
 
 // ScanGlobalPartitions scans the partiton of partitions across all fns.
-func (q *queueProcessor) ScanGlobalPartitions(ctx context.Context, peekLimit int64, peekUntil time.Time, metricShardName string, reportPeekedPartitions *int64) error {
+func (q *queueProcessor) ScanGlobalPartitions(ctx context.Context, peekLimit int64, peekUntil time.Time, metricShardName string, reportPeekedPartitions *int64, dispatch DispatchFunc) error {
 	partitions, err := q.Shard().PartitionPeek(ctx, q.isSequential(), peekUntil, peekLimit)
 	if err != nil {
 		return fmt.Errorf("could not peek global partitions: %w", err)
 	}
 
-	return q.processScannedPartitions(ctx, partitions, peekUntil, metricShardName, reportPeekedPartitions)
+	return q.processScannedPartitions(ctx, partitions, peekUntil, metricShardName, reportPeekedPartitions, dispatch)
 }
 
 func (q *queueProcessor) processScannedPartitions(
@@ -245,6 +236,7 @@ func (q *queueProcessor) processScannedPartitions(
 	peekUntil time.Time,
 	metricShardName string,
 	reportPeekedPartitions *int64,
+	dispatch DispatchFunc,
 ) error {
 	if reportPeekedPartitions != nil {
 		atomic.AddInt64(reportPeekedPartitions, int64(len(partitions)))
@@ -275,7 +267,7 @@ func (q *queueProcessor) processScannedPartitions(
 				metrics.IncrQueueScanNoCapacityCounter(ctx, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": shard.Name()}})
 				return nil
 			}
-			err := q.ProcessPartition(ctx, &p, 0, false)
+			err := q.ProcessPartition(ctx, &p, 0, false, dispatch)
 
 			metrics.IncrQueuePartitionProcessedCounter(ctx, metrics.CounterOpt{
 				PkgName: pkgName,

--- a/pkg/execution/queue/scanner.go
+++ b/pkg/execution/queue/scanner.go
@@ -1,0 +1,36 @@
+package queue
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type partitionQueueScanner struct {
+	q *queueProcessor
+}
+
+func (s partitionQueueScanner) Run(ctx context.Context, dispatch DispatchFunc) error {
+	q := s.q
+
+	// start execution and shadow scan concurrently
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		return q.executionScan(ctx, dispatch)
+	})
+
+	if q.runMode.ShadowPartition {
+		eg.Go(func() error {
+			return q.shadowScan(ctx)
+		})
+	}
+
+	if q.runMode.NormalizePartition {
+		eg.Go(func() error {
+			return q.backlogNormalizationScan(ctx)
+		})
+	}
+
+	return eg.Wait()
+}

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -808,11 +808,15 @@ func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {
 			Items:                []*osqueue.QueueItem{&qi},
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			StaticTime:           clock.Now(),
-			Parallel:             false,
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+				q.Workers() <- item
+				return nil
+			},
+			StaticTime: clock.Now(),
+			Parallel:   false,
 		}
 
-		err = iter.Process(ctx, &qi)
+		err = iter.LeaseItem(ctx, &qi)
 		require.NoError(t, err)
 
 		require.Equal(t, 1, len(cmLifecycles.AcquireCalls))
@@ -855,11 +859,15 @@ func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {
 			Items:                []*osqueue.QueueItem{&qi},
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			StaticTime:           clock.Now(),
-			Parallel:             false,
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+				q.Workers() <- item
+				return nil
+			},
+			StaticTime: clock.Now(),
+			Parallel:   false,
 		}
 
-		err = iter.Process(ctx, &qi)
+		err = iter.LeaseItem(ctx, &qi)
 		require.NoError(t, err)
 
 		require.Equal(t, 1, len(cmLifecycles.AcquireCalls))
@@ -944,11 +952,15 @@ func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {
 			Items:                []*osqueue.QueueItem{&qi},
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			StaticTime:           clock.Now(),
-			Parallel:             false,
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+				q.Workers() <- item
+				return nil
+			},
+			StaticTime: clock.Now(),
+			Parallel:   false,
 		}
 
-		err = iter.Process(ctx, &qi)
+		err = iter.LeaseItem(ctx, &qi)
 		require.NoError(t, err)
 
 		// No further Constraint API calls should be made
@@ -1059,8 +1071,12 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 			Items:                items,
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			StaticTime:           clock.Now(),
-			Parallel:             false,
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+				q.Workers() <- item
+				return nil
+			},
+			StaticTime: clock.Now(),
+			Parallel:   false,
 		}
 
 		require.False(t, iter.IsRequeuable())
@@ -1127,7 +1143,10 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 		// score in global set is at earliest item
 		require.Equal(t, start.Unix(), int64(score(t, r, kg.GlobalPartitionIndex(), p.ID)))
 
-		err = q.ProcessPartition(ctx, &p, 0, false)
+		err = q.ProcessPartition(ctx, &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) error {
+			q.Workers() <- item
+			return nil
+		})
 		require.NoError(t, err)
 
 		require.Equal(t, 0, zcard(t, rc, partitionConcurrencyKey(p, kg)))
@@ -1192,8 +1211,12 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 			Items:                items,
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			StaticTime:           clock.Now(),
-			Parallel:             false,
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+				q.Workers() <- item
+				return nil
+			},
+			StaticTime: clock.Now(),
+			Parallel:   false,
 		}
 
 		require.False(t, iter.IsRequeuable())
@@ -1263,7 +1286,10 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 		// score in global set is at earliest item
 		require.Equal(t, start.Unix(), int64(score(t, r, kg.GlobalPartitionIndex(), p.ID)))
 
-		err = q.ProcessPartition(ctx, &p, 0, false)
+		err = q.ProcessPartition(ctx, &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) error {
+			q.Workers() <- item
+			return nil
+		})
 		require.NoError(t, err)
 
 		// first two items were successfully leased
@@ -1400,7 +1426,10 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 		// score in global set is at earliest item
 		require.Equal(t, start.Unix(), int64(score(t, r, kg.GlobalPartitionIndex(), p.ID)))
 
-		err = q.ProcessPartition(logger.WithStdlib(ctx, l), &p, 0, false)
+		err = q.ProcessPartition(logger.WithStdlib(ctx, l), &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) error {
+			q.Workers() <- item
+			return nil
+		})
 		require.NoError(t, err)
 
 		// first two items were successfully leased

--- a/tests/execution/queue/earliest_peek_time_test.go
+++ b/tests/execution/queue/earliest_peek_time_test.go
@@ -19,6 +19,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func dispatchToOSQueueWorkers(workers chan osqueue.ProcessItem) osqueue.DispatchFunc {
+	return func(_ context.Context, item osqueue.ProcessItem) error {
+		workers <- item
+		return nil
+	}
+}
+
 func TestProcessorIteratorSetsEarliestPeekTimeBeforeConstraintLimit(t *testing.T) {
 	ctx := context.Background()
 
@@ -104,6 +111,7 @@ func TestProcessorIteratorSetsEarliestPeekTimeBeforeConstraintLimit(t *testing.T
 		Partition:  &partition,
 		Items:      []*osqueue.QueueItem{&qi1, &qi2},
 		Queue:      q,
+		Dispatch:   dispatchToOSQueueWorkers(q.Workers()),
 		StaticTime: peekTime,
 	}
 
@@ -340,6 +348,7 @@ func TestProcessorIteratorSetsEarliestPeekTimeForProcessedItemsBeforeConcurrency
 		Partition:  &partition,
 		Items:      items,
 		Queue:      q,
+		Dispatch:   dispatchToOSQueueWorkers(q.Workers()),
 		StaticTime: peekTime,
 	}
 
@@ -457,6 +466,7 @@ func TestProcessorIteratorDoesNotStampRemainingItemsWhenDisabled(t *testing.T) {
 		Partition:  &partition,
 		Items:      items,
 		Queue:      q,
+		Dispatch:   dispatchToOSQueueWorkers(q.Workers()),
 		StaticTime: clock.Now().Add(250 * time.Millisecond),
 	}
 
@@ -559,6 +569,7 @@ func TestQueueLatencySeparatesSystemAndUserLatencyAfterEarliestPeekStamp(t *test
 		Partition:  &partition,
 		Items:      []*osqueue.QueueItem{&qi1, &qi2},
 		Queue:      q,
+		Dispatch:   dispatchToOSQueueWorkers(q.Workers()),
 		StaticTime: peekTime,
 	}
 
@@ -586,6 +597,7 @@ func TestQueueLatencySeparatesSystemAndUserLatencyAfterEarliestPeekStamp(t *test
 		Partition:  &partition,
 		Items:      []*osqueue.QueueItem{&qi2},
 		Queue:      q,
+		Dispatch:   dispatchToOSQueueWorkers(q.Workers()),
 		StaticTime: processTime,
 	}
 	err = iter.Iterate(ctx)

--- a/tests/execution/queue/queue_semaphore_test.go
+++ b/tests/execution/queue/queue_semaphore_test.go
@@ -22,6 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func dispatchToQueueWorkers(workers chan queue.ProcessItem) queue.DispatchFunc {
+	return func(_ context.Context, item queue.ProcessItem) error {
+		workers <- item
+		return nil
+	}
+}
+
 func TestQueueSemaphoreWithConstraintAPI(t *testing.T) {
 	ctx := context.Background()
 
@@ -115,6 +122,7 @@ func TestQueueSemaphoreWithConstraintAPI(t *testing.T) {
 		Partition:  &partition,
 		Items:      []*queue.QueueItem{&qi1, &qi2},
 		Queue:      q,
+		Dispatch:   dispatchToQueueWorkers(q.Workers()),
 		StaticTime: clock.Now(),
 	}
 
@@ -342,6 +350,7 @@ func TestQueueSemaphore(t *testing.T) {
 					Partition:  &partition,
 					Items:      []*queue.QueueItem{&qi},
 					Queue:      deps.qp,
+					Dispatch:   dispatchToQueueWorkers(deps.qp.Workers()),
 					StaticTime: clock.Now(),
 				}
 
@@ -396,6 +405,7 @@ func TestQueueSemaphore(t *testing.T) {
 					Partition:  &partition,
 					Items:      []*queue.QueueItem{&qi},
 					Queue:      deps.qp,
+					Dispatch:   dispatchToQueueWorkers(deps.qp.Workers()),
 					StaticTime: clock.Now(),
 				}
 
@@ -437,6 +447,7 @@ func TestQueueSemaphore(t *testing.T) {
 					Partition:  &partition,
 					Items:      []*queue.QueueItem{&qi},
 					Queue:      deps.qp,
+					Dispatch:   dispatchToQueueWorkers(deps.qp.Workers()),
 					StaticTime: clock.Now(),
 				}
 
@@ -490,6 +501,7 @@ func TestQueueSemaphore(t *testing.T) {
 					Partition:  &partition,
 					Items:      []*queue.QueueItem{&qi},
 					Queue:      deps.qp,
+					Dispatch:   dispatchToQueueWorkers(deps.qp.Workers()),
 					StaticTime: clock.Now(),
 				}
 
@@ -552,6 +564,7 @@ func TestQueueSemaphore(t *testing.T) {
 					Partition:  &partition,
 					Items:      []*queue.QueueItem{&qi, &qi2},
 					Queue:      deps.qp,
+					Dispatch:   dispatchToQueueWorkers(deps.qp.Workers()),
 					StaticTime: clock.Now(),
 				}
 
@@ -610,6 +623,7 @@ func TestQueueSemaphore(t *testing.T) {
 					Partition:  &partition,
 					Items:      []*queue.QueueItem{&qi},
 					Queue:      deps.qp,
+					Dispatch:   dispatchToQueueWorkers(deps.qp.Workers()),
 					StaticTime: clock.Now(),
 				}
 
@@ -671,6 +685,7 @@ func TestQueueSemaphore(t *testing.T) {
 					Partition:  &partition,
 					Items:      []*queue.QueueItem{&qi, &qi2},
 					Queue:      deps.qp,
+					Dispatch:   dispatchToQueueWorkers(deps.qp.Workers()),
 					StaticTime: clock.Now(),
 				}
 


### PR DESCRIPTION
## Description

Adds a queue scanner boundary so shard implementations can optionally own queue discovery and leasing while the shared queue processor keeps job execution common.

The OSS fallback scanner preserves the existing queue package scan loops for compatibility. Queue run startup now claims/selects the shard, starts queue roles, picks the shard scanner when the active shard implements the scanner interface, and otherwise uses the fallback scanner.

## Release note

None

## Migration note

None

## Validation

- go test -count=1 ./pkg/execution/queue
- go test -run '^$' ./pkg/execution/state/redis_state