### PR TITLE
feat(dev-server-ui): add function filter to the runs page

### DIFF
--- a/ui/apps/dev-server-ui/src/coreapi.ts
+++ b/ui/apps/dev-server-ui/src/coreapi.ts
@@ -275,7 +275,9 @@ export const RERUN_FROM_STEP = gql`
 export const GET_RUNS = gql`
   query GetRuns(
     $appIDs: [UUID!]
+    $functionIDs: [UUID!]
     $startTime: Time!
+    $endTime: Time = null
     $status: [FunctionRunStatus!]
     $timeField: RunsV2OrderByField!
     $functionRunCursor: String = null
@@ -286,7 +288,9 @@ export const GET_RUNS = gql`
     runs(
       filter: {
         appIDs: $appIDs
+        functionIDs: $functionIDs
         from: $startTime
+        until: $endTime
         status: $status
         timeField: $timeField
         query: $celQuery
@@ -337,17 +341,25 @@ export const GET_RUNS = gql`
 
 export const COUNT_RUNS = gql`
   query CountRuns(
+    $appIDs: [UUID!]
+    $functionIDs: [UUID!]
     $startTime: Time!
+    $endTime: Time = null
     $status: [FunctionRunStatus!]
     $timeField: RunsV2OrderByField!
+    $celQuery: String = null
     $preview: Boolean = false
     $isDeferred: Boolean = null
   ) {
     runs(
       filter: {
+        appIDs: $appIDs
+        functionIDs: $functionIDs
         from: $startTime
+        until: $endTime
         status: $status
         timeField: $timeField
+        query: $celQuery
         isDeferred: $isDeferred
       }
       orderBy: [{ field: $timeField, direction: DESC }]

--- a/ui/apps/dev-server-ui/src/routes/_dashboard/runs/index.tsx
+++ b/ui/apps/dev-server-ui/src/routes/_dashboard/runs/index.tsx
@@ -4,6 +4,7 @@ import { client } from '@/store/baseApi';
 import { useInfoQuery } from '@/store/devApi';
 import {
   useGetAppsQuery,
+  useGetFunctionsQuery,
   GetRunsQuery,
   GetRunsDocument,
   CountRunsQuery,
@@ -61,6 +62,7 @@ function RunsComponent() {
   const [preview, setPreview] = useState(false);
 
   const [filterApp] = useStringArraySearchParam('filterApp');
+  const [filterFunction] = useStringArraySearchParam('filterFunction');
   const [totalCount, setTotalCount] = useState<number>();
   const [filteredStatus] = useValidatedArraySearchParam(
     'filterStatus',
@@ -77,6 +79,9 @@ function RunsComponent() {
   const [search] = useSearchParam('search');
   const calculatedStartTime = useCalculatedStartTime({ lastDays, startTime });
   const appsRes = useGetAppsQuery();
+  const functionsRes = useGetFunctionsQuery(undefined, {
+    refetchOnMountOrArgChange: true,
+  });
 
   useEffect(() => {
     if (pollingFlagReady && pollingDisabled) {
@@ -92,6 +97,7 @@ function RunsComponent() {
     async ({ pageParam }: { pageParam: string | null }) => {
       const data: GetRunsQuery = await client.request(GetRunsDocument, {
         appIDs: filterApp,
+        functionIDs: filterFunction,
         functionRunCursor: pageParam,
         startTime: calculatedStartTime,
         endTime: endTime,
@@ -122,8 +128,10 @@ function RunsComponent() {
     },
     [
       filterApp,
+      filterFunction,
       filteredStatus,
       calculatedStartTime,
+      endTime,
       timeField,
       search,
       preview,
@@ -137,6 +145,7 @@ function RunsComponent() {
         'runs',
         {
           filterApp,
+          filterFunction,
           filteredStatus,
           calculatedStartTime,
           endTime,
@@ -165,6 +174,8 @@ function RunsComponent() {
     setTotalCount(undefined);
     (async () => {
       const data: CountRunsQuery = await client.request(CountRunsDocument, {
+        appIDs: filterApp,
+        functionIDs: filterFunction,
         startTime: calculatedStartTime,
         endTime,
         status: filteredStatus,
@@ -176,6 +187,8 @@ function RunsComponent() {
       setTotalCount(data.runs.totalCount);
     })();
   }, [
+    filterApp,
+    filterFunction,
     calculatedStartTime,
     endTime,
     filteredStatus,
@@ -209,6 +222,26 @@ function RunsComponent() {
     return out;
   }, [data?.pages]);
 
+  // Options for the function filter dropdown. Function names are only unique
+  // per app, so disambiguate duplicates with the app name.
+  const functionEntities = useMemo(() => {
+    const fns = functionsRes.data?.functions;
+    if (!fns) {
+      return [];
+    }
+    const nameCounts = new Map<string, number>();
+    for (const fn of fns) {
+      nameCounts.set(fn.name, (nameCounts.get(fn.name) ?? 0) + 1);
+    }
+    return fns.map((fn) => ({
+      id: fn.id,
+      name:
+        (nameCounts.get(fn.name) ?? 0) > 1
+          ? `${fn.name} (${fn.app.name})`
+          : fn.name,
+    }));
+  }, [functionsRes.data?.functions]);
+
   const getTrigger = useGetTrigger();
 
   const onScrollToTop = useCallback(() => {
@@ -240,6 +273,7 @@ function RunsComponent() {
       />
       <RunsPage
         apps={appsRes.data?.apps || []}
+        functions={functionEntities}
         data={runs ?? []}
         defaultVisibleColumns={[
           'status',

--- a/ui/apps/dev-server-ui/src/store/generated-types.ts
+++ b/ui/apps/dev-server-ui/src/store/generated-types.ts
@@ -1330,7 +1330,9 @@ export type RerunFromStepMutation = { __typename?: 'Mutation'; rerun: any };
 
 export type GetRunsQueryVariables = Exact<{
   appIDs: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
+  functionIDs: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
   startTime: Scalars['Time'];
+  endTime?: InputMaybe<Scalars['Time']>;
   status: InputMaybe<Array<FunctionRunStatus> | FunctionRunStatus>;
   timeField: RunsV2OrderByField;
   functionRunCursor?: InputMaybe<Scalars['String']>;
@@ -1377,9 +1379,13 @@ export type GetRunsQuery = {
 };
 
 export type CountRunsQueryVariables = Exact<{
+  appIDs: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
+  functionIDs: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
   startTime: Scalars['Time'];
+  endTime?: InputMaybe<Scalars['Time']>;
   status: InputMaybe<Array<FunctionRunStatus> | FunctionRunStatus>;
   timeField: RunsV2OrderByField;
+  celQuery?: InputMaybe<Scalars['String']>;
   preview?: InputMaybe<Scalars['Boolean']>;
   isDeferred?: InputMaybe<Scalars['Boolean']>;
 }>;

--- a/ui/apps/dev-server-ui/src/store/generated.ts
+++ b/ui/apps/dev-server-ui/src/store/generated.ts
@@ -1166,7 +1166,9 @@ export type RerunFromStepMutation = { __typename?: 'Mutation', rerun: any };
 
 export type GetRunsQueryVariables = Exact<{
   appIDs: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
+  functionIDs: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
   startTime: Scalars['Time'];
+  endTime?: InputMaybe<Scalars['Time']>;
   status: InputMaybe<Array<FunctionRunStatus> | FunctionRunStatus>;
   timeField: RunsV2OrderByField;
   functionRunCursor?: InputMaybe<Scalars['String']>;
@@ -1179,9 +1181,13 @@ export type GetRunsQueryVariables = Exact<{
 export type GetRunsQuery = { __typename?: 'Query', runs: { __typename?: 'RunsV2Connection', edges: Array<{ __typename?: 'FunctionRunV2Edge', node: { __typename?: 'FunctionRunV2', cronSchedule: string | null, eventName: string | null, id: any, isBatch: boolean, queuedAt: any, endedAt: any | null, startedAt: any | null, status: FunctionRunStatus, hasAI: boolean, isDeferred: boolean, app: { __typename?: 'App', externalID: string, name: string }, function: { __typename?: 'Function', name: string, slug: string }, deferredFrom: Array<{ __typename?: 'RunDeferredFrom', runID: any, function: { __typename?: 'Function', name: string, slug: string } }> } }>, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null } } };
 
 export type CountRunsQueryVariables = Exact<{
+  appIDs: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
+  functionIDs: InputMaybe<Array<Scalars['UUID']> | Scalars['UUID']>;
   startTime: Scalars['Time'];
+  endTime?: InputMaybe<Scalars['Time']>;
   status: InputMaybe<Array<FunctionRunStatus> | FunctionRunStatus>;
   timeField: RunsV2OrderByField;
+  celQuery?: InputMaybe<Scalars['String']>;
   preview?: InputMaybe<Scalars['Boolean']>;
   isDeferred?: InputMaybe<Scalars['Boolean']>;
 }>;
@@ -1612,9 +1618,9 @@ export const RerunFromStepDocument = `
 }
     `;
 export const GetRunsDocument = `
-    query GetRuns($appIDs: [UUID!], $startTime: Time!, $status: [FunctionRunStatus!], $timeField: RunsV2OrderByField!, $functionRunCursor: String = null, $celQuery: String = null, $preview: Boolean = false, $isDeferred: Boolean = null) {
+    query GetRuns($appIDs: [UUID!], $functionIDs: [UUID!], $startTime: Time!, $endTime: Time = null, $status: [FunctionRunStatus!], $timeField: RunsV2OrderByField!, $functionRunCursor: String = null, $celQuery: String = null, $preview: Boolean = false, $isDeferred: Boolean = null) {
   runs(
-    filter: {appIDs: $appIDs, from: $startTime, status: $status, timeField: $timeField, query: $celQuery, isDeferred: $isDeferred}
+    filter: {appIDs: $appIDs, functionIDs: $functionIDs, from: $startTime, until: $endTime, status: $status, timeField: $timeField, query: $celQuery, isDeferred: $isDeferred}
     orderBy: [{field: $timeField, direction: DESC}]
     after: $functionRunCursor
     preview: $preview
@@ -1658,9 +1664,9 @@ export const GetRunsDocument = `
 }
     `;
 export const CountRunsDocument = `
-    query CountRuns($startTime: Time!, $status: [FunctionRunStatus!], $timeField: RunsV2OrderByField!, $preview: Boolean = false, $isDeferred: Boolean = null) {
+    query CountRuns($appIDs: [UUID!], $functionIDs: [UUID!], $startTime: Time!, $endTime: Time = null, $status: [FunctionRunStatus!], $timeField: RunsV2OrderByField!, $celQuery: String = null, $preview: Boolean = false, $isDeferred: Boolean = null) {
   runs(
-    filter: {from: $startTime, status: $status, timeField: $timeField, isDeferred: $isDeferred}
+    filter: {appIDs: $appIDs, functionIDs: $functionIDs, from: $startTime, until: $endTime, status: $status, timeField: $timeField, query: $celQuery, isDeferred: $isDeferred}
     orderBy: [{field: $timeField, direction: DESC}]
     preview: $preview
   ) {

--- a/ui/packages/components/src/Filter/EntityFilter.tsx
+++ b/ui/packages/components/src/Filter/EntityFilter.tsx
@@ -24,7 +24,11 @@ export default function EntityFilter({
   const selectedValues = entities.filter((entity) =>
     temporarySelectedValues.some((id) => id === entity.id)
   );
-  const areAllEntitiesSelected = temporarySelectedValues.length === entities.length;
+  // Compare by membership, not length: selected IDs can be absent from
+  // entities (e.g. a URL filter referencing a since-archived function), and a
+  // length comparison would misreport those selections as "All".
+  const areAllEntitiesSelected =
+    entities.length > 0 && entities.every((entity) => temporarySelectedValues.includes(entity.id));
 
   const filteredOptions =
     query === ''
@@ -75,7 +79,9 @@ export default function EntityFilter({
       <SelectWithSearch.Button isLabelVisible className={className} ref={comboboxRef} size="small">
         <div className="min-w-7 max-w-24 truncate text-nowrap text-left">
           {temporarySelectedValues.length === 1 && !areAllEntitiesSelected && (
-            <span>{selectedValues[0]?.name}</span>
+            // The selected ID may not resolve to an entity (stale URL value or
+            // entities still loading), so fall back to a count label.
+            <span>{selectedValues[0]?.name ?? `1 ${type}`}</span>
           )}
           {temporarySelectedValues.length > 1 && !areAllEntitiesSelected && (
             <span>


### PR DESCRIPTION
## Description

Adds a searchable function filter dropdown to the dev server's `/runs` page, alongside the existing app filter, so runs for specific functions can be inspected like in the cloud dashboard.

The shared `RunsPage` component already implemented the filter UI (`EntityFilter type="function"`, writing the `filterFunction` URL param), and the dev server GraphQL API already supported `RunsFilterV2.functionIDs` end-to-end — this PR is the first caller to wire the two together:

- `GetRuns`/`CountRuns` declare `$functionIDs` and pass it in the runs filter (plus regenerated codegen output).
- The `/runs` route reads `filterFunction` and threads it into both queries' variables, cache keys, and dependency arrays; dropdown options come from `GetFunctions`, with duplicate function names disambiguated by app name.
- Fixes latent bugs in the shared `EntityFilter` chip, activated by its first consumer: length-based "All" detection could misreport selections referencing since-archived functions as "All", and a single unresolvable selection rendered a blank chip label.
- Declares variables the route was already sending but the documents silently dropped: the run count badge now honors `appIDs`, CEL search, and the end-time bound, and `GetRuns` honors the absolute end date (`until`), matching the cloud dashboard's documents.

Verified end-to-end against a live dev server: registered a Go SDK app with two functions, triggered 5 runs, and asserted 26 filter combinations (function/app/CEL/end-time, list + count) across both the trace and preview query paths.

### Screenshots

The new Function filter in the runs filter bar:

![Runs page with the new Function filter](https://raw.githubusercontent.com/cdavis1324/inngest/assets-runs-function-filter/1-runs-page-with-function-filter.png)

Searchable dropdown with multi-select and Apply/Reset:

![Function dropdown open with search](https://raw.githubusercontent.com/cdavis1324/inngest/assets-runs-function-filter/2-function-dropdown-search.png)

Two functions selected — the list and the run count narrow to the selected functions, and the selection persists in the URL via `filterFunction`:

![Runs filtered to two functions](https://raw.githubusercontent.com/cdavis1324/inngest/assets-runs-function-filter/3-runs-filtered-by-function.png)

## Release note

The dev server's Runs page can now filter runs by function via a searchable dropdown. The runs list and run count also now consistently honor the app filter, CEL search, and end-date range.

## Migration note

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
