### PR TITLE
feat(metadata): Augment incoming ai metadata with cost estimates

### DIFF
--- a/pkg/tracing/metadata.go
+++ b/pkg/tracing/metadata.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
 )
 
 type MetadataSpanAttrOpts func(cfg *MetadataSpanConfig)
@@ -29,6 +30,16 @@ func CreateMetadataSpan(ctx context.Context, tracerProvider TracerProvider, pare
 // CreateMetadataSpanFromValues creates a metadata span from pre-serialized values,
 // avoiding redundant serialization when the caller has already called Serialize.
 func CreateMetadataSpanFromValues(ctx context.Context, tracerProvider TracerProvider, parent *meta.SpanReference, location, pkgName string, stateMetadata *statev2.Metadata, kind metadata.Kind, op metadata.Opcode, values metadata.Values, scope metadata.Scope, opts ...MetadataSpanAttrOpts) (*meta.SpanReference, error) {
+	// Every metadata span, regardless of caller, passes through here — so
+	// this is the single chokepoint to backfill EstimatedCost for
+	// "inngest.ai" metadata that arrived without one (e.g. submitted
+	// directly via inngest.metadata.update or the AddRunMetadata API,
+	// bypassing the AIMetadata-producing extractors). A no-op when
+	// EstimatedCost is already set.
+	if kind == extractors.KindInngestAI {
+		extractors.BackfillEstimatedCostInValues(values)
+	}
+
 	spanSize := values.Size()
 
 	// Per-span size limit

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -109,25 +109,18 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 		latencyMs = &serverProcessingMs
 	}
 
-	// prefer the response model (the model that actually served the request)
-	// for cost estimation, falling back to the requested model.
-	costModel := parsedOutput.Model
-	if costModel == "" {
-		costModel = parsedInput.Model
-	}
-
 	aiMd := &AIMetadata{
 		RequestModel:  parsedInput.Model,
 		ResponseModel: parsedOutput.Model,
 		Provider:      req.Format,
 		OperationName: "",
 
-		InputTokens:   inputTokens,
-		OutputTokens:  outputTokens,
-		TotalTokens:   &totalTokens,
-		EstimatedCost: EstimateCost(costModel, inputTokens, outputTokens),
-		LatencyMs:     latencyMs,
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  &totalTokens,
+		LatencyMs:    latencyMs,
 	}
+	backfillEstimatedCost(aiMd)
 
 	return []metadata.Structured{
 		aiMd,
@@ -249,13 +242,6 @@ func ExtractAIOutputMetadata(output []byte, stepDurationMs int64) ([]metadata.St
 		latencyMs = &stepDurationMs
 	}
 
-	// prefer the response model (the model that actually served the request)
-	// for cost estimation, falling back to the requested model.
-	costModel := responseModel
-	if costModel == "" {
-		costModel = requestModel
-	}
-
 	aiMd := &AIMetadata{
 		InputTokens:   inputTokens,
 		OutputTokens:  outputTokens,
@@ -264,8 +250,8 @@ func ExtractAIOutputMetadata(output []byte, stepDurationMs int64) ([]metadata.St
 		ResponseModel: responseModel,
 		Provider:      "vercel-ai",
 		LatencyMs:     latencyMs,
-		EstimatedCost: EstimateCost(costModel, inputTokens, outputTokens),
 	}
+	backfillEstimatedCost(aiMd)
 
 	return []metadata.Structured{aiMd}, nil
 }
@@ -335,6 +321,67 @@ var modelPricing = map[string]ModelPricing{
 	"command-r":      {0.50, 1.50},
 	"command":        {1.00, 2.00},
 	"command-light":  {0.30, 0.60},
+}
+
+// estimatedCostForTokens prefers the response model (the model that actually
+// served the request) for cost estimation, falling back to the requested
+// model.
+func estimatedCostForTokens(responseModel, requestModel string, inputTokens, outputTokens int64) *float64 {
+	costModel := responseModel
+	if costModel == "" {
+		costModel = requestModel
+	}
+	return EstimateCost(costModel, inputTokens, outputTokens)
+}
+
+// backfillEstimatedCost sets md.EstimatedCost from model + token usage only
+// when it isn't already populated — so an extractor that already supplies
+// its own EstimatedCost (e.g. a provider-reported cost) is never
+// overwritten. Every AIMetadata construction site should call this instead
+// of computing cost inline, so the response-model-preferred-over-request-model
+// rule lives in one place.
+func backfillEstimatedCost(md *AIMetadata) {
+	if md.EstimatedCost != nil {
+		return
+	}
+	md.EstimatedCost = estimatedCostForTokens(md.ResponseModel, md.RequestModel, md.InputTokens, md.OutputTokens)
+}
+
+// BackfillEstimatedCostInValues fills an "estimated_cost" entry into raw
+// "inngest.ai" metadata values when one isn't already present. Unlike
+// backfillEstimatedCost, this operates on untyped metadata.Values — the shape
+// AI metadata takes when it's submitted directly by an SDK or API caller
+// (e.g. inngest.metadata.update or the AddRunMetadata API) rather than
+// produced by the extractor functions above, so it never passes through an
+// AIMetadata struct at all.
+func BackfillEstimatedCostInValues(values metadata.Values) {
+	if values == nil {
+		return
+	}
+
+	if raw, ok := values["estimated_cost"]; ok {
+		var existing *float64
+		if err := json.Unmarshal(raw, &existing); err == nil && existing != nil {
+			return
+		}
+	}
+
+	var inputTokens, outputTokens int64
+	_ = json.Unmarshal(values["input_tokens"], &inputTokens)
+	_ = json.Unmarshal(values["output_tokens"], &outputTokens)
+
+	var responseModel, requestModel string
+	_ = json.Unmarshal(values["response_model"], &responseModel)
+	_ = json.Unmarshal(values["request_model"], &requestModel)
+
+	cost := estimatedCostForTokens(responseModel, requestModel, inputTokens, outputTokens)
+	if cost == nil {
+		return
+	}
+
+	if b, err := json.Marshal(cost); err == nil {
+		values["estimated_cost"] = b
+	}
 }
 
 // EstimateCost calculates the estimated cost in USD for the given model and token counts

--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -338,6 +338,117 @@ func TestExtractAIOutputMetadata_InvalidJSON(t *testing.T) {
 	assert.Nil(t, md, "Invalid JSON should return nil")
 }
 
+func TestBackfillEstimatedCostInValues(t *testing.T) {
+	t.Parallel()
+
+	valuesOf := func(v map[string]any) metadata.Values {
+		values := metadata.Values{}
+		for k, val := range v {
+			b, err := json.Marshal(val)
+			require.NoError(t, err)
+			values[k] = b
+		}
+		return values
+	}
+
+	costOf := func(t *testing.T, values metadata.Values) *float64 {
+		raw, ok := values["estimated_cost"]
+		if !ok {
+			return nil
+		}
+		var cost *float64
+		require.NoError(t, json.Unmarshal(raw, &cost))
+		return cost
+	}
+
+	cases := []struct {
+		name      string
+		values    map[string]any
+		wantCost  bool
+		wantExact *float64
+	}{
+		{
+			name: "backfills from response model when cost absent",
+			values: map[string]any{
+				"input_tokens":   int64(1_000_000),
+				"output_tokens":  int64(1_000_000),
+				"request_model":  "gpt-4o-request-snapshot",
+				"response_model": "gpt-4o",
+			},
+			wantCost:  true,
+			wantExact: util.ToPtr(12.5),
+		},
+		{
+			name: "falls back to request model when response model absent",
+			values: map[string]any{
+				"input_tokens":  int64(1_000_000),
+				"output_tokens": int64(1_000_000),
+				"request_model": "gpt-4o",
+			},
+			wantCost:  true,
+			wantExact: util.ToPtr(12.5),
+		},
+		{
+			name: "leaves an existing non-null cost untouched",
+			values: map[string]any{
+				"input_tokens":   int64(1_000_000),
+				"output_tokens":  int64(1_000_000),
+				"request_model":  "gpt-4o",
+				"estimated_cost": 42.0,
+			},
+			wantCost:  true,
+			wantExact: util.ToPtr(42.0),
+		},
+		{
+			name: "overwrites an explicit null cost",
+			values: map[string]any{
+				"input_tokens":   int64(1_000_000),
+				"output_tokens":  int64(1_000_000),
+				"request_model":  "gpt-4o",
+				"estimated_cost": nil,
+			},
+			wantCost:  true,
+			wantExact: util.ToPtr(12.5),
+		},
+		{
+			name: "no model means no cost",
+			values: map[string]any{
+				"input_tokens":  int64(500),
+				"output_tokens": int64(500),
+			},
+			wantCost: false,
+		},
+		{
+			name: "unpriced model means no cost",
+			values: map[string]any{
+				"input_tokens":  int64(500),
+				"output_tokens": int64(500),
+				"request_model": "some-unlisted-finetune",
+			},
+			wantCost: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			values := valuesOf(tc.values)
+			BackfillEstimatedCostInValues(values)
+
+			cost := costOf(t, values)
+			if !tc.wantCost {
+				assert.Nil(t, cost)
+				return
+			}
+			require.NotNil(t, cost)
+			if tc.wantExact != nil {
+				assert.Equal(t, *tc.wantExact, *cost)
+			}
+		})
+	}
+}
+
 func TestExtractAIOutputMetadata_TypicalStepOutput(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/tracing/metadata/extractors/aimetadata.go
+++ b/pkg/tracing/metadata/extractors/aimetadata.go
@@ -41,13 +41,7 @@ func (e *AIMetadataExtractor) extractAIMetadata(span *tracev1.Span) (md AIMetada
 		md.TotalTokens = &totalTokens
 	}
 
-	// prefer the response model (the model that actually served the request)
-	// for cost estimation, falling back to the requested model.
-	costModel := md.ResponseModel
-	if costModel == "" {
-		costModel = md.RequestModel
-	}
-	md.EstimatedCost = EstimateCost(costModel, md.InputTokens, md.OutputTokens)
+	backfillEstimatedCost(&md)
 
 	return md, true
 }


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This extends the EstimateCost functionality to also augment metadata incoming from the API and opcodes

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
