### PR TITLE
feat(metadata): Extract More AI Metdata

### DIFF
--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -901,6 +901,82 @@ func TestSyncStepMetadata(t *testing.T) {
 		require.Len(mocks.tracer.createdSpans, 1, "expected only the step span")
 		require.Equal(meta.SpanNameStep, mocks.tracer.createdSpans[0].name)
 	})
+
+	t.Run("enriches inngest.ai metadata values", func(t *testing.T) {
+		// SDK-sent inngest.ai values get derivable gaps (total_tokens,
+		// estimated_cost) filled before the metadata span is created.
+		ctx := context.Background()
+		require := require.New(t)
+
+		now := time.Now()
+		ops := []state.GeneratorOpcode{
+			{
+				ID:     "step-ai",
+				Op:     enums.OpcodeStepRun,
+				Data:   json.RawMessage(`{"result": "ai output"}`),
+				Name:   "AI Step",
+				Timing: interval.New(now, now.Add(100*time.Millisecond)),
+				Metadata: []metadata.ScopedUpdate{
+					{
+						Scope: enums.MetadataScopeStep,
+						Update: metadata.Update{
+							RawUpdate: metadata.RawUpdate{
+								Kind: "inngest.ai",
+								Op:   enums.MetadataOpcodeMerge,
+								Values: metadata.Values{
+									"input_tokens":  json.RawMessage(`100`),
+									"output_tokens": json.RawMessage(`50`),
+									"request_model": json.RawMessage(`"gpt-4o"`),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		mocks, testData := setupSyncCheckpointTest(t, ops...)
+
+		testData.checkpointer = New(Opts{
+			State:           mocks.state,
+			TracerProvider:  mocks.tracer,
+			Queue:           mocks.queue,
+			MetricsProvider: mocks.metrics,
+			Executor:        mocks.executor,
+			FnReader:        mocks.fnReader,
+			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
+				return true
+			}),
+		})
+
+		expectedData := map[string]any{"data": json.RawMessage(`{"result": "ai output"}`)}
+		expectedOutputBytes, _ := json.Marshal(expectedData)
+		mocks.state.On("SaveStep", ctx, testData.metadata.ID, "step-ai", expectedOutputBytes).Return(false, nil)
+
+		mocks.tracer.
+			On("CreateSpan", mock.Anything, mock.Anything, mock.AnythingOfType("*tracing.CreateSpanOptions")).
+			Return(&meta.SpanReference{}, nil)
+
+		mocks.metrics.On("OnStepFinished", ctx, mock.AnythingOfType("checkpoint.MetricCardinality"), enums.StepStatusCompleted)
+
+		err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+		require.NoError(err)
+
+		var values *metadata.Values
+		for _, s := range mocks.tracer.createdSpans {
+			if s.name == meta.SpanNameMetadata {
+				var ok bool
+				values, ok = s.attributes.Get(meta.Attrs.Metadata.Key()).(*metadata.Values)
+				require.True(ok, "Expected metadata values attribute on the metadata span")
+			}
+		}
+		require.NotNil(values, "Expected a metadata span")
+
+		require.Equal(json.RawMessage(`100`), (*values)["input_tokens"])
+		require.Equal(json.RawMessage(`50`), (*values)["output_tokens"])
+		require.Equal(json.RawMessage(`150`), (*values)["total_tokens"])
+		require.Equal(json.RawMessage(`0.00075`), (*values)["estimated_cost"])
+	})
 }
 
 // TestCheckpointSyncSteps_RunComplete asserts that an OpcodeRunComplete op:

--- a/pkg/tracing/metadata.go
+++ b/pkg/tracing/metadata.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/enums"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/inngest/inngest/pkg/tracing/meta"
@@ -31,12 +32,14 @@ func CreateMetadataSpan(ctx context.Context, tracerProvider TracerProvider, pare
 // avoiding redundant serialization when the caller has already called Serialize.
 func CreateMetadataSpanFromValues(ctx context.Context, tracerProvider TracerProvider, parent *meta.SpanReference, location, pkgName string, stateMetadata *statev2.Metadata, kind metadata.Kind, op metadata.Opcode, values metadata.Values, scope metadata.Scope, opts ...MetadataSpanAttrOpts) (*meta.SpanReference, error) {
 	// Every metadata span, regardless of caller, passes through here — so
-	// this is the single chokepoint to backfill EstimatedCost for
-	// "inngest.ai" metadata that arrived without one (e.g. submitted
-	// directly via inngest.metadata.update or the AddRunMetadata API,
-	// bypassing the AIMetadata-producing extractors). A no-op when
-	// EstimatedCost is already set.
-	if kind == extractors.KindInngestAI {
+	// this is the single chokepoint to backfill TotalTokens and
+	// EstimatedCost for "inngest.ai" metadata that arrived without them
+	// (e.g. submitted directly via inngest.metadata.update or the
+	// AddRunMetadata API, bypassing the AIMetadata-producing extractors).
+	// No-ops when the values are already set. Delete values are keys to
+	// remove, not metrics, so they are never backfilled.
+	if kind == extractors.KindInngestAI && op != enums.MetadataOpcodeDelete {
+		extractors.BackfillTotalTokensInValues(values)
 		extractors.BackfillEstimatedCostInValues(values)
 	}
 

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -347,6 +347,44 @@ func backfillEstimatedCost(md *AIMetadata) {
 	md.EstimatedCost = estimatedCostForTokens(md.ResponseModel, md.RequestModel, md.InputTokens, md.OutputTokens)
 }
 
+// backfillTotalTokens sets md.TotalTokens by summing input and output tokens
+// only when the emitter didn't supply a total and there is usage to sum.
+func backfillTotalTokens(md *AIMetadata) {
+	if md.TotalTokens != nil || (md.InputTokens == 0 && md.OutputTokens == 0) {
+		return
+	}
+	totalTokens := md.InputTokens + md.OutputTokens
+	md.TotalTokens = &totalTokens
+}
+
+// BackfillTotalTokensInValues fills a "total_tokens" entry into raw
+// "inngest.ai" metadata values when one isn't already present, mirroring
+// BackfillEstimatedCostInValues for token totals.
+func BackfillTotalTokensInValues(values metadata.Values) {
+	if values == nil {
+		return
+	}
+
+	if raw, ok := values["total_tokens"]; ok {
+		var existing *int64
+		if err := json.Unmarshal(raw, &existing); err == nil && existing != nil {
+			return
+		}
+	}
+
+	var inputTokens, outputTokens int64
+	_ = json.Unmarshal(values["input_tokens"], &inputTokens)
+	_ = json.Unmarshal(values["output_tokens"], &outputTokens)
+	if inputTokens == 0 && outputTokens == 0 {
+		return
+	}
+
+	totalTokens := inputTokens + outputTokens
+	if b, err := json.Marshal(totalTokens); err == nil {
+		values["total_tokens"] = b
+	}
+}
+
 // BackfillEstimatedCostInValues fills an "estimated_cost" entry into raw
 // "inngest.ai" metadata values when one isn't already present. Unlike
 // backfillEstimatedCost, this operates on untyped metadata.Values — the shape

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"math"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -110,7 +109,7 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 		RequestModel:  parsedInput.Model,
 		ResponseModel: parsedOutput.Model,
 		ResponseID:    parsedOutput.ID,
-		Provider:      aiProviderFromRequest(u.Host, req.Format),
+		Provider:      req.Format,
 
 		InputTokens:  int64(parsedOutput.TokensIn),
 		OutputTokens: int64(parsedOutput.TokensOut),
@@ -151,31 +150,6 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 			ResponseStatus:      util.ToPtr(int64(respStatus)),
 		},
 	}, nil
-}
-
-// aiProviderFromRequest resolves a provider identifier from the request
-// format. The OpenAI chat format is shared by many compatible providers
-// (Groq, DeepSeek, local endpoints), so only api.openai.com itself maps to
-// "openai"; other hosts keep the format verbatim, with the endpoint visible
-// in the adjacent HTTP metadata.
-func aiProviderFromRequest(host, format string) string {
-	switch format {
-	case aigateway.FormatAnthropic:
-		return "anthropic"
-	case aigateway.FormatGemini:
-		return "gcp.gemini"
-	case aigateway.FormatBedrock:
-		return "aws.bedrock"
-	}
-
-	if h, _, err := net.SplitHostPort(host); err == nil {
-		host = h
-	}
-	if strings.EqualFold(host, "api.openai.com") {
-		return "openai"
-	}
-
-	return format
 }
 
 type vercelAIUsage struct {

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -121,12 +121,8 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 		aiMd.FinishReasons = []string{parsedOutput.StopReason}
 	}
 
-	if parsedInput.Temperature != nil {
-		aiMd.Temperature = util.ToPtr(float32To64(*parsedInput.Temperature))
-	}
-	if parsedInput.TopP != nil {
-		aiMd.TopP = util.ToPtr(float32To64(*parsedInput.TopP))
-	}
+	aiMd.Temperature = parsedInput.Temperature
+	aiMd.TopP = parsedInput.TopP
 	maxTokens := parsedInput.MaxTokens
 	if maxTokens == 0 {
 		maxTokens = parsedInput.MaxCompletionTokens
@@ -180,14 +176,6 @@ func aiProviderFromRequest(host, format string) string {
 	}
 
 	return format
-}
-
-// float32To64 widens via the shortest decimal representation so float32
-// request params survive without binary noise (0.7 stays 0.7 rather than
-// becoming 0.699999988079071).
-func float32To64(f float32) float64 {
-	v, _ := strconv.ParseFloat(strconv.FormatFloat(float64(f), 'g', -1, 32), 64)
-	return v
 }
 
 type vercelAIUsage struct {

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"math"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -100,10 +101,6 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 		}
 	}
 
-	inputTokens := int64(parsedOutput.TokensIn)
-	outputTokens := int64(parsedOutput.TokensOut)
-	totalTokens := inputTokens + outputTokens
-
 	var latencyMs *int64
 	if serverProcessingMs > 0 {
 		latencyMs = &serverProcessingMs
@@ -112,14 +109,36 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 	aiMd := &AIMetadata{
 		RequestModel:  parsedInput.Model,
 		ResponseModel: parsedOutput.Model,
-		Provider:      req.Format,
-		OperationName: "",
+		ResponseID:    parsedOutput.ID,
+		Provider:      aiProviderFromRequest(u.Host, req.Format),
 
-		InputTokens:  inputTokens,
-		OutputTokens: outputTokens,
-		TotalTokens:  &totalTokens,
+		InputTokens:  int64(parsedOutput.TokensIn),
+		OutputTokens: int64(parsedOutput.TokensOut),
 		LatencyMs:    latencyMs,
 	}
+
+	if parsedOutput.StopReason != "" {
+		aiMd.FinishReasons = []string{parsedOutput.StopReason}
+	}
+
+	if parsedInput.Temperature != nil {
+		aiMd.Temperature = util.ToPtr(float32To64(*parsedInput.Temperature))
+	}
+	if parsedInput.TopP != nil {
+		aiMd.TopP = util.ToPtr(float32To64(*parsedInput.TopP))
+	}
+	maxTokens := parsedInput.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = parsedInput.MaxCompletionTokens
+	}
+	if maxTokens != 0 {
+		aiMd.MaxTokens = util.ToPtr(int64(maxTokens))
+	}
+	if parsedInput.Seed != nil {
+		aiMd.Seed = util.ToPtr(int64(*parsedInput.Seed))
+	}
+
+	backfillTotalTokens(aiMd)
 	backfillEstimatedCost(aiMd)
 
 	return []metadata.Structured{
@@ -136,6 +155,39 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 			ResponseStatus:      util.ToPtr(int64(respStatus)),
 		},
 	}, nil
+}
+
+// aiProviderFromRequest resolves a provider identifier from the request
+// format. The OpenAI chat format is shared by many compatible providers
+// (Groq, DeepSeek, local endpoints), so only api.openai.com itself maps to
+// "openai"; other hosts keep the format verbatim, with the endpoint visible
+// in the adjacent HTTP metadata.
+func aiProviderFromRequest(host, format string) string {
+	switch format {
+	case aigateway.FormatAnthropic:
+		return "anthropic"
+	case aigateway.FormatGemini:
+		return "gcp.gemini"
+	case aigateway.FormatBedrock:
+		return "aws.bedrock"
+	}
+
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	if strings.EqualFold(host, "api.openai.com") {
+		return "openai"
+	}
+
+	return format
+}
+
+// float32To64 widens via the shortest decimal representation so float32
+// request params survive without binary noise (0.7 stays 0.7 rather than
+// becoming 0.699999988079071).
+func float32To64(f float32) float64 {
+	v, _ := strconv.ParseFloat(strconv.FormatFloat(float64(f), 'g', -1, 32), 64)
+	return v
 }
 
 type vercelAIUsage struct {

--- a/pkg/tracing/metadata/extractors/ai_gateway_test.go
+++ b/pkg/tracing/metadata/extractors/ai_gateway_test.go
@@ -1,0 +1,286 @@
+package extractors
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/util"
+	"github.com/inngest/inngest/pkg/util/aigateway"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func extractGatewayAIMetadata(t *testing.T, req aigateway.Request, resp []byte, serverProcessingMs int64) *AIMetadata {
+	t.Helper()
+
+	md, err := ExtractAIGatewayMetadata(req, 200, resp, serverProcessingMs)
+	require.NoError(t, err)
+	require.Len(t, md, 2, "Expected AI and HTTP metadata")
+
+	aiMd, ok := md[0].(*AIMetadata)
+	require.True(t, ok, "Expected first entry to be AIMetadata")
+	return aiMd
+}
+
+func TestExtractAIGatewayMetadata_OpenAIChatCompletion(t *testing.T) {
+	t.Parallel()
+
+	req := aigateway.Request{
+		URL:    "https://api.openai.com/v1/chat/completions",
+		Format: aigateway.FormatOpenAIChat,
+		Body: json.RawMessage(`{
+			"model": "gpt-4o",
+			"messages": [{"role": "user", "content": "Hello"}]
+		}`),
+	}
+	resp := []byte(`{
+		"id": "chatcmpl-abc123",
+		"object": "chat.completion",
+		"created": 1741569952,
+		"model": "gpt-4o-2024-08-06",
+		"choices": [
+			{
+				"index": 0,
+				"message": {"role": "assistant", "content": "Hi there!"},
+				"finish_reason": "stop"
+			}
+		],
+		"usage": {"prompt_tokens": 25, "completion_tokens": 50, "total_tokens": 75}
+	}`)
+
+	aiMd := extractGatewayAIMetadata(t, req, resp, 1234)
+
+	assert.Equal(t, "gpt-4o", aiMd.RequestModel)
+	assert.Equal(t, "gpt-4o-2024-08-06", aiMd.ResponseModel)
+	assert.Equal(t, "chatcmpl-abc123", aiMd.ResponseID)
+	assert.Equal(t, []string{"stop"}, aiMd.FinishReasons)
+	assert.Equal(t, "openai", aiMd.Provider)
+	assert.Equal(t, int64(25), aiMd.InputTokens)
+	assert.Equal(t, int64(50), aiMd.OutputTokens)
+	assert.Equal(t, util.ToPtr[int64](75), aiMd.TotalTokens)
+	assert.NotNil(t, aiMd.EstimatedCost)
+	assert.Equal(t, util.ToPtr[int64](1234), aiMd.LatencyMs)
+}
+
+func TestExtractAIGatewayMetadata_AnthropicFormatFallback(t *testing.T) {
+	t.Parallel()
+
+	req := aigateway.Request{
+		URL:    "https://llm-proxy.internal.example.com/v1/messages",
+		Format: aigateway.FormatAnthropic,
+		Body:   json.RawMessage(`{"model": "claude-sonnet-4-5", "max_tokens": 512}`),
+	}
+	resp := []byte(`{
+		"id": "msg_01XYZ",
+		"type": "message",
+		"role": "assistant",
+		"model": "claude-sonnet-4-5",
+		"content": [{"type": "text", "text": "Hello"}],
+		"stop_reason": "end_turn",
+		"usage": {"input_tokens": 30, "output_tokens": 60}
+	}`)
+
+	aiMd := extractGatewayAIMetadata(t, req, resp, 0)
+
+	assert.Equal(t, "anthropic", aiMd.Provider)
+	assert.Equal(t, "msg_01XYZ", aiMd.ResponseID)
+	assert.Equal(t, []string{"end_turn"}, aiMd.FinishReasons)
+	assert.Equal(t, int64(30), aiMd.InputTokens)
+	assert.Equal(t, int64(60), aiMd.OutputTokens)
+	assert.Equal(t, util.ToPtr[int64](90), aiMd.TotalTokens)
+	assert.NotNil(t, aiMd.EstimatedCost)
+	assert.Nil(t, aiMd.LatencyMs, "Should not report latency when server processing time is unknown")
+}
+
+func TestExtractAIGatewayMetadata_RequestParams(t *testing.T) {
+	t.Parallel()
+
+	resp := []byte(`{
+		"id": "chatcmpl-1",
+		"model": "gpt-4o",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+		"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+	}`)
+
+	cases := []struct {
+		name          string
+		body          string
+		wantTemp      *float64
+		wantTopP      *float64
+		wantMaxTokens *int64
+		wantSeed      *int64
+	}{
+		{
+			name:          "all params set",
+			body:          `{"model": "gpt-4o", "temperature": 0.5, "top_p": 0.75, "max_tokens": 1024, "seed": 42}`,
+			wantTemp:      util.ToPtr(0.5),
+			wantTopP:      util.ToPtr(0.75),
+			wantMaxTokens: util.ToPtr[int64](1024),
+			wantSeed:      util.ToPtr[int64](42),
+		},
+		{
+			name:     "float32 params widen without binary noise",
+			body:     `{"model": "gpt-4o", "temperature": 0.7, "top_p": 0.9}`,
+			wantTemp: util.ToPtr(0.7),
+			wantTopP: util.ToPtr(0.9),
+		},
+		{
+			name:          "max tokens falls back to max completion tokens",
+			body:          `{"model": "gpt-4o", "max_completion_tokens": 2048}`,
+			wantMaxTokens: util.ToPtr[int64](2048),
+		},
+		{
+			name:     "seed zero is preserved",
+			body:     `{"model": "gpt-4o", "seed": 0}`,
+			wantSeed: util.ToPtr[int64](0),
+		},
+		{
+			name:     "temperature and top_p zero are preserved",
+			body:     `{"model": "gpt-4o", "temperature": 0, "top_p": 0}`,
+			wantTemp: util.ToPtr(0.0),
+			wantTopP: util.ToPtr(0.0),
+		},
+		{
+			name: "null params stay nil",
+			body: `{"model": "gpt-4o", "temperature": null, "top_p": null}`,
+		},
+		{
+			name: "absent params stay nil",
+			body: `{"model": "gpt-4o"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := aigateway.Request{
+				URL:    "https://api.openai.com/v1/chat/completions",
+				Format: aigateway.FormatOpenAIChat,
+				Body:   json.RawMessage(tc.body),
+			}
+
+			aiMd := extractGatewayAIMetadata(t, req, resp, 0)
+
+			assert.Equal(t, tc.wantTemp, aiMd.Temperature)
+			assert.Equal(t, tc.wantTopP, aiMd.TopP)
+			assert.Equal(t, tc.wantMaxTokens, aiMd.MaxTokens)
+			assert.Equal(t, tc.wantSeed, aiMd.Seed)
+		})
+	}
+}
+
+func TestExtractAIGatewayMetadata_UnknownHostKeepsFormatAsProvider(t *testing.T) {
+	t.Parallel()
+
+	req := aigateway.Request{
+		URL:    "https://my-llm.internal:8080/v1/chat/completions",
+		Format: aigateway.FormatOpenAIChat,
+		Body:   json.RawMessage(`{"model": "local-model"}`),
+	}
+	resp := []byte(`{
+		"id": "chatcmpl-2",
+		"model": "local-model",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+		"usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}
+	}`)
+
+	aiMd := extractGatewayAIMetadata(t, req, resp, 0)
+
+	assert.Equal(t, "openai-chat", aiMd.Provider)
+	assert.Nil(t, aiMd.EstimatedCost, "Should not estimate cost for unknown models")
+}
+
+func TestExtractAIGatewayMetadata_NoFinishReasonsWhenStopReasonEmpty(t *testing.T) {
+	t.Parallel()
+
+	req := aigateway.Request{
+		URL:    "https://api.openai.com/v1/chat/completions",
+		Format: aigateway.FormatOpenAIChat,
+		Body:   json.RawMessage(`{"model": "gpt-4o"}`),
+	}
+	resp := []byte(`{
+		"id": "chatcmpl-3",
+		"model": "gpt-4o",
+		"choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+		"usage": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}
+	}`)
+
+	aiMd := extractGatewayAIMetadata(t, req, resp, 0)
+
+	assert.Nil(t, aiMd.FinishReasons)
+}
+
+func TestAIProviderFromRequest(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		host   string
+		format string
+		want   string
+	}{
+		{
+			name:   "anthropic format",
+			host:   "llm-proxy.internal",
+			format: aigateway.FormatAnthropic,
+			want:   "anthropic",
+		},
+		{
+			name:   "gemini format",
+			host:   "llm-proxy.internal",
+			format: aigateway.FormatGemini,
+			want:   "gcp.gemini",
+		},
+		{
+			name:   "bedrock format",
+			host:   "bedrock-runtime.us-east-1.amazonaws.com",
+			format: aigateway.FormatBedrock,
+			want:   "aws.bedrock",
+		},
+		{
+			name:   "openai host with openai format",
+			host:   "api.openai.com",
+			format: aigateway.FormatOpenAIChat,
+			want:   "openai",
+		},
+		{
+			name:   "openai host with explicit port",
+			host:   "api.openai.com:443",
+			format: aigateway.FormatOpenAIChat,
+			want:   "openai",
+		},
+		{
+			name:   "openai host is case-insensitive",
+			host:   "API.OpenAI.com",
+			format: aigateway.FormatOpenAIChat,
+			want:   "openai",
+		},
+		{
+			name:   "openai-compatible host keeps format verbatim",
+			host:   "api.groq.com",
+			format: aigateway.FormatOpenAIChat,
+			want:   "openai-chat",
+		},
+		{
+			name:   "unknown host with port keeps format verbatim",
+			host:   "my-llm.internal:8080",
+			format: aigateway.FormatOpenAIChat,
+			want:   "openai-chat",
+		},
+		{
+			name:   "lookalike host does not match",
+			host:   "evilapi.openai.com",
+			format: aigateway.FormatOpenAIChat,
+			want:   "openai-chat",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.want, aiProviderFromRequest(tc.host, tc.format))
+		})
+	}
+}

--- a/pkg/tracing/metadata/extractors/ai_gateway_test.go
+++ b/pkg/tracing/metadata/extractors/ai_gateway_test.go
@@ -54,7 +54,7 @@ func TestExtractAIGatewayMetadata_OpenAIChatCompletion(t *testing.T) {
 	assert.Equal(t, "gpt-4o-2024-08-06", aiMd.ResponseModel)
 	assert.Equal(t, "chatcmpl-abc123", aiMd.ResponseID)
 	assert.Equal(t, []string{"stop"}, aiMd.FinishReasons)
-	assert.Equal(t, "openai", aiMd.Provider)
+	assert.Equal(t, "openai-chat", aiMd.Provider)
 	assert.Equal(t, int64(25), aiMd.InputTokens)
 	assert.Equal(t, int64(50), aiMd.OutputTokens)
 	assert.Equal(t, util.ToPtr[int64](75), aiMd.TotalTokens)
@@ -164,7 +164,7 @@ func TestExtractAIGatewayMetadata_RequestParams(t *testing.T) {
 	}
 }
 
-func TestExtractAIGatewayMetadata_UnknownHostKeepsFormatAsProvider(t *testing.T) {
+func TestExtractAIGatewayMetadata_UnknownModelHasNoEstimatedCost(t *testing.T) {
 	t.Parallel()
 
 	req := aigateway.Request{
@@ -181,7 +181,6 @@ func TestExtractAIGatewayMetadata_UnknownHostKeepsFormatAsProvider(t *testing.T)
 
 	aiMd := extractGatewayAIMetadata(t, req, resp, 0)
 
-	assert.Equal(t, "openai-chat", aiMd.Provider)
 	assert.Nil(t, aiMd.EstimatedCost, "Should not estimate cost for unknown models")
 }
 
@@ -203,78 +202,4 @@ func TestExtractAIGatewayMetadata_NoFinishReasonsWhenStopReasonEmpty(t *testing.
 	aiMd := extractGatewayAIMetadata(t, req, resp, 0)
 
 	assert.Nil(t, aiMd.FinishReasons)
-}
-
-func TestAIProviderFromRequest(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name   string
-		host   string
-		format string
-		want   string
-	}{
-		{
-			name:   "anthropic format",
-			host:   "llm-proxy.internal",
-			format: aigateway.FormatAnthropic,
-			want:   "anthropic",
-		},
-		{
-			name:   "gemini format",
-			host:   "llm-proxy.internal",
-			format: aigateway.FormatGemini,
-			want:   "gcp.gemini",
-		},
-		{
-			name:   "bedrock format",
-			host:   "bedrock-runtime.us-east-1.amazonaws.com",
-			format: aigateway.FormatBedrock,
-			want:   "aws.bedrock",
-		},
-		{
-			name:   "openai host with openai format",
-			host:   "api.openai.com",
-			format: aigateway.FormatOpenAIChat,
-			want:   "openai",
-		},
-		{
-			name:   "openai host with explicit port",
-			host:   "api.openai.com:443",
-			format: aigateway.FormatOpenAIChat,
-			want:   "openai",
-		},
-		{
-			name:   "openai host is case-insensitive",
-			host:   "API.OpenAI.com",
-			format: aigateway.FormatOpenAIChat,
-			want:   "openai",
-		},
-		{
-			name:   "openai-compatible host keeps format verbatim",
-			host:   "api.groq.com",
-			format: aigateway.FormatOpenAIChat,
-			want:   "openai-chat",
-		},
-		{
-			name:   "unknown host with port keeps format verbatim",
-			host:   "my-llm.internal:8080",
-			format: aigateway.FormatOpenAIChat,
-			want:   "openai-chat",
-		},
-		{
-			name:   "lookalike host does not match",
-			host:   "evilapi.openai.com",
-			format: aigateway.FormatOpenAIChat,
-			want:   "openai-chat",
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			assert.Equal(t, tc.want, aiProviderFromRequest(tc.host, tc.format))
-		})
-	}
 }

--- a/pkg/tracing/metadata/extractors/ai_gateway_test.go
+++ b/pkg/tracing/metadata/extractors/ai_gateway_test.go
@@ -119,12 +119,6 @@ func TestExtractAIGatewayMetadata_RequestParams(t *testing.T) {
 			wantSeed:      util.ToPtr[int64](42),
 		},
 		{
-			name:     "float32 params widen without binary noise",
-			body:     `{"model": "gpt-4o", "temperature": 0.7, "top_p": 0.9}`,
-			wantTemp: util.ToPtr(0.7),
-			wantTopP: util.ToPtr(0.9),
-		},
-		{
 			name:          "max tokens falls back to max completion tokens",
 			body:          `{"model": "gpt-4o", "max_completion_tokens": 2048}`,
 			wantMaxTokens: util.ToPtr[int64](2048),

--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -469,3 +469,83 @@ func TestExtractAIOutputMetadata_TypicalStepOutput(t *testing.T) {
 		assert.Nil(t, md, "Non-AI step output should return nil: %s", string(output))
 	}
 }
+
+func TestBackfillTotalTokensInValues(t *testing.T) {
+	t.Parallel()
+
+	valuesOf := func(v map[string]any) metadata.Values {
+		values := metadata.Values{}
+		for k, val := range v {
+			b, err := json.Marshal(val)
+			require.NoError(t, err)
+			values[k] = b
+		}
+		return values
+	}
+
+	totalOf := func(t *testing.T, values metadata.Values) *int64 {
+		raw, ok := values["total_tokens"]
+		if !ok {
+			return nil
+		}
+		var total *int64
+		require.NoError(t, json.Unmarshal(raw, &total))
+		return total
+	}
+
+	cases := []struct {
+		name      string
+		values    map[string]any
+		wantTotal *int64
+	}{
+		{
+			name: "backfills from input and output tokens",
+			values: map[string]any{
+				"input_tokens":  int64(100),
+				"output_tokens": int64(50),
+			},
+			wantTotal: util.ToPtr[int64](150),
+		},
+		{
+			name: "leaves an existing non-null total untouched",
+			values: map[string]any{
+				"input_tokens":  int64(100),
+				"output_tokens": int64(50),
+				"total_tokens":  int64(999),
+			},
+			wantTotal: util.ToPtr[int64](999),
+		},
+		{
+			name: "overwrites an explicit null total",
+			values: map[string]any{
+				"input_tokens":  int64(100),
+				"output_tokens": int64(50),
+				"total_tokens":  nil,
+			},
+			wantTotal: util.ToPtr[int64](150),
+		},
+		{
+			name: "no usage means no total",
+			values: map[string]any{
+				"request_model": "gpt-4o",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			values := valuesOf(tc.values)
+			BackfillTotalTokensInValues(values)
+
+			total := totalOf(t, values)
+			if tc.wantTotal == nil {
+				assert.Nil(t, total)
+				return
+			}
+			require.NotNil(t, total)
+			assert.Equal(t, *tc.wantTotal, *total)
+		})
+	}
+}

--- a/pkg/tracing/metadata/extractors/aimetadata.go
+++ b/pkg/tracing/metadata/extractors/aimetadata.go
@@ -35,12 +35,7 @@ func (e *AIMetadataExtractor) extractAIMetadata(span *tracev1.Span) (md AIMetada
 		md.LatencyMs = &latencyMs
 	}
 
-	// calculate total tokens if a provider value wasn't supplied
-	if md.TotalTokens == nil && (md.InputTokens > 0 || md.OutputTokens > 0) {
-		totalTokens := md.InputTokens + md.OutputTokens
-		md.TotalTokens = &totalTokens
-	}
-
+	backfillTotalTokens(&md)
 	backfillEstimatedCost(&md)
 
 	return md, true

--- a/pkg/tracing/metadata_test.go
+++ b/pkg/tracing/metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"maps"
 	"strings"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,6 +92,70 @@ func TestCreateMetadataSpan_EmptyValues(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, ref)
+}
+
+// captureTracerProvider records CreateSpan options for attribute assertions.
+type captureTracerProvider struct {
+	TracerProvider
+	spans []*CreateSpanOptions
+}
+
+func (p *captureTracerProvider) CreateSpan(ctx context.Context, name string, opts *CreateSpanOptions) (*meta.SpanReference, error) {
+	p.spans = append(p.spans, opts)
+	return &meta.SpanReference{}, nil
+}
+
+func TestCreateMetadataSpanFromValues_EnrichesAIValues(t *testing.T) {
+	tp := &captureTracerProvider{}
+
+	values := metadata.Values{
+		"input_tokens":  json.RawMessage(`100`),
+		"output_tokens": json.RawMessage(`50`),
+		"request_model": json.RawMessage(`"gpt-4o"`),
+	}
+
+	ref, err := CreateMetadataSpanFromValues(
+		context.Background(), tp, &meta.SpanReference{},
+		"test.location", "test", nil,
+		extractors.KindInngestAI, enums.MetadataOpcodeMerge, values, enums.MetadataScopeStep,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+
+	require.Len(t, tp.spans, 1)
+	got, ok := tp.spans[0].Attributes.Get(meta.Attrs.Metadata.Key()).(*metadata.Values)
+	require.True(t, ok, "expected metadata values attribute on the span")
+	require.Equal(t, json.RawMessage(`100`), (*got)["input_tokens"])
+	require.Equal(t, json.RawMessage(`150`), (*got)["total_tokens"])
+	require.Equal(t, json.RawMessage(`0.00075`), (*got)["estimated_cost"])
+	_, hasLatency := (*got)["latency_ms"]
+	require.False(t, hasLatency, "no latency should be derived")
+}
+
+func TestCreateMetadataSpanFromValues_DeleteOpNotEnriched(t *testing.T) {
+	tp := &captureTracerProvider{}
+
+	values := metadata.Values{
+		"input_tokens":  json.RawMessage(`100`),
+		"output_tokens": json.RawMessage(`50`),
+		"request_model": json.RawMessage(`"gpt-4o"`),
+	}
+	// The span stores the same map that backfills mutate in place, so the
+	// expectation must be an independent copy taken before the call.
+	want := maps.Clone(values)
+
+	ref, err := CreateMetadataSpanFromValues(
+		context.Background(), tp, &meta.SpanReference{},
+		"test.location", "test", nil,
+		extractors.KindInngestAI, enums.MetadataOpcodeDelete, values, enums.MetadataScopeStep,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+
+	require.Len(t, tp.spans, 1)
+	got, ok := tp.spans[0].Attributes.Get(meta.Attrs.Metadata.Key()).(*metadata.Values)
+	require.True(t, ok, "expected metadata values attribute on the span")
+	require.Equal(t, want, *got, "delete op values must not be enriched")
 }
 
 func TestCreateMetadataSpanFromValues_CumulativeLimitExceeded(t *testing.T) {

--- a/pkg/util/aigateway/aigateway.go
+++ b/pkg/util/aigateway/aigateway.go
@@ -17,8 +17,8 @@ type ParsedInferenceRequest struct {
 	URL                 string   `json:"url"`
 	Model               string   `json:"model"`
 	Seed                *int     `json:"seed,omitempty"`
-	Temprature          float32  `json:"temperature,omitempty"`
-	TopP                float32  `json:"top_p,omitempty"`
+	Temperature         *float32 `json:"temperature,omitempty"`
+	TopP                *float32 `json:"top_p,omitempty"`
 	MaxTokens           int      `json:"max_tokens,omitempty"`
 	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
 	StopSequences       []string `json:"stop,omitempty"`
@@ -34,7 +34,7 @@ type ParsedInferenceRequest struct {
 
 // ParsedInferenceResponse represents the parsed output for a given inference request.
 type ParsedInferenceResponse struct {
-	ID         string            `json:"id"`
+	ID string `json:"id"`
 	// Model is the model that actually served the request, as reported by the
 	// provider. This may differ from the requested model (e.g. a dated snapshot).
 	Model      string            `json:"model,omitempty"`
@@ -93,6 +93,14 @@ func ParseInput(req Request) (ParsedInferenceRequest, error) {
 			return ParsedInferenceRequest{}, err
 		}
 
+		// rf uses non-pointer floats, so params where an explicit zero is
+		// meaningful (e.g. temperature 0) must be re-parsed as pointers.
+		var floatParams struct {
+			Temperature *float32 `json:"temperature"`
+			TopP        *float32 `json:"top_p"`
+		}
+		_ = json.Unmarshal(req.Body, &floatParams)
+
 		// Parse the tool choice.
 		var toolChoice string
 		switch t := rf.ToolChoice.(type) {
@@ -130,8 +138,8 @@ func ParseInput(req Request) (ParsedInferenceRequest, error) {
 			URL:                 req.URL,
 			Model:               rf.Model,
 			Seed:                rf.Seed,
-			Temprature:          rf.Temperature,
-			TopP:                rf.TopP,
+			Temperature:         floatParams.Temperature,
+			TopP:                floatParams.TopP,
 			MaxTokens:           rf.MaxTokens,
 			MaxCompletionTokens: rf.MaxCompletionTokens,
 			StopSequences:       rf.Stop,

--- a/pkg/util/aigateway/aigateway.go
+++ b/pkg/util/aigateway/aigateway.go
@@ -17,8 +17,8 @@ type ParsedInferenceRequest struct {
 	URL                 string   `json:"url"`
 	Model               string   `json:"model"`
 	Seed                *int     `json:"seed,omitempty"`
-	Temperature         *float32 `json:"temperature,omitempty"`
-	TopP                *float32 `json:"top_p,omitempty"`
+	Temperature         *float64 `json:"temperature,omitempty"`
+	TopP                *float64 `json:"top_p,omitempty"`
 	MaxTokens           int      `json:"max_tokens,omitempty"`
 	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
 	StopSequences       []string `json:"stop,omitempty"`
@@ -93,11 +93,11 @@ func ParseInput(req Request) (ParsedInferenceRequest, error) {
 			return ParsedInferenceRequest{}, err
 		}
 
-		// rf uses non-pointer floats, so params where an explicit zero is
+		// rf uses non-pointer float32s, so params where an explicit zero is
 		// meaningful (e.g. temperature 0) must be re-parsed as pointers.
 		var floatParams struct {
-			Temperature *float32 `json:"temperature"`
-			TopP        *float32 `json:"top_p"`
+			Temperature *float64 `json:"temperature"`
+			TopP        *float64 `json:"top_p"`
 		}
 		_ = json.Unmarshal(req.Body, &floatParams)
 


### PR DESCRIPTION
## Description

Fills derivable gaps in `inngest.ai` metadata (`total_tokens`, `estimated_cost`)
at the metadata-span choke point (`CreateMetadataSpanFromValues`), covering every emission path: SDK generator opcodes, sync checkpoints, and the public
run-metadata API. Caller-supplied values are never overwritten; delete ops are
untouched. The three AI extractors now share the same `AIMetadata.Enrich` logic.

This fixes an issue where the following function's AI calls do *not* produce equivalent metadata:

```ts
import { inngest } from "../client";
import { Agent, run } from "@openai/agents";

export const helloWorld = inngest.createFunction(
	{ id: "hello-world", triggers: [{ event: "test/hello.world" }] },
	async ({ step }) => {
		const agent = new Agent({
			name: "Bubba",
			instructions: "You are a helpful assistant.",
		});

		const haikuTopic = await step.run("get-topic", async () => {
			const response = await run(
				agent,
				"Choose a single, specific programming related topic, such as Inngest, TypeScript, or Go.",
			);
			return response.finalOutput;
		});

		const result = await step.ai.wrap("get-agent-output", async () => {
			const response = await run(
				agent,
				`Write a haiku about this topic: ${haikuTopic}`,
			);
			return response.finalOutput;
		});

		const rewrittenResult = await step.ai.infer("revise-agent-output", {
			model: step.ai.models.openai({ model: "gpt-4o" }),
			body: {
				messages: [
					{
						role: "assistant",
						content: `Make any highly artistic, poetic, and high brow changes to this haiku while keeping the overall message: ${result}`,
					},
				],
			},
		});

		return {
			topic: haikuTopic,
			original: result,
			rewritten: rewrittenResult.choices[0].message.content,
		};
	},
);
```

Also extracts more from AI gateway calls — response ID, finish reasons, request params (`temperature`, `top_p`, `max_tokens`, `seed`), and a normalized `provider` (`openai`, `anthropic`, `gcp.gemini`, `aws.bedrock`) — and fixes the `Temprature` typo (Go identifier only).



## Release Note

AI step metadata now includes derived `total_tokens` and `estimated_cost` when
omitted by the SDK, plus richer AI gateway metadata: response ID, finish
reasons, request parameters, and a normalized provider.

## Migration note

AI gateway `provider` values changed from the raw request format (e.g.
`openai-chat`) to normalized identifiers (e.g. `openai`), and
`total_tokens`/`estimated_cost are now omitted instead of `0` when no tokens
are reported.