### PR TITLE
refactor(queue): add scanner runtime

### DIFF
--- a/pkg/execution/queue/consts.go
+++ b/pkg/execution/queue/consts.go
@@ -55,14 +55,15 @@ const (
 	DefaultQueuePeekMax  int64 = 750
 	AbsoluteQueuePeekMax int64 = 5000
 
-	QueuePeekCurrMultiplier      int64 = 4 // threshold 25%
-	QueuePeekEWMALen             int   = 10
-	QueueLeaseDuration                 = 30 * time.Second
-	QueueItemEarliestPeekTimeTTL       = 7 * 24 * time.Hour
-	RoleLeaseDuration                  = 10 * time.Second
-	RoleLeaseMax                       = 20 * time.Second
-	ShardLeaseDuration                 = 10 * time.Second
-	ShardLeaseMax                      = 20 * time.Second
+	QueuePeekCurrMultiplier        int64 = 4 // threshold 25%
+	QueuePeekEWMALen               int   = 10
+	QueueLeaseDuration                   = 30 * time.Second
+	QueueContinuationResultTimeout       = 10 * time.Minute
+	QueueItemEarliestPeekTimeTTL         = 7 * 24 * time.Hour
+	RoleLeaseDuration                    = 10 * time.Second
+	RoleLeaseMax                         = 20 * time.Second
+	ShardLeaseDuration                   = 10 * time.Second
+	ShardLeaseMax                        = 20 * time.Second
 
 	PriorityMax     uint = 0
 	PriorityDefault uint = 5

--- a/pkg/execution/queue/continuation.go
+++ b/pkg/execution/queue/continuation.go
@@ -84,17 +84,22 @@ func (q *queueProcessor) removeContinue(ctx context.Context, p *QueuePartition, 
 }
 
 func (q *queueProcessor) watchDispatchedPartitionItem(ctx context.Context, dispatched DispatchedItem, p *QueuePartition, continuationCount uint) {
-	if dispatched == nil || p == nil {
+	if !q.runMode.Continuations || dispatched == nil || p == nil {
 		return
 	}
 
 	partition := *p
 	go func() {
+		timeout := q.Clock().NewTimer(QueueContinuationResultTimeout)
+		defer timeout.Stop()
+
 		select {
 		case result := <-dispatched.Done():
 			if result.Err == nil && result.ScheduledImmediateJob {
 				q.addContinue(ctx, &partition, continuationCount+1)
 			}
+		case <-timeout.Chan():
+			return
 		case <-ctx.Done():
 			return
 		}

--- a/pkg/execution/queue/continuation.go
+++ b/pkg/execution/queue/continuation.go
@@ -83,6 +83,24 @@ func (q *queueProcessor) removeContinue(ctx context.Context, p *QueuePartition, 
 	}
 }
 
+func (q *queueProcessor) watchDispatchedPartitionItem(ctx context.Context, dispatched DispatchedItem, p *QueuePartition, continuationCount uint) {
+	if dispatched == nil || p == nil {
+		return
+	}
+
+	partition := *p
+	go func() {
+		select {
+		case result := <-dispatched.Done():
+			if result.Err == nil && result.ScheduledImmediateJob {
+				q.addContinue(ctx, &partition, continuationCount+1)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}()
+}
+
 func (q *queueProcessor) scanContinuations(ctx context.Context, dispatch DispatchFunc) error {
 	if !q.runMode.Continuations {
 		// continuations are not enabled.

--- a/pkg/execution/queue/continuation_test.go
+++ b/pkg/execution/queue/continuation_test.go
@@ -1,0 +1,72 @@
+package queue
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWatchDispatchedPartitionItemAddsContinuation(t *testing.T) {
+	ctx := context.Background()
+	fnID := uuid.New()
+	q := &queueProcessor{
+		QueueOptions:  NewQueueOptions(),
+		continues:     map[string]continuation{},
+		continuesLock: &sync.Mutex{},
+	}
+	q.runMode.Continuations = true
+
+	partition := &QueuePartition{
+		ID:         fnID.String(),
+		FunctionID: &fnID,
+		AccountID:  uuid.New(),
+	}
+	handle := newDispatchedItemHandle()
+
+	q.watchDispatchedPartitionItem(ctx, handle, partition, 1)
+	handle.complete(DispatchedItemResult{ScheduledImmediateJob: true})
+
+	require.Eventually(t, func() bool {
+		q.continuesLock.Lock()
+		defer q.continuesLock.Unlock()
+
+		cont, ok := q.continues[partition.Queue()]
+		return ok && cont.count == 2 && cont.partition.ID == partition.ID
+	}, time.Second, time.Millisecond)
+}
+
+func TestWatchDispatchedPartitionItemSkipsContinuationOnError(t *testing.T) {
+	ctx := context.Background()
+	fnID := uuid.New()
+	q := &queueProcessor{
+		QueueOptions:  NewQueueOptions(),
+		continues:     map[string]continuation{},
+		continuesLock: &sync.Mutex{},
+	}
+	q.runMode.Continuations = true
+
+	partition := &QueuePartition{
+		ID:         fnID.String(),
+		FunctionID: &fnID,
+		AccountID:  uuid.New(),
+	}
+	handle := newDispatchedItemHandle()
+
+	q.watchDispatchedPartitionItem(ctx, handle, partition, 1)
+	handle.complete(DispatchedItemResult{
+		ScheduledImmediateJob: true,
+		Err:                   context.Canceled,
+	})
+
+	require.Never(t, func() bool {
+		q.continuesLock.Lock()
+		defer q.continuesLock.Unlock()
+
+		_, ok := q.continues[partition.Queue()]
+		return ok
+	}, 50*time.Millisecond, time.Millisecond)
+}

--- a/pkg/execution/queue/dispatch.go
+++ b/pkg/execution/queue/dispatch.go
@@ -1,0 +1,43 @@
+package queue
+
+import "sync"
+
+type DispatchedItem interface {
+	Done() <-chan DispatchedItemResult
+}
+
+type DispatchedItemResult struct {
+	ScheduledImmediateJob bool
+	Err                   error
+}
+
+type dispatchedItemHandle struct {
+	once sync.Once
+	done chan DispatchedItemResult
+}
+
+func newDispatchedItemHandle() *dispatchedItemHandle {
+	return &dispatchedItemHandle{
+		// Buffered so worker completion never blocks if no scanner is waiting.
+		done: make(chan DispatchedItemResult, 1),
+	}
+}
+
+// NewCompletedDispatchedItem returns a dispatched item that has already completed.
+// This is useful for scanner implementations or tests that synchronously process dispatch.
+func NewCompletedDispatchedItem(result DispatchedItemResult) DispatchedItem {
+	handle := newDispatchedItemHandle()
+	handle.complete(result)
+	return handle
+}
+
+func (h *dispatchedItemHandle) Done() <-chan DispatchedItemResult {
+	return h.done
+}
+
+func (h *dispatchedItemHandle) complete(result DispatchedItemResult) {
+	h.once.Do(func() {
+		h.done <- result
+		close(h.done)
+	})
+}

--- a/pkg/execution/queue/errors.go
+++ b/pkg/execution/queue/errors.go
@@ -110,6 +110,7 @@ var (
 var (
 	ErrProcessNoCapacity               = fmt.Errorf("no capacity")
 	ErrProcessMissingDispatch          = fmt.Errorf("missing dispatch function")
+	ErrQueueScannerMissingLeaser       = fmt.Errorf("missing queue scanner leaser")
 	ErrProcessStopIterator             = fmt.Errorf("stop iterator")
 	ErrProcessNoUserConstraintCapacity = fmt.Errorf("no user constraint capacity: %w", ErrProcessStopIterator)
 )

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -122,7 +122,7 @@ type QueueProcessor interface {
 		ctx context.Context,
 		i ProcessItem,
 		f RunFunc,
-	) error
+	) (ProcessItemResult, error)
 	ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool, dispatch DispatchFunc) error
 }
 

--- a/pkg/execution/queue/lease_item.go
+++ b/pkg/execution/queue/lease_item.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
@@ -16,12 +17,19 @@ import (
 
 func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, dispatch DispatchFunc) (LeaseItemResult, error) {
 	item := req.Item
-	partition := req.Partition
-	l := logger.StdlibLogger(ctx).With("partition", partition, "item", item)
+	accountID := item.Data.Identifier.AccountID
+	envID := item.Data.Identifier.WorkspaceID
+	fnID := item.Data.Identifier.WorkflowID
+	if fnID == uuid.Nil {
+		fnID = item.FunctionID
+	}
+	l := logger.StdlibLogger(ctx).With("item", item)
 
 	ctx, span := q.Options().ConditionalTracer.NewSpan(ctx, "queue.LeaseItem", TraceScopeFromQueueItem(*item, q.Shard().Name()))
 	defer span.End()
-	span.SetAttributes(attribute.String("partition_id", partition.ID))
+	span.SetAttributes(attribute.String("account_id", accountID.String()))
+	span.SetAttributes(attribute.String("env_id", envID.String()))
+	span.SetAttributes(attribute.String("fn_id", fnID.String()))
 	span.SetAttributes(attribute.String("item_kind", item.Data.Kind))
 	span.SetAttributes(attribute.String("run_id", item.Data.Identifier.RunID.String()))
 	span.SetAttributes(attribute.String("item_id", item.ID))
@@ -209,11 +217,11 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 	//
 	// Anyway, here we set the first peek item to the item's start time if there was a
 	// peek since the job was added.
-	if item.EarliestPeekTime == 0 && partition.Last > 0 && partition.Last > item.AtMS {
+	if item.EarliestPeekTime == 0 && req.EarliestPeekTimeFallbackMS > 0 {
 		// Fudge the earliest peek time because we know this wasn't peeked and so
 		// the peek time wasn't set;  but, as we were still processing jobs after
 		// the job was added this item was concurrency-limited.
-		item.EarliestPeekTime = item.AtMS
+		item.EarliestPeekTime = req.EarliestPeekTimeFallbackMS
 	}
 
 	// We may return a keyError, which masks the actual error underneath.  If so,
@@ -285,20 +293,20 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 			status = "system_concurrency_limit"
 		case errors.Is(cause, ErrPartitionConcurrencyLimit):
 			status = "partition_concurrency_limit"
-			if partition.FunctionID != nil {
-				q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *partition.FunctionID)
+			if fnID != uuid.Nil {
+				q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), fnID)
 			}
 		case errors.Is(cause, ErrAccountConcurrencyLimit):
 			status = "account_concurrency_limit"
 			// For backwards compatibility, we report on the function level as well.
-			if partition.FunctionID != nil {
-				q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *partition.FunctionID)
+			if fnID != uuid.Nil {
+				q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), fnID)
 			}
 
 			q.Options().lifecycles.OnAccountConcurrencyLimitReached(
 				context.WithoutCancel(ctx),
-				partition.AccountID,
-				partition.EnvID,
+				accountID,
+				itemEnvIDPtr(envID),
 			)
 		}
 
@@ -329,8 +337,8 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 		return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited, RetryAfter: limitedRetryAfter}, fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
 	case errors.Is(cause, ErrConcurrencyLimitCustomKey):
 		// For backwards compatibility, we report on the function level as well.
-		if partition.FunctionID != nil {
-			q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), *partition.FunctionID)
+		if fnID != uuid.Nil {
+			q.Options().lifecycles.OnFnConcurrencyLimitReached(context.WithoutCancel(ctx), fnID)
 		}
 
 		// TODO: Report on key that was hit (this must have been empty previously)
@@ -406,10 +414,10 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 		PkgName: pkgName,
 		Tags:    map[string]any{"status": "success", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
 	})
-	err = dispatch(ctx, ProcessItem{
-		P:    *partition,
-		I:    *item,
-		PCtr: req.PartitionContinueCtr,
+	_, err = dispatch(ctx, ProcessItem{
+		I:             *item,
+		Priority:      req.Priority,
+		ContinueCount: req.ContinueCount,
 
 		CapacityLease:       constraintRes.CapacityLease,
 		ConditionalTraceCtx: context.WithoutCancel(ctx),
@@ -422,4 +430,11 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 	commitSemaphoreAcquire = true
 
 	return result, nil
+}
+
+func itemEnvIDPtr(envID uuid.UUID) *uuid.UUID {
+	if envID == uuid.Nil {
+		return nil
+	}
+	return &envID
 }

--- a/pkg/execution/queue/lease_item.go
+++ b/pkg/execution/queue/lease_item.go
@@ -242,6 +242,7 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 	if leaseID != nil {
 		errTags["lease"] = leaseID.String()
 	}
+	limitedRetryAfter := constraintRes.RetryAfter
 
 	switch {
 	case errors.Is(cause, ErrQueueItemThrottled):
@@ -256,7 +257,7 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 				l.ReportError(err, "could not requeue item to backlog after hitting throttle limit",
 					logger.WithErrorReportTags(errTags),
 				)
-				return LeaseItemResult{Status: LeaseItemStatusThrottled}, fmt.Errorf("could not requeue to backlog: %w", err)
+				return LeaseItemResult{Status: LeaseItemStatusThrottled, RetryAfter: limitedRetryAfter}, fmt.Errorf("could not requeue to backlog: %w", err)
 			}
 
 			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
@@ -269,7 +270,7 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 			})
 		}
 
-		return LeaseItemResult{Status: LeaseItemStatusThrottled}, nil
+		return LeaseItemResult{Status: LeaseItemStatusThrottled, RetryAfter: limitedRetryAfter}, nil
 	case errors.Is(cause, ErrPartitionConcurrencyLimit), errors.Is(cause, ErrAccountConcurrencyLimit), errors.Is(cause, ErrSystemConcurrencyLimit):
 		// Since the queue is at capacity on a fn or account level, no
 		// more jobs in this loop should be worked on - so break.
@@ -312,7 +313,7 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 				l.ReportError(err, "could not requeue item to backlog after hitting concurrency limit",
 					logger.WithErrorReportTags(errTags),
 				)
-				return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited}, fmt.Errorf("could not requeue to backlog: %w", err)
+				return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited, RetryAfter: limitedRetryAfter}, fmt.Errorf("could not requeue to backlog: %w", err)
 			}
 
 			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
@@ -325,7 +326,7 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 			})
 		}
 
-		return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited}, fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
+		return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited, RetryAfter: limitedRetryAfter}, fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
 	case errors.Is(cause, ErrConcurrencyLimitCustomKey):
 		// For backwards compatibility, we report on the function level as well.
 		if partition.FunctionID != nil {
@@ -346,7 +347,7 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 				l.ReportError(err, "could not requeue item to backlog after hitting custom concurrency limit",
 					logger.WithErrorReportTags(errTags),
 				)
-				return LeaseItemResult{Status: LeaseItemStatusCustomConcurrencyLimited}, fmt.Errorf("could not requeue to backlog: %w", err)
+				return LeaseItemResult{Status: LeaseItemStatusCustomConcurrencyLimited, RetryAfter: limitedRetryAfter}, fmt.Errorf("could not requeue to backlog: %w", err)
 			}
 
 			metrics.IncrRequeueExistingToBacklogCounter(ctx, metrics.CounterOpt{
@@ -358,7 +359,7 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 				},
 			})
 		}
-		return LeaseItemResult{Status: LeaseItemStatusCustomConcurrencyLimited}, nil
+		return LeaseItemResult{Status: LeaseItemStatusCustomConcurrencyLimited, RetryAfter: limitedRetryAfter}, nil
 	case errors.Is(cause, ErrSemaphoreLimit):
 		// Semaphore capacity exhausted for this specific item (e.g., start job with fn concurrency).
 		// Skip this item and continue scanning; other items without semaphores (step 2, etc.)
@@ -367,7 +368,7 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 			PkgName: pkgName,
 			Tags:    map[string]any{"status": "semaphore_limit", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
 		})
-		return LeaseItemResult{Status: LeaseItemStatusSemaphoreLimited}, nil
+		return LeaseItemResult{Status: LeaseItemStatusSemaphoreLimited, RetryAfter: limitedRetryAfter}, nil
 	case errors.Is(cause, ErrQueueItemNotFound):
 		// This is an okay error.  Move to the next job item.
 		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -734,46 +734,6 @@ type ShadowContinuation struct {
 	Count      uint
 }
 
-type DispatchedItem interface {
-	Done() <-chan DispatchedItemResult
-}
-
-type DispatchedItemResult struct {
-	ScheduledImmediateJob bool
-	Err                   error
-}
-
-type dispatchedItemHandle struct {
-	once sync.Once
-	done chan DispatchedItemResult
-}
-
-func newDispatchedItemHandle() *dispatchedItemHandle {
-	return &dispatchedItemHandle{
-		// Buffered so worker completion never blocks if no scanner is waiting.
-		done: make(chan DispatchedItemResult, 1),
-	}
-}
-
-// NewCompletedDispatchedItem returns a dispatched item that has already completed.
-// This is useful for scanner implementations or tests that synchronously process dispatch.
-func NewCompletedDispatchedItem(result DispatchedItemResult) DispatchedItem {
-	handle := newDispatchedItemHandle()
-	handle.complete(result)
-	return handle
-}
-
-func (h *dispatchedItemHandle) Done() <-chan DispatchedItemResult {
-	return h.done
-}
-
-func (h *dispatchedItemHandle) complete(result DispatchedItemResult) {
-	h.once.Do(func() {
-		h.done <- result
-		close(h.done)
-	})
-}
-
 // ProcessItem references the queue item and scanner-provided metadata to be processed by a worker.
 type ProcessItem struct {
 	I QueueItem

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -734,19 +734,57 @@ type ShadowContinuation struct {
 	Count      uint
 }
 
-// ProcessItem references the queue partition and queue item to be processed by a worker.
-// both items need to be passed to a worker as both items are needed to generate concurrency
-// keys to extend leases and dequeue.
+type DispatchedItem interface {
+	Done() <-chan DispatchedItemResult
+}
+
+type DispatchedItemResult struct {
+	ScheduledImmediateJob bool
+	Err                   error
+}
+
+type dispatchedItemHandle struct {
+	once sync.Once
+	done chan DispatchedItemResult
+}
+
+func newDispatchedItemHandle() *dispatchedItemHandle {
+	return &dispatchedItemHandle{
+		// Buffered so worker completion never blocks if no scanner is waiting.
+		done: make(chan DispatchedItemResult, 1),
+	}
+}
+
+// NewCompletedDispatchedItem returns a dispatched item that has already completed.
+// This is useful for scanner implementations or tests that synchronously process dispatch.
+func NewCompletedDispatchedItem(result DispatchedItemResult) DispatchedItem {
+	handle := newDispatchedItemHandle()
+	handle.complete(result)
+	return handle
+}
+
+func (h *dispatchedItemHandle) Done() <-chan DispatchedItemResult {
+	return h.done
+}
+
+func (h *dispatchedItemHandle) complete(result DispatchedItemResult) {
+	h.once.Do(func() {
+		h.done <- result
+		close(h.done)
+	})
+}
+
+// ProcessItem references the queue item and scanner-provided metadata to be processed by a worker.
 type ProcessItem struct {
-	P QueuePartition
 	I QueueItem
 
-	// PCtr represents the number of times the partition has been continued.
-	PCtr uint
+	Priority      uint
+	ContinueCount uint
 
 	CapacityLease *CapacityLease
 
 	ConditionalTraceCtx context.Context
+	result              *dispatchedItemHandle
 }
 
 type capacityLease struct {

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/constraintapi"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/logger"
@@ -22,22 +23,26 @@ func (q *queueProcessor) ProcessItem(
 	ctx context.Context,
 	i ProcessItem,
 	f RunFunc,
-) error {
+) (ProcessItemResult, error) {
 	shard := q.Shard()
-	accountID, envID, fnID, runID := i.I.Data.Identifier.AccountID, i.I.Data.Identifier.WorkspaceID, i.I.Data.Identifier.WorkflowID, i.I.Data.Identifier.RunID
+	accountID := i.I.Data.Identifier.AccountID
+	envID := i.I.Data.Identifier.WorkspaceID
+	fnID := i.I.Data.Identifier.WorkflowID
+	if fnID == uuid.Nil {
+		fnID = i.I.FunctionID
+	}
+	runID := i.I.Data.Identifier.RunID
 
 	l := logger.StdlibLogger(ctx).With(
 		"item_id", i.I.ID,
 		"account_id", accountID,
 		"env_id", envID,
 		"fn_id", fnID,
-		"partition_id", i.P.ID,
 		"run_id", i.I.Data.Identifier.RunID,
 	)
 
 	ctx, span := q.ConditionalTracer.NewSpan(ctx, "queue.ProcessItem", TraceScopeFromQueueItem(i.I, shard.Name()))
 	defer span.End()
-	span.SetAttributes(attribute.String("partition_id", i.P.ID))
 	span.SetAttributes(attribute.String("item_id", i.I.ID))
 	span.SetAttributes(attribute.String("item_kind", i.I.Data.Kind))
 	span.SetAttributes(attribute.String("run_id", runID.String()))
@@ -49,11 +54,11 @@ func (q *queueProcessor) ProcessItem(
 	}
 
 	qi := i.I
-	p := i.P
-	continuationCtr := i.PCtr
+	continuationCtr := i.ContinueCount
 
 	leaseID := qi.LeaseID
 	leaseMu := sync.RWMutex{}
+	processResult := ProcessItemResult{}
 
 	currentLeaseID := func() *ulid.ULID {
 		leaseMu.RLock()
@@ -119,7 +124,7 @@ func (q *queueProcessor) ProcessItem(
 
 				current := currentLeaseID()
 				if current == nil {
-					l.Error("cannot extend lease since lease ID is nil", "qi", qi, "partition", p)
+					l.Error("cannot extend lease since lease ID is nil", "qi", qi)
 					// Don't extend lease since one doesn't exist
 					errCh <- fmt.Errorf("cannot extend lease since lease ID is nil")
 					return
@@ -136,7 +141,7 @@ func (q *queueProcessor) ProcessItem(
 					// log error if unexpected; the queue item may be removed by a Dequeue() operation
 					// invoked by finalize() (Cancellations, Parallelism)
 					if !errors.Is(ErrQueueItemNotFound, err) {
-						l.Error("error extending lease", "error", err, "qi", qi, "partition", p)
+						l.Error("error extending lease", "error", err, "qi", qi)
 					}
 
 					// always stop processing the queue item if lease cannot be extended
@@ -177,7 +182,7 @@ func (q *queueProcessor) ProcessItem(
 		leaseIssuedAt := capacityLeaseID.issuedAt()
 
 		res, err := q.CapacityManager.Release(context.Background(), &constraintapi.CapacityReleaseRequest{
-			AccountID:      p.AccountID,
+			AccountID:      accountID,
 			IdempotencyKey: qi.ID,
 			LeaseID:        *currentLeaseID,
 			Source: constraintapi.LeaseSource{
@@ -189,9 +194,9 @@ func (q *queueProcessor) ProcessItem(
 		})
 		if err != nil {
 			l.ReportError(err, "failed to release capacity", logger.WithErrorReportTags(map[string]string{
-				"account_id":      p.AccountID.String(),
+				"account_id":      accountID.String(),
 				"lease_id":        currentLeaseID.String(),
-				"function_id":     p.FunctionID.String(),
+				"function_id":     fnID.String(),
 				"lease_issued_at": leaseIssuedAt.String(),
 			}))
 			return
@@ -231,7 +236,7 @@ func (q *queueProcessor) ProcessItem(
 
 					currentCapacityLease := capacityLeaseID.get()
 					if currentCapacityLease == nil {
-						l.Error("cannot extend capacity lease since capacity lease ID is nil", "qi", qi, "partition", p)
+						l.Error("cannot extend capacity lease since capacity lease ID is nil", "qi", qi)
 						// Don't extend lease since one doesn't exist
 						errCh <- AlwaysRetryError(fmt.Errorf("cannot extend capacity lease since lease ID is nil"))
 						return
@@ -267,10 +272,9 @@ func (q *queueProcessor) ProcessItem(
 							"error extending capacity lease",
 							logger.WithErrorReportLog(true),
 							logger.WithErrorReportTags(map[string]string{
-								"partitionID": p.ID,
-								"accountID":   accountID.String(),
-								"item":        qi.ID,
-								"leaseID":     currentCapacityLease.String(),
+								"accountID": accountID.String(),
+								"item":      qi.ID,
+								"leaseID":   currentCapacityLease.String(),
 							}),
 						)
 
@@ -289,7 +293,7 @@ func (q *queueProcessor) ProcessItem(
 						}
 
 						// Lease could not be extended
-						l.Error("failed to extend capacity lease, no new lease ID received", "qi", qi, "partition", p)
+						l.Error("failed to extend capacity lease, no new lease ID received", "qi", qi)
 						errCh <- AlwaysRetryError(fmt.Errorf("failed to extend capacity lease, no new lease ID received"))
 						return
 					}
@@ -415,7 +419,7 @@ func (q *queueProcessor) ProcessItem(
 		runInfo := RunInfo{
 			Latency:             latency,
 			SojournDelay:        sojourn,
-			Priority:            q.PartitionPriorityFinder(ctx, p),
+			Priority:            i.Priority,
 			QueueShardName:      shard.Name(),
 			ContinueCount:       continuationCtr,
 			RefilledFromBacklog: qi.RefilledFrom,
@@ -425,6 +429,7 @@ func (q *queueProcessor) ProcessItem(
 
 		// Call the run func.
 		res, err := f(doCtx, runInfo, qi.Data)
+		processResult.RunResult = res
 
 		{
 			// Clean up leases and such
@@ -434,12 +439,6 @@ func (q *queueProcessor) ProcessItem(
 				extendCapacityLeaseTick.Stop()
 			}
 
-		}
-
-		if res.ScheduledImmediateJob {
-			// Add the partition to be continued again.  Note that if we've already
-			// continued beyond the limit this is a noop.
-			q.addContinue(ctx, &p, continuationCtr+1)
 		}
 
 		status := "completed"
@@ -485,17 +484,17 @@ func (q *queueProcessor) ProcessItem(
 			if err := q.Requeue(context.WithoutCancel(ctx), shard.Name(), requeueItem, at); err != nil {
 				if err == ErrQueueItemNotFound {
 					// Safe. The executor may have dequeued.
-					return nil
+					return ProcessItemResult{}, nil
 				}
 
 				l.Error("error requeuing job", "error", err, "item", requeueItem)
-				return err
+				return ProcessItemResult{}, err
 			}
 			if _, ok := err.(QuitError); ok {
 				q.quit <- err
-				return err
+				return ProcessItemResult{}, err
 			}
-			return nil
+			return ProcessItemResult{}, nil
 		}
 
 		// Dequeue this entirely, as this permanently failed.
@@ -503,26 +502,26 @@ func (q *queueProcessor) ProcessItem(
 		if err := q.Dequeue(context.WithoutCancel(ctx), shard.Name(), itemWithCurrentLease(qi)); err != nil {
 			if err == ErrQueueItemNotFound {
 				// Safe. The executor may have dequeued.
-				return nil
+				return ProcessItemResult{}, nil
 			}
-			return err
+			return ProcessItemResult{}, err
 		}
 
 		if _, ok := err.(QuitError); ok {
 			l.Warn("received queue quit error", "error", err)
 			q.quit <- err
-			return err
+			return ProcessItemResult{}, err
 		}
 	case <-jobCtx.Done():
 		stopItemLeaseRenewal()
 		if err := q.Dequeue(context.WithoutCancel(ctx), shard.Name(), itemWithCurrentLease(qi)); err != nil {
 			if err == ErrQueueItemNotFound {
 				// Safe. The executor may have dequeued.
-				return nil
+				return processResult, nil
 			}
-			return err
+			return ProcessItemResult{}, err
 		}
 	}
 
-	return nil
+	return processResult, nil
 }

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -286,13 +286,22 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 
 	parallel := parallelFn || parallelAccount || isSystemFn
 
+	dispatchWithContinuations := func(ctx context.Context, item ProcessItem) (DispatchedItem, error) {
+		dispatched, err := dispatch(ctx, item)
+		if err != nil {
+			return dispatched, err
+		}
+		q.watchDispatchedPartitionItem(ctx, dispatched, p, continuationCount)
+		return dispatched, nil
+	}
+
 	iter := ProcessorIterator{
 		Partition:            p,
 		Items:                queue,
 		PartitionContinueCtr: continuationCount,
 		Queue:                q,
 		Leaser:               q,
-		Dispatch:             dispatch,
+		Dispatch:             dispatchWithContinuations,
 		StaticTime:           q.Clock().Now(),
 		Parallel:             parallel,
 	}

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -286,13 +286,16 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 
 	parallel := parallelFn || parallelAccount || isSystemFn
 
-	dispatchWithContinuations := func(ctx context.Context, item ProcessItem) (DispatchedItem, error) {
-		dispatched, err := dispatch(ctx, item)
-		if err != nil {
-			return dispatched, err
+	dispatchForIterator := dispatch
+	if q.runMode.Continuations {
+		dispatchForIterator = func(ctx context.Context, item ProcessItem) (DispatchedItem, error) {
+			dispatched, err := dispatch(ctx, item)
+			if err != nil {
+				return dispatched, err
+			}
+			q.watchDispatchedPartitionItem(ctx, dispatched, p, continuationCount)
+			return dispatched, nil
 		}
-		q.watchDispatchedPartitionItem(ctx, dispatched, p, continuationCount)
-		return dispatched, nil
 	}
 
 	iter := ProcessorIterator{
@@ -301,7 +304,7 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 		PartitionContinueCtr: continuationCount,
 		Queue:                q,
 		Leaser:               q,
-		Dispatch:             dispatchWithContinuations,
+		Dispatch:             dispatchForIterator,
 		StaticTime:           q.Clock().Now(),
 		Parallel:             parallel,
 	}

--- a/pkg/execution/queue/process_partition_deleted_account_test.go
+++ b/pkg/execution/queue/process_partition_deleted_account_test.go
@@ -37,9 +37,9 @@ func TestProcessPartitionRequeuesDeletedAccount(t *testing.T) {
 		ID:         fnID.String(),
 		FunctionID: &fnID,
 		AccountID:  accountID,
-	}, 0, false, func(_ context.Context, item ProcessItem) error {
+	}, 0, false, func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
 		q.workers <- item
-		return nil
+		return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
 	})
 	require.NoError(t, err)
 

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -247,7 +247,15 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 		return nil
 	}
 
-	err := scanner.Run(ctx, dispatch)
+	rt := QueueScannerRuntime{
+		Leaser:   q,
+		Dispatch: dispatch,
+	}
+	if rt.Leaser == nil {
+		return ErrQueueScannerMissingLeaser
+	}
+
+	err := scanner.Run(ctx, rt)
 
 	l.Info("queue waiting to quit", "err", err)
 	q.wg.Wait()

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -248,8 +248,9 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 	}
 
 	rt := QueueScannerRuntime{
-		Leaser:   q,
-		Dispatch: dispatch,
+		Leaser:          q,
+		Dispatch:        dispatch,
+		WorkerSemaphore: q.Semaphore(),
 	}
 	if rt.Leaser == nil {
 		return ErrQueueScannerMissingLeaser

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -242,9 +242,16 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 		}
 	}
 
-	dispatch := func(_ context.Context, item ProcessItem) error {
-		q.workers <- item
-		return nil
+	dispatch := func(ctx context.Context, item ProcessItem) (DispatchedItem, error) {
+		handle := newDispatchedItemHandle()
+		item.result = handle
+
+		select {
+		case q.workers <- item:
+			return handle, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 
 	rt := QueueScannerRuntime{

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -186,11 +186,22 @@ func (p *ProcessorIterator) LeaseItem(ctx context.Context, item *QueueItem) erro
 		}
 	}
 
+	priority := uint(0)
+	if opts := p.Queue.Options(); opts != nil {
+		priority = opts.PartitionPriorityFinder(ctx, *p.Partition)
+	}
+
+	earliestPeekTimeFallbackMS := int64(0)
+	if item.EarliestPeekTime == 0 && p.Partition.Last > 0 && p.Partition.Last > item.AtMS {
+		earliestPeekTimeFallbackMS = item.AtMS
+	}
+
 	result, err := leaser.LeaseItem(ctx, LeaseItemRequest{
-		Item:                 item,
-		Partition:            p.Partition,
-		PartitionContinueCtr: p.PartitionContinueCtr,
-		StaticTime:           p.StaticTime,
+		Item:                       item,
+		Priority:                   priority,
+		ContinueCount:              p.PartitionContinueCtr,
+		EarliestPeekTimeFallbackMS: earliestPeekTimeFallbackMS,
+		StaticTime:                 p.StaticTime,
 	}, p.Dispatch)
 	p.applyLeaseItemResult(result)
 	return err

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -74,8 +74,8 @@ func (m *mockQueueProcessor) NormalizeItem(ctx context.Context, sp *QueueShadowP
 	return item, nil
 }
 
-func (m *mockQueueProcessor) ProcessItem(ctx context.Context, i ProcessItem, f RunFunc) error {
-	return nil
+func (m *mockQueueProcessor) ProcessItem(ctx context.Context, i ProcessItem, f RunFunc) (ProcessItemResult, error) {
+	return ProcessItemResult{}, nil
 }
 
 func (m *mockQueueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool, dispatch DispatchFunc) error {
@@ -484,10 +484,10 @@ func processorIteratorConstraintLeaser(mockProc *mockQueueProcessor) QueueItemLe
 				if dispatch == nil {
 					return LeaseItemResult{Status: LeaseItemStatusLeaseError, Err: ErrProcessMissingDispatch}, ErrProcessMissingDispatch
 				}
-				err := dispatch(ctx, ProcessItem{
-					P:    *req.Partition,
-					I:    *req.Item,
-					PCtr: req.PartitionContinueCtr,
+				_, err := dispatch(ctx, ProcessItem{
+					I:             *req.Item,
+					Priority:      req.Priority,
+					ContinueCount: req.ContinueCount,
 				})
 				if err != nil {
 					return LeaseItemResult{Status: LeaseItemStatusDispatched}, err
@@ -532,8 +532,8 @@ func processorIteratorLeaseBehaviorLeaser(mockProc *mockQueueProcessor) QueueIte
 				constraint = mockProc.constraintResultFunc()
 			}
 			if constraint != enums.QueueConstraintNotLimited {
-				if req.Item.EarliestPeekTime == 0 && req.Partition.Last > 0 && req.Partition.Last > req.Item.AtMS {
-					req.Item.EarliestPeekTime = req.Item.AtMS
+				if req.Item.EarliestPeekTime == 0 && req.EarliestPeekTimeFallbackMS > 0 {
+					req.Item.EarliestPeekTime = req.EarliestPeekTimeFallbackMS
 				}
 				return LeaseItemResult{Status: LeaseItemStatusConcurrencyLimited}, fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
 			}
@@ -541,10 +541,10 @@ func processorIteratorLeaseBehaviorLeaser(mockProc *mockQueueProcessor) QueueIte
 			if dispatch == nil {
 				return LeaseItemResult{Status: LeaseItemStatusLeaseError, Err: ErrProcessMissingDispatch}, ErrProcessMissingDispatch
 			}
-			err := dispatch(ctx, ProcessItem{
-				P:    *req.Partition,
-				I:    *req.Item,
-				PCtr: req.PartitionContinueCtr,
+			_, err := dispatch(ctx, ProcessItem{
+				I:             *req.Item,
+				Priority:      req.Priority,
+				ContinueCount: req.ContinueCount,
 			})
 			if err != nil {
 				return LeaseItemResult{Status: LeaseItemStatusDispatched}, err
@@ -639,9 +639,9 @@ func TestProcessorIteratorCounterRaceCondition(t *testing.T) {
 		PartitionContinueCtr: 0,
 		Queue:                mockProc,
 		Leaser:               processorIteratorConstraintLeaser(mockProc),
-		Dispatch: func(_ context.Context, item ProcessItem) error {
+		Dispatch: func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
 			workers <- item
-			return nil
+			return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
 		},
 		StaticTime: time.Now(),
 		Parallel:   true, // Enable parallel processing
@@ -754,9 +754,9 @@ func TestProcessorIteratorCounterRaceConditionMixed(t *testing.T) {
 		PartitionContinueCtr: 0,
 		Queue:                mockProc,
 		Leaser:               processorIteratorConstraintLeaser(mockProc),
-		Dispatch: func(_ context.Context, item ProcessItem) error {
+		Dispatch: func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
 			workers <- item
-			return nil
+			return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
 		},
 		StaticTime: time.Now(),
 		Parallel:   true,
@@ -861,9 +861,9 @@ func TestProcessorIteratorIsCustomKeyLimitOnlyRace(t *testing.T) {
 		PartitionContinueCtr: 0,
 		Queue:                mockProc,
 		Leaser:               processorIteratorConstraintLeaser(mockProc),
-		Dispatch: func(_ context.Context, item ProcessItem) error {
+		Dispatch: func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
 			workers <- item
-			return nil
+			return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
 		},
 		StaticTime: time.Now(),
 		Parallel:   true,
@@ -938,9 +938,9 @@ func TestProcessorIteratorUsesPartitionLastEarliestPeekFallbackWhenFlagDisabled(
 		Items:     []*QueueItem{item},
 		Queue:     mockProc,
 		Leaser:    processorIteratorLeaseBehaviorLeaser(mockProc),
-		Dispatch: func(_ context.Context, item ProcessItem) error {
+		Dispatch: func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
 			mockProc.workers <- item
-			return nil
+			return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
 		},
 		StaticTime: at.Add(2 * time.Second),
 	}
@@ -1011,9 +1011,9 @@ func TestProcessorIteratorSkipsEarliestPeekTimeWhenNoWorkerCapacity(t *testing.T
 		Items:     []*QueueItem{item},
 		Queue:     mockProc,
 		Leaser:    processorIteratorLeaseBehaviorLeaser(mockProc),
-		Dispatch: func(_ context.Context, item ProcessItem) error {
+		Dispatch: func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
 			mockProc.workers <- item
-			return nil
+			return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
 		},
 		StaticTime: peekTime,
 	}
@@ -1080,9 +1080,9 @@ func TestProcessorIteratorContinuesWhenEarliestPeekTimeStampFails(t *testing.T) 
 		Items:     []*QueueItem{item},
 		Queue:     mockProc,
 		Leaser:    processorIteratorLeaseBehaviorLeaser(mockProc),
-		Dispatch: func(_ context.Context, item ProcessItem) error {
+		Dispatch: func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
 			workers <- item
-			return nil
+			return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
 		},
 		StaticTime: at.Add(2 * time.Second),
 	}

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -115,6 +115,8 @@ func TestProcessorRunUsesShardQueueScanner(t *testing.T) {
 	require.True(t, scanner.called.Load())
 	require.NotNil(t, scanner.runtime.Leaser)
 	require.NotNil(t, scanner.runtime.Dispatch)
+	require.NotNil(t, scanner.runtime.WorkerSemaphore)
+	require.Same(t, q.Semaphore(), scanner.runtime.WorkerSemaphore)
 }
 
 func TestProcessorRunReturnsQueueScannerError(t *testing.T) {

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -41,14 +41,14 @@ func (m *mockConsumer) Dequeue(_ context.Context, shardName string, _ QueueItem,
 }
 
 type mockQueueScanner struct {
-	called   atomic.Bool
-	dispatch DispatchFunc
-	err      error
+	called  atomic.Bool
+	runtime QueueScannerRuntime
+	err     error
 }
 
-func (m *mockQueueScanner) Run(_ context.Context, dispatch DispatchFunc) error {
+func (m *mockQueueScanner) Run(_ context.Context, rt QueueScannerRuntime) error {
 	m.called.Store(true)
-	m.dispatch = dispatch
+	m.runtime = rt
 	return m.err
 }
 
@@ -57,8 +57,8 @@ type mockScannerShard struct {
 	scanner QueueScanner
 }
 
-func (m *mockScannerShard) Run(ctx context.Context, dispatch DispatchFunc) error {
-	return m.scanner.Run(ctx, dispatch)
+func (m *mockScannerShard) Run(ctx context.Context, rt QueueScannerRuntime) error {
+	return m.scanner.Run(ctx, rt)
 }
 
 func TestProcessorWithQueueProducerOverridesDefaultProducer(t *testing.T) {
@@ -113,7 +113,8 @@ func TestProcessorRunUsesShardQueueScanner(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, scanner.called.Load())
-	require.NotNil(t, scanner.dispatch)
+	require.NotNil(t, scanner.runtime.Leaser)
+	require.NotNil(t, scanner.runtime.Dispatch)
 }
 
 func TestProcessorRunReturnsQueueScannerError(t *testing.T) {

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -48,17 +48,18 @@ type RunInfo struct {
 // Item's retry policy.
 type RunFunc func(context.Context, RunInfo, Item) (RunResult, error)
 
-type DispatchFunc func(ctx context.Context, item ProcessItem) error
+type DispatchFunc func(ctx context.Context, item ProcessItem) (DispatchedItem, error)
 
 type QueueItemLeaser interface {
 	LeaseItem(ctx context.Context, req LeaseItemRequest, dispatch DispatchFunc) (LeaseItemResult, error)
 }
 
 type LeaseItemRequest struct {
-	Item                 *QueueItem
-	Partition            *QueuePartition
-	PartitionContinueCtr uint
-	StaticTime           time.Time
+	Item                       *QueueItem
+	Priority                   uint
+	ContinueCount              uint
+	EarliestPeekTimeFallbackMS int64
+	StaticTime                 time.Time
 }
 
 type LeaseItemStatus int
@@ -99,6 +100,10 @@ type RunResult struct {
 	// ScheduledImmediateJob indicates whether this run function scheduled another job
 	// in the same partition for immediate consumption.
 	ScheduledImmediateJob bool
+}
+
+type ProcessItemResult struct {
+	RunResult RunResult
 }
 
 type EnqueueOpts struct {

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -82,18 +81,6 @@ type LeaseItemResult struct {
 	Status     LeaseItemStatus
 	Err        error
 	RetryAfter time.Time
-}
-
-type QueueScannerRuntime struct {
-	Leaser          QueueItemLeaser
-	Dispatch        DispatchFunc
-	WorkerSemaphore util.TrackingSemaphore
-}
-
-// QueueScanner discovers and leases queue work. It should hand leased items to
-// the dispatch function and leave item execution to the common queue processor layer.
-type QueueScanner interface {
-	Run(ctx context.Context, rt QueueScannerRuntime) error
 }
 
 type RunResult struct {

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -83,8 +84,9 @@ type LeaseItemResult struct {
 }
 
 type QueueScannerRuntime struct {
-	Leaser   QueueItemLeaser
-	Dispatch DispatchFunc
+	Leaser          QueueItemLeaser
+	Dispatch        DispatchFunc
+	WorkerSemaphore util.TrackingSemaphore
 }
 
 // QueueScanner discovers and leases queue work. It should hand leased items to

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -77,14 +77,20 @@ const (
 )
 
 type LeaseItemResult struct {
-	Status LeaseItemStatus
-	Err    error
+	Status     LeaseItemStatus
+	Err        error
+	RetryAfter time.Time
+}
+
+type QueueScannerRuntime struct {
+	Leaser   QueueItemLeaser
+	Dispatch DispatchFunc
 }
 
 // QueueScanner discovers and leases queue work. It should hand leased items to
 // the dispatch function and leave item execution to the common queue processor layer.
 type QueueScanner interface {
-	Run(ctx context.Context, dispatch DispatchFunc) error
+	Run(ctx context.Context, rt QueueScannerRuntime) error
 }
 
 type RunResult struct {

--- a/pkg/execution/queue/scanner.go
+++ b/pkg/execution/queue/scanner.go
@@ -3,8 +3,21 @@ package queue
 import (
 	"context"
 
+	"github.com/inngest/inngest/pkg/util"
 	"golang.org/x/sync/errgroup"
 )
+
+type QueueScannerRuntime struct {
+	Leaser          QueueItemLeaser
+	Dispatch        DispatchFunc
+	WorkerSemaphore util.TrackingSemaphore
+}
+
+// QueueScanner discovers and leases queue work. It should hand leased items to
+// the dispatch function and leave item execution to the common queue processor layer.
+type QueueScanner interface {
+	Run(ctx context.Context, rt QueueScannerRuntime) error
+}
 
 type partitionQueueScanner struct {
 	q *queueProcessor

--- a/pkg/execution/queue/scanner.go
+++ b/pkg/execution/queue/scanner.go
@@ -10,14 +10,14 @@ type partitionQueueScanner struct {
 	q *queueProcessor
 }
 
-func (s partitionQueueScanner) Run(ctx context.Context, dispatch DispatchFunc) error {
+func (s partitionQueueScanner) Run(ctx context.Context, rt QueueScannerRuntime) error {
 	q := s.q
 
 	// start execution and shadow scan concurrently
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		return q.executionScan(ctx, dispatch)
+		return q.executionScan(ctx, rt.Dispatch)
 	})
 
 	if q.runMode.ShadowPartition {

--- a/pkg/execution/queue/worker.go
+++ b/pkg/execution/queue/worker.go
@@ -28,7 +28,13 @@ func (q *queueProcessor) worker(ctx context.Context, f RunFunc) {
 
 			processCtx, cancel := context.WithCancel(processCtx)
 
-			err := q.ProcessItem(processCtx, i, f)
+			result, err := q.ProcessItem(processCtx, i, f)
+			if i.result != nil {
+				i.result.complete(DispatchedItemResult{
+					ScheduledImmediateJob: result.RunResult.ScheduledImmediateJob,
+					Err:                   err,
+				})
+			}
 			q.Semaphore().Release(1)
 			metrics.WorkerQueueCapacityCounter(ctx, -1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.Shard().Name()}})
 			cancel()

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -90,13 +90,10 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		p := osqueue.ItemPartition(ctx, qi)
-
 		var counter int64
 
-		err = q.ProcessItem(ctx, osqueue.ProcessItem{
+		_, err = q.ProcessItem(ctx, osqueue.ProcessItem{
 			I:             qi,
-			P:             p,
 			CapacityLease: nil,
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 			atomic.AddInt64(&counter, 1)
@@ -125,13 +122,10 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		p := osqueue.ItemPartition(ctx, qi)
-
 		var counter int64
 
-		err = q.ProcessItem(ctx, osqueue.ProcessItem{
+		_, err = q.ProcessItem(ctx, osqueue.ProcessItem{
 			I:             qi,
-			P:             p,
 			CapacityLease: nil,
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 			<-time.After(3 * time.Second)
@@ -163,8 +157,6 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 
 		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
-
-		p := osqueue.ItemPartition(ctx, qi)
 
 		// Acquire a lease
 		resp, err := cm.Acquire(ctx, &constraintapi.CapacityAcquireRequest{
@@ -211,9 +203,8 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 
 		var counter int64
 
-		err = q.ProcessItem(ctx, osqueue.ProcessItem{
+		_, err = q.ProcessItem(ctx, osqueue.ProcessItem{
 			I: qi,
-			P: p,
 			CapacityLease: &osqueue.CapacityLease{
 				LeaseID:    resp.Leases[0].LeaseID,
 				IssuedAtMS: clock.Now().UnixMilli(),
@@ -271,8 +262,6 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		p := osqueue.ItemPartition(ctx, qi)
-
 		// Acquire a lease (same pattern as existing test)
 		resp, err := cm.Acquire(ctx, &constraintapi.CapacityAcquireRequest{
 			AccountID:            accountID,
@@ -323,9 +312,8 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 
 		var counter int64
 
-		err = q.ProcessItem(ctx, osqueue.ProcessItem{
+		_, err = q.ProcessItem(ctx, osqueue.ProcessItem{
 			I: qi,
-			P: p,
 			CapacityLease: &osqueue.CapacityLease{
 				LeaseID:    resp.Leases[0].LeaseID,
 				IssuedAtMS: clock.Now().UnixMilli(),
@@ -386,8 +374,6 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		p := osqueue.ItemPartition(ctx, qi)
-
 		// Acquire a lease
 		resp, err := cm.Acquire(ctx, &constraintapi.CapacityAcquireRequest{
 			AccountID:            accountID,
@@ -433,9 +419,8 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 
 		var counter int64
 
-		err = q.ProcessItem(ctx, osqueue.ProcessItem{
+		_, err = q.ProcessItem(ctx, osqueue.ProcessItem{
 			I: qi,
-			P: p,
 			CapacityLease: &osqueue.CapacityLease{
 				LeaseID:    resp.Leases[0].LeaseID,
 				IssuedAtMS: clock.Now().UnixMilli(),
@@ -514,8 +499,6 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		p := osqueue.ItemPartition(ctx, qi)
-
 		// Acquire a lease
 		resp, err := cm.Acquire(ctx, &constraintapi.CapacityAcquireRequest{
 			AccountID:            accountID,
@@ -559,9 +542,8 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 
 		var counter int64
 
-		err = q.ProcessItem(ctx, osqueue.ProcessItem{
+		_, err = q.ProcessItem(ctx, osqueue.ProcessItem{
 			I: qi,
-			P: p,
 			CapacityLease: &osqueue.CapacityLease{
 				LeaseID:    resp.Leases[0].LeaseID,
 				IssuedAtMS: clock.Now().UnixMilli(),
@@ -664,8 +646,7 @@ func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
 			started := make(chan struct{})
 			done := make(chan error, 1)
 			go func() {
-				done <- q.ProcessItem(ctx, osqueue.ProcessItem{
-					P: osqueue.ItemPartition(ctx, item),
+				_, err := q.ProcessItem(ctx, osqueue.ProcessItem{
 					I: item,
 				}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 					close(started)
@@ -688,6 +669,7 @@ func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
 						}
 					}
 				})
+				done <- err
 			}()
 
 			require.Eventually(t, func() bool {
@@ -808,9 +790,9 @@ func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {
 			Items:                []*osqueue.QueueItem{&qi},
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 				q.Workers() <- item
-				return nil
+				return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 			},
 			StaticTime: clock.Now(),
 			Parallel:   false,
@@ -859,9 +841,9 @@ func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {
 			Items:                []*osqueue.QueueItem{&qi},
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 				q.Workers() <- item
-				return nil
+				return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 			},
 			StaticTime: clock.Now(),
 			Parallel:   false,
@@ -952,9 +934,9 @@ func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {
 			Items:                []*osqueue.QueueItem{&qi},
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 				q.Workers() <- item
-				return nil
+				return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 			},
 			StaticTime: clock.Now(),
 			Parallel:   false,
@@ -1071,9 +1053,9 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 			Items:                items,
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 				q.Workers() <- item
-				return nil
+				return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 			},
 			StaticTime: clock.Now(),
 			Parallel:   false,
@@ -1143,9 +1125,9 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 		// score in global set is at earliest item
 		require.Equal(t, start.Unix(), int64(score(t, r, kg.GlobalPartitionIndex(), p.ID)))
 
-		err = q.ProcessPartition(ctx, &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) error {
+		err = q.ProcessPartition(ctx, &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 			q.Workers() <- item
-			return nil
+			return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 		})
 		require.NoError(t, err)
 
@@ -1211,9 +1193,9 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 			Items:                items,
 			PartitionContinueCtr: 0,
 			Queue:                q,
-			Dispatch: func(_ context.Context, item osqueue.ProcessItem) error {
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 				q.Workers() <- item
-				return nil
+				return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 			},
 			StaticTime: clock.Now(),
 			Parallel:   false,
@@ -1286,9 +1268,9 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 		// score in global set is at earliest item
 		require.Equal(t, start.Unix(), int64(score(t, r, kg.GlobalPartitionIndex(), p.ID)))
 
-		err = q.ProcessPartition(ctx, &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) error {
+		err = q.ProcessPartition(ctx, &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 			q.Workers() <- item
-			return nil
+			return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 		})
 		require.NoError(t, err)
 
@@ -1426,9 +1408,9 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 		// score in global set is at earliest item
 		require.Equal(t, start.Unix(), int64(score(t, r, kg.GlobalPartitionIndex(), p.ID)))
 
-		err = q.ProcessPartition(logger.WithStdlib(ctx, l), &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) error {
+		err = q.ProcessPartition(logger.WithStdlib(ctx, l), &p, 0, false, func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 			q.Workers() <- item
-			return nil
+			return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 		})
 		require.NoError(t, err)
 

--- a/tests/execution/queue/earliest_peek_time_test.go
+++ b/tests/execution/queue/earliest_peek_time_test.go
@@ -20,9 +20,9 @@ import (
 )
 
 func dispatchToOSQueueWorkers(workers chan osqueue.ProcessItem) osqueue.DispatchFunc {
-	return func(_ context.Context, item osqueue.ProcessItem) error {
+	return func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
 		workers <- item
-		return nil
+		return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
 	}
 }
 
@@ -578,7 +578,7 @@ func TestQueueLatencySeparatesSystemAndUserLatencyAfterEarliestPeekStamp(t *test
 	require.Equal(t, peekTime.UnixMilli(), qi2.EarliestPeekTime)
 
 	firstWork := <-q.Workers()
-	err = q.ProcessItem(ctx, firstWork, func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
+	_, err = q.ProcessItem(ctx, firstWork, func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
 		return osqueue.RunResult{}, nil
 	})
 	require.NoError(t, err)
@@ -606,7 +606,7 @@ func TestQueueLatencySeparatesSystemAndUserLatencyAfterEarliestPeekStamp(t *test
 
 	infoCh := make(chan osqueue.RunInfo, 1)
 	secondWork := <-q.Workers()
-	err = q.ProcessItem(ctx, secondWork, func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
+	_, err = q.ProcessItem(ctx, secondWork, func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
 		infoCh <- info
 		return osqueue.RunResult{}, nil
 	})

--- a/tests/execution/queue/queue_semaphore_test.go
+++ b/tests/execution/queue/queue_semaphore_test.go
@@ -23,9 +23,9 @@ import (
 )
 
 func dispatchToQueueWorkers(workers chan queue.ProcessItem) queue.DispatchFunc {
-	return func(_ context.Context, item queue.ProcessItem) error {
+	return func(_ context.Context, item queue.ProcessItem) (queue.DispatchedItem, error) {
 		workers <- item
-		return nil
+		return queue.NewCompletedDispatchedItem(queue.DispatchedItemResult{}), nil
 	}
 }
 
@@ -218,12 +218,10 @@ func TestLeaseItemReturnsRetryAfterForConstraintLimit(t *testing.T) {
 	qi2, err := shard.EnqueueItem(ctx, makeItem(), clock.Now(), queue.EnqueueOpts{})
 	require.NoError(t, err)
 
-	partition := queue.ItemPartition(ctx, qi1)
 	dispatch := dispatchToQueueWorkers(q.Workers())
 	req := func(item *queue.QueueItem) queue.LeaseItemRequest {
 		return queue.LeaseItemRequest{
 			Item:       item,
-			Partition:  &partition,
 			StaticTime: clock.Now(),
 		}
 	}

--- a/tests/execution/queue/queue_semaphore_test.go
+++ b/tests/execution/queue/queue_semaphore_test.go
@@ -153,6 +153,92 @@ func TestQueueSemaphoreWithConstraintAPI(t *testing.T) {
 	require.Equal(t, int64(1), q.Semaphore().Count())
 }
 
+func TestLeaseItemReturnsRetryAfterForConstraintLimit(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClock()
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("test"),
+		constraintapi.WithClock(clock),
+	)
+	require.NoError(t, err)
+
+	options := []queue.QueueOpt{
+		queue.WithClock(clock),
+		queue.WithCapacityManager(cm),
+		queue.WithAcquireCapacityLeaseOnBacklogRefill(true),
+		queue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p queue.PartitionIdentifier) queue.PartitionConstraintConfig {
+			return queue.PartitionConstraintConfig{
+				FunctionVersion: 1,
+				Concurrency: queue.PartitionConcurrency{
+					AccountConcurrency:  1,
+					FunctionConcurrency: 1,
+				},
+			}
+		}),
+	}
+
+	shard := redis_state.NewQueueShard("test", queueClient, options...)
+	shardRegistry, err := queue.NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+	q, err := queue.New(ctx, "test", shardRegistry, options...)
+	require.NoError(t, err)
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	makeItem := func() queue.QueueItem {
+		return queue.QueueItem{
+			Data: queue.Item{
+				Kind: queue.KindStart,
+				Identifier: state.Identifier{
+					AccountID:   accountID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
+					RunID:       ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader),
+				},
+				WorkspaceID: envID,
+			},
+			FunctionID:  fnID,
+			WorkspaceID: envID,
+		}
+	}
+
+	qi1, err := shard.EnqueueItem(ctx, makeItem(), clock.Now(), queue.EnqueueOpts{})
+	require.NoError(t, err)
+	qi2, err := shard.EnqueueItem(ctx, makeItem(), clock.Now(), queue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	partition := queue.ItemPartition(ctx, qi1)
+	dispatch := dispatchToQueueWorkers(q.Workers())
+	req := func(item *queue.QueueItem) queue.LeaseItemRequest {
+		return queue.LeaseItemRequest{
+			Item:       item,
+			Partition:  &partition,
+			StaticTime: clock.Now(),
+		}
+	}
+
+	result, err := q.LeaseItem(ctx, req(&qi1), dispatch)
+	require.NoError(t, err)
+	require.Equal(t, queue.LeaseItemStatusDispatched, result.Status)
+	require.Zero(t, result.RetryAfter)
+
+	result, err = q.LeaseItem(ctx, req(&qi2), dispatch)
+	require.ErrorIs(t, err, queue.ErrProcessNoUserConstraintCapacity)
+	require.Equal(t, queue.LeaseItemStatusConcurrencyLimited, result.Status)
+	require.WithinDuration(t, clock.Now().Add(constraintapi.ConcurrencyLimitRetryAfter), result.RetryAfter, time.Millisecond)
+}
+
 func TestQueueSemaphoreDisableFlagSkipsSemaphoreOnlyValidCapacityLeaseAcquire(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description

Adds a `QueueScannerRuntime` boundary so scanner implementations receive the shared item leaser, dispatch function, and worker semaphore together. This lets backend-specific scanners discover work with their own storage model while still handing candidate items to the common queue lease and worker-dispatch path, and lets scanners avoid scanning when worker capacity is exhausted.

Decouples queue item leasing and processing from queue partitions:

- `LeaseItemRequest` now carries only the item plus scanner-resolved metadata: priority, continuation count, earliest-peek fallback, and static time.
- `LeaseItem` derives account, environment, function, and run identifiers from the item itself instead of requiring a `QueuePartition`.
- `ProcessItem` no longer depends on queue partition state; it uses item identifiers and scanner-provided priority/continuation metadata.
- Partition priority is resolved during scanning and passed through to workers.
- `LeaseItemResult` carries `RetryAfter` for constrained statuses so scanner implementations can defer their own scheduling pointers without parsing errors or rechecking constraints.

Adds a dispatch completion contract:

- `DispatchFunc` now returns a `DispatchedItem` future when an item is accepted for processing.
- The default dispatcher creates the completion handle, sends the item to the worker channel with context cancellation, and returns the handle to the scanner.
- Workers complete the handle after `ProcessItem` returns, including whether the run scheduled immediate follow-up work.
- Completion channels are buffered so workers do not block if no scanner is waiting.
- `NewCompletedDispatchedItem` provides a standard helper for synchronous scanner/test implementations.

Moves continuation ownership out of `ProcessItem` and into the partition scanner path. When continuations are enabled, the partition processor watches dispatched item completion and adds a continuation only after successful immediate follow-up work. The watcher exits on completion, scanner context cancellation, or a 10-minute timeout to avoid stale goroutines.

Organizes scanner and dispatch types into focused files:

- `pkg/execution/queue/scanner.go` owns scanner runtime/interface code.
- `pkg/execution/queue/dispatch.go` owns dispatch result/future types and helpers.

## Release note

None

## Migration note

Out-of-tree queue scanner implementations must update `Run(ctx, dispatch)` to `Run(ctx, runtime)`, use `runtime.Dispatch` to submit leased work, and may inspect `runtime.WorkerSemaphore` before scanning. Implementations that call `DispatchFunc` must handle the returned `DispatchedItem`; callers may ignore it, or wait on `Done()` with context cancellation or a timeout.

Callers of `LeaseItem` must stop passing queue partitions and instead provide item metadata on `LeaseItemRequest`. Callers of `ProcessItem` must handle the new `(ProcessItemResult, error)` return shape.

## Validation

- `go test ./pkg/execution/queue`
- `go test ./tests/execution/queue`
- `make lint`
