### PR TITLE
feat(dashboard): route Insights AI through OpenRouter

### DIFF
--- a/ui/apps/dashboard/src/lib/inngest/functions/agent/loop.test.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agent/loop.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { runAgentLoop, type QueryDraft, type ToolDef } from './loop';
+import {
+  runAgentLoop,
+  type ChatCompletion,
+  type QueryDraft,
+  type ToolDef,
+} from './loop';
 
 function fakeStep(waitForEventResult: unknown = null) {
   return {
@@ -9,11 +14,13 @@ function fakeStep(waitForEventResult: unknown = null) {
   };
 }
 
-function fakeClient(responses: unknown[]) {
+// Replays canned completions in order, recording each request body.
+function fakeComplete(responses: unknown[]) {
   let i = 0;
-  return {
-    messages: { create: vi.fn(async () => responses[i++]) },
-  } as never;
+  return vi.fn(
+    (_body: unknown): Promise<ChatCompletion> =>
+      Promise.resolve(responses[i++] as ChatCompletion),
+  );
 }
 
 const echoTool: ToolDef = {
@@ -24,7 +31,6 @@ const echoTool: ToolDef = {
 function baseArgs(overrides: Record<string, unknown> = {}) {
   return {
     step: fakeStep() as never,
-    model: 'claude-sonnet-4-5',
     system: 'system prompt',
     messages: [{ role: 'user' as const, content: 'hi' }],
     tools: [echoTool],
@@ -39,22 +45,36 @@ function baseArgs(overrides: Record<string, unknown> = {}) {
 
 function textResponse(text: string) {
   return {
-    content: [{ type: 'text', text }],
-    usage: { input_tokens: 10, output_tokens: 5 },
+    choices: [{ message: { role: 'assistant', content: text } }],
+    usage: { prompt_tokens: 10, completion_tokens: 5 },
   };
 }
 
 function toolResponse(name: string, input: Record<string, unknown>, id = 't1') {
   return {
-    content: [{ type: 'tool_use', id, name, input }],
-    usage: { input_tokens: 10, output_tokens: 5 },
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id,
+              type: 'function',
+              function: { name, arguments: JSON.stringify(input) },
+            },
+          ],
+        },
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5 },
   };
 }
 
 describe('runAgentLoop', () => {
   it('returns a text-only response as the summary without calling tools', async () => {
-    const client = fakeClient([textResponse('done summary')]);
-    const res = await runAgentLoop({ ...baseArgs(), client });
+    const complete = fakeComplete([textResponse('done summary')]);
+    const res = await runAgentLoop({ ...baseArgs(), complete });
 
     expect(res.summary).toBe('done summary');
     expect(res.iterations).toBe(1);
@@ -65,27 +85,28 @@ describe('runAgentLoop', () => {
   });
 
   it('executes tool calls then finishes on a text-only turn', async () => {
-    const client = fakeClient([
+    const complete = fakeComplete([
       toolResponse('echo', { msg: 'x' }),
       textResponse('final'),
     ]);
-    const res = await runAgentLoop({ ...baseArgs(), client });
+    const res = await runAgentLoop({ ...baseArgs(), complete });
 
     expect(res.toolCalls).toBe(1);
     expect(res.iterations).toBe(2);
     expect(res.summary).toBe('final');
 
     // The second LLM call must carry the assistant turn and the tool result.
-    const secondCall = (
-      client as { messages: { create: ReturnType<typeof vi.fn> } }
-    ).messages.create.mock.calls[1]?.[0] as {
-      messages: { role: string; content: unknown }[];
+    // Messages: [system, user, assistant(tool_calls), tool].
+    const secondCall = complete.mock.calls[1]?.[0] as {
+      messages: { role: string; content: unknown; tool_call_id?: string }[];
     };
-    expect(secondCall.messages).toHaveLength(3);
-    expect(secondCall.messages[1]?.role).toBe('assistant');
-    expect(secondCall.messages[2]?.content).toEqual([
-      { type: 'tool_result', tool_use_id: 't1', content: 'echoed:x' },
-    ]);
+    expect(secondCall.messages).toHaveLength(4);
+    expect(secondCall.messages[2]?.role).toBe('assistant');
+    expect(secondCall.messages[3]).toEqual({
+      role: 'tool',
+      tool_call_id: 't1',
+      content: 'echoed:x',
+    });
   });
 
   it('applies draftPatch and publishes outside the tool step (replay-safe)', async () => {
@@ -102,14 +123,14 @@ describe('runAgentLoop', () => {
         publish: { event: 'step.completed', data: { sql: 'SELECT 1' } },
       }),
     };
-    const client = fakeClient([
+    const complete = fakeComplete([
       toolResponse('submit', {}),
       textResponse('summary'),
     ]);
     const draft: QueryDraft = { selectedEvents: [] };
     const res = await runAgentLoop({
       ...baseArgs({ tools: [submit], draft }),
-      client,
+      complete,
       publish: async (_id, event, data) => {
         published.push({ event, data });
       },
@@ -127,15 +148,17 @@ describe('runAgentLoop', () => {
     const responses = Array.from({ length: 3 }, (_, i) =>
       toolResponse('echo', { msg: 'x' }, `t${i}`),
     );
-    const client = fakeClient(responses);
-    const res = await runAgentLoop({ ...baseArgs(), client, maxIterations: 3 });
+    const complete = fakeComplete(responses);
+    const res = await runAgentLoop({
+      ...baseArgs(),
+      complete,
+      maxIterations: 3,
+    });
 
     expect(res.iterations).toBe(3);
     expect(res.summary).toBe('');
 
-    const lastCall = (
-      client as { messages: { create: ReturnType<typeof vi.fn> } }
-    ).messages.create.mock.calls[2]?.[0] as {
+    const lastCall = complete.mock.calls[2]?.[0] as {
       messages: { content: unknown }[];
     };
     const lastMessage = lastCall.messages[lastCall.messages.length - 1];
@@ -143,16 +166,34 @@ describe('runAgentLoop', () => {
   });
 
   it('keeps text that accompanies a tool call on the final iteration', async () => {
-    const client = fakeClient([
+    const complete = fakeComplete([
       {
-        content: [
-          { type: 'text', text: 'Here is your query.' },
-          { type: 'tool_use', id: 't1', name: 'echo', input: { msg: 'x' } },
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'Here is your query.',
+              tool_calls: [
+                {
+                  id: 't1',
+                  type: 'function',
+                  function: {
+                    name: 'echo',
+                    arguments: JSON.stringify({ msg: 'x' }),
+                  },
+                },
+              ],
+            },
+          },
         ],
-        usage: { input_tokens: 10, output_tokens: 5 },
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
       },
     ]);
-    const res = await runAgentLoop({ ...baseArgs(), client, maxIterations: 1 });
+    const res = await runAgentLoop({
+      ...baseArgs(),
+      complete,
+      maxIterations: 1,
+    });
 
     expect(res.summary).toBe('Here is your query.');
   });
@@ -179,14 +220,14 @@ describe('runAgentLoop', () => {
         },
       });
       const published: { event: string; data: Record<string, unknown> }[] = [];
-      const client = fakeClient([
+      const complete = fakeComplete([
         toolResponse('validate_query', { sql: 'SELECT count() FROM runs' }),
         textResponse('done'),
       ]);
       const res = await runAgentLoop({
         ...baseArgs({ tools: [validateTool] }),
         step: step as never,
-        client,
+        complete,
         publish: async (_id, event, data) => {
           published.push({ event, data });
         },
@@ -207,14 +248,10 @@ describe('runAgentLoop', () => {
       expect(res.validationAttempts).toBe(1);
       expect(res.validationFailures).toEqual([]);
 
-      const secondCall = (
-        client as { messages: { create: ReturnType<typeof vi.fn> } }
-      ).messages.create.mock.calls[1]?.[0] as {
-        messages: { content: [{ content: string }] }[];
+      const secondCall = complete.mock.calls[1]?.[0] as {
+        messages: { content: string }[];
       };
-      expect(secondCall.messages[2]?.content[0]?.content).toContain(
-        'ran successfully',
-      );
+      expect(secondCall.messages[3]?.content).toContain('ran successfully');
     });
 
     it('records diagnostics as validation failures', async () => {
@@ -227,14 +264,14 @@ describe('runAgentLoop', () => {
           ],
         },
       });
-      const client = fakeClient([
+      const complete = fakeComplete([
         toolResponse('validate_query', { sql: 'SELECT nope FROM runs' }),
         textResponse('done'),
       ]);
       const res = await runAgentLoop({
         ...baseArgs({ tools: [validateTool] }),
         step: step as never,
-        client,
+        complete,
       });
 
       expect(res.validationAttempts).toBe(1);
@@ -250,7 +287,7 @@ describe('runAgentLoop', () => {
     it('treats a hallucinated validate_query call as an unknown tool when not offered', async () => {
       const step = fakeStep();
       const publish = vi.fn(async () => {});
-      const client = fakeClient([
+      const complete = fakeComplete([
         toolResponse('validate_query', { sql: 'SELECT 1' }),
         textResponse('done'),
       ]);
@@ -258,7 +295,7 @@ describe('runAgentLoop', () => {
       const res = await runAgentLoop({
         ...baseArgs({ tools: [echoTool] }),
         step: step as never,
-        client,
+        complete,
         publish,
       });
 
@@ -266,37 +303,31 @@ describe('runAgentLoop', () => {
       expect(step.waitForEvent).not.toHaveBeenCalled();
       expect(res.validationAttempts).toBe(0);
 
-      const secondCall = (
-        client as { messages: { create: ReturnType<typeof vi.fn> } }
-      ).messages.create.mock.calls[1]?.[0] as {
-        messages: { content: [{ content: string }] }[];
+      const secondCall = complete.mock.calls[1]?.[0] as {
+        messages: { content: string }[];
       };
-      expect(secondCall.messages[2]?.content[0]?.content).toContain(
+      expect(secondCall.messages[3]?.content).toContain(
         'Unknown tool: validate_query',
       );
     });
 
     it('degrades gracefully when no validation result arrives (timeout)', async () => {
       const step = fakeStep(null);
-      const client = fakeClient([
+      const complete = fakeComplete([
         toolResponse('validate_query', { sql: 'SELECT 1' }),
         textResponse('done'),
       ]);
       const res = await runAgentLoop({
         ...baseArgs({ tools: [validateTool] }),
         step: step as never,
-        client,
+        complete,
       });
 
       expect(res.validationFailures).toEqual([]);
-      const secondCall = (
-        client as { messages: { create: ReturnType<typeof vi.fn> } }
-      ).messages.create.mock.calls[1]?.[0] as {
-        messages: { content: [{ content: string }] }[];
+      const secondCall = complete.mock.calls[1]?.[0] as {
+        messages: { content: string }[];
       };
-      expect(secondCall.messages[2]?.content[0]?.content).toContain(
-        'unavailable',
-      );
+      expect(secondCall.messages[3]?.content).toContain('unavailable');
     });
   });
 });

--- a/ui/apps/dashboard/src/lib/inngest/functions/agent/loop.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agent/loop.ts
@@ -1,20 +1,51 @@
-import type Anthropic from '@anthropic-ai/sdk';
-
 // The think→act→observe loop behind the Insights agent, ported from
 // inngest-agents (packages/agent-core/src/loop.ts). Each LLM call and tool
 // call is a durable Inngest step; the loop ends when the model responds with
 // text and no tool calls.
+//
+// Wire format is OpenAI chat completions, which OpenRouter speaks natively.
 
 export const VALIDATE_QUERY = 'validate_query';
 export const VALIDATION_COMPLETED_EVENT = 'insights-agent/validation.completed';
 
-export type AgentMessage = Anthropic.MessageParam;
+export interface ToolCall {
+  id: string;
+  type: 'function';
+  /** JSON-encoded arguments object. */
+  function: { name: string; arguments: string };
+}
 
-export type AnthropicTool = {
+export type AgentMessage =
+  | { role: 'system' | 'user'; content: string }
+  | { role: 'assistant'; content: string | null; tool_calls?: ToolCall[] }
+  | { role: 'tool'; tool_call_id: string; content: string };
+
+/** JSON Schema tool definition, translated to the wire format by the loop. */
+export type ToolSpec = {
   name: string;
   description: string;
   input_schema: { type: 'object'; [k: string]: unknown };
 };
+
+interface ChatTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+export interface ChatCompletion {
+  choices: {
+    message: {
+      role: 'assistant';
+      content: string | null;
+      tool_calls?: ToolCall[];
+    };
+  }[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number; cost?: number };
+}
 
 export interface InsightsClientState {
   eventTypes?: string[];
@@ -44,7 +75,7 @@ export interface ToolOutcome {
 }
 
 export interface ToolDef {
-  tool: AnthropicTool;
+  tool: ToolSpec;
   execute: (
     input: Record<string, unknown>,
     ctx: ToolContext,
@@ -72,6 +103,8 @@ export interface AgentLoopResult {
   toolCalls: number;
   tokensIn: number;
   tokensOut: number;
+  // Summed usage.cost, which OpenRouter reports on every response.
+  costUsd: number;
   validationAttempts: number;
   validationFailures: ValidationFailure[];
 }
@@ -88,8 +121,11 @@ interface StepTools {
 
 interface RunAgentLoopArgs {
   step: StepTools;
-  client: Anthropic;
-  model: string;
+  complete: (body: {
+    messages: AgentMessage[];
+    tools: ChatTool[];
+    max_tokens: number;
+  }) => Promise<ChatCompletion>;
   system: string;
   messages: AgentMessage[];
   tools: ToolDef[];
@@ -111,30 +147,43 @@ interface RunAgentLoopArgs {
 const FINAL_ITERATION_NUDGE =
   '[SYSTEM: This is your final iteration. If you have a query ready, call submit_query then summarize; otherwise answer or ask your clarifying question now. Do not call any other tools.]';
 
+// Degrades to no input rather than throwing, so a malformed call surfaces as the
+// tool's own validation error instead of burning the run's retries.
+export function parseToolArguments(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw || '{}');
+    return typeof parsed === 'object' && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
 export async function runAgentLoop(
   args: RunAgentLoopArgs,
 ): Promise<AgentLoopResult> {
-  const {
-    step,
-    client,
-    model,
-    system,
-    tools,
-    ctx,
-    draft,
-    publish,
-    runId,
-    userId,
-  } = args;
+  const { step, complete, system, tools, ctx, draft, publish, runId, userId } =
+    args;
   const maxIterations = args.maxIterations ?? 12;
-  const messages: AgentMessage[] = [...args.messages];
+  const messages: AgentMessage[] = [
+    { role: 'system', content: system },
+    ...args.messages,
+  ];
   const registry = new Map(tools.map((t) => [t.tool.name, t]));
+  const chatTools: ChatTool[] = tools.map((t) => ({
+    type: 'function',
+    function: {
+      name: t.tool.name,
+      description: t.tool.description,
+      parameters: t.tool.input_schema,
+    },
+  }));
 
   let iterations = 0;
   let toolCalls = 0;
   let summary = '';
   let tokensIn = 0;
   let tokensOut = 0;
+  let costUsd = 0;
   let validationAttempts = 0;
   const validationFailures: ValidationFailure[] = [];
 
@@ -152,43 +201,42 @@ export async function runAgentLoop(
     // A thrown LLM call fails this attempt and Inngest retries the step; if all
     // retries exhaust, the run fails and onFailure reports it to the UI.
     const response = (await step.run(`think-${iterations}`, () =>
-      client.messages.create({
-        model,
-        max_tokens: 4096,
-        system,
+      complete({
         messages: turnMessages,
-        tools: tools.map((t) => t.tool) as Anthropic.Messages.Tool[],
+        tools: chatTools,
+        max_tokens: 4096,
       }),
-    )) as Anthropic.Message;
+    )) as ChatCompletion;
 
-    tokensIn += response.usage?.input_tokens ?? 0;
-    tokensOut += response.usage?.output_tokens ?? 0;
+    tokensIn += response.usage?.prompt_tokens ?? 0;
+    tokensOut += response.usage?.completion_tokens ?? 0;
+    costUsd += response.usage?.cost ?? 0;
 
-    const toolUses = response.content.filter(
-      (block): block is Anthropic.ToolUseBlock => block.type === 'tool_use',
-    );
-    const text = response.content
-      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
-      .map((block) => block.text)
-      .join('\n');
+    const message = response.choices[0]?.message;
+    const requestedCalls = message?.tool_calls ?? [];
+    const text = message?.content ?? '';
 
     if (text) {
       summary = text;
     }
-    if (toolUses.length === 0) {
+    if (requestedCalls.length === 0) {
       break;
     }
 
-    // The assistant turn must round-trip verbatim so tool_use ids match.
-    messages.push({ role: 'assistant', content: response.content });
+    // The assistant turn must round-trip verbatim so tool_call ids match.
+    messages.push({
+      role: 'assistant',
+      content: message?.content ?? null,
+      tool_calls: requestedCalls,
+    });
 
-    const toolResults: Anthropic.ToolResultBlockParam[] = [];
-    for (const toolUse of toolUses) {
+    for (const call of requestedCalls) {
       toolCalls++;
-      const input = (toolUse.input ?? {}) as Record<string, unknown>;
+      const input = parseToolArguments(call.function.arguments);
+      const name = call.function.name;
 
       let outcome: ToolOutcome;
-      if (toolUse.name === VALIDATE_QUERY && registry.has(VALIDATE_QUERY)) {
+      if (name === VALIDATE_QUERY && registry.has(VALIDATE_QUERY)) {
         // Validation uses durable primitives that can't nest inside step.run;
         // the registry check drops hallucinated calls when the tool wasn't offered.
         validationAttempts++;
@@ -203,13 +251,12 @@ export async function runAgentLoop(
           validationFailures,
         });
       } else {
-        const def = registry.get(toolUse.name);
+        const def = registry.get(name);
         outcome = def
-          ? ((await step.run(
-              `tool-${toolUse.name}-${iterations}-${toolCalls}`,
-              () => def.execute(input, ctx),
+          ? ((await step.run(`tool-${name}-${iterations}-${toolCalls}`, () =>
+              def.execute(input, ctx),
             )) as ToolOutcome)
-          : { observation: `Unknown tool: ${toolUse.name}` };
+          : { observation: `Unknown tool: ${name}` };
       }
 
       // Effects are applied here, outside the memoized step (see ToolOutcome).
@@ -222,13 +269,12 @@ export async function runAgentLoop(
         );
       }
 
-      toolResults.push({
-        type: 'tool_result',
-        tool_use_id: toolUse.id,
+      messages.push({
+        role: 'tool',
+        tool_call_id: call.id,
         content: outcome.observation,
       });
     }
-    messages.push({ role: 'user', content: toolResults });
   }
 
   return {
@@ -237,6 +283,7 @@ export async function runAgentLoop(
     toolCalls,
     tokensIn,
     tokensOut,
+    costUsd,
     validationAttempts,
     validationFailures,
   };

--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -57,8 +57,9 @@ async function chatCompletion(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      model: OPENROUTER_MODEL_IDS[model] ?? model,
       ...body,
+      // Last so the resolved model always wins over a stray `model` in `body`.
+      model: OPENROUTER_MODEL_IDS[model] ?? model,
     }),
   });
   if (!res.ok) {

--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -1,12 +1,13 @@
-import Anthropic from '@anthropic-ai/sdk';
-import { anthropic, experiment } from 'inngest';
+import { experiment } from 'inngest';
 import { createScorer } from 'inngest/experimental';
 import { v4 as uuidv4 } from 'uuid';
 
 import { inngest } from '../client';
 import { insightsChannel } from '../realtime';
 import {
+  parseToolArguments,
   runAgentLoop,
+  type ChatCompletion,
   type InsightsClientState,
   type QueryDraft,
 } from './agent/loop';
@@ -33,12 +34,40 @@ type ChatEventData = {
   canValidate?: boolean;
 };
 
-// Anthropic API pricing per 1M tokens (hardcoded for now).
-const PRICING: Record<string, { inputPerMTok: number; outputPerMTok: number }> =
-  {
-    'claude-sonnet-4-5': { inputPerMTok: 3, outputPerMTok: 15 },
-    'claude-opus-4-8': { inputPerMTok: 5, outputPerMTok: 25 },
-  };
+// All LLM calls route through OpenRouter. Requires OPENROUTER_API_KEY.
+const OPENROUTER_CHAT_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+// Internal model ids, kept stable for pricing and experiment attribution, mapped
+// to the OpenRouter slugs the API expects.
+const OPENROUTER_MODEL_IDS: Record<string, string> = {
+  'claude-opus-5': 'anthropic/claude-opus-5',
+  'glm-5.2': 'z-ai/glm-5.2',
+  'claude-haiku-4-5': 'anthropic/claude-haiku-4.5',
+};
+
+// Throws on a non-2xx response so the enclosing step.run retries.
+async function chatCompletion(
+  model: string,
+  body: Record<string, unknown>,
+): Promise<ChatCompletion> {
+  const res = await fetch(OPENROUTER_CHAT_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.OPENROUTER_API_KEY ?? ''}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: OPENROUTER_MODEL_IDS[model] ?? model,
+      ...body,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `OpenRouter request failed (${res.status}): ${await res.text()}`,
+    );
+  }
+  return (await res.json()) as ChatCompletion;
+}
 
 // Deferred LLM-as-judge, run after the parent run finalizes. Two modes:
 // - SQL produced → insights_judge_relevance: how well the query fits the chat
@@ -71,44 +100,45 @@ export const insightsJudgeScorer = createScorer(
       ? `User chat context:\n${chatContext}\n\nGenerated SQL:\n${sql}`
       : `User chat context:\n${chatContext}\n\nAssistant response (no SQL):\n${summary}`;
 
-    const result = await step.ai.infer('judge-relevance', {
-      model: anthropic({
-        model: 'claude-haiku-4-5',
-        defaultParameters: { max_tokens: 1024 },
-      }),
-      body: {
-        system,
-        messages: [{ role: 'user' as const, content }],
+    const result = (await step.run('judge-relevance', () =>
+      chatCompletion('claude-haiku-4-5', {
+        max_tokens: 1024,
+        messages: [
+          { role: 'system', content: system },
+          { role: 'user', content },
+        ],
         tools: [
           {
-            name: 'submit_score' as const,
-            description: 'Submit the relevance score for the generated SQL.',
-            input_schema: {
-              type: 'object' as const,
-              properties: {
-                relevance: {
-                  type: 'number',
-                  description:
-                    'How well the SQL fits the user request, 0 to 1.',
+            type: 'function',
+            function: {
+              name: 'submit_score',
+              description: 'Submit the relevance score for the generated SQL.',
+              parameters: {
+                type: 'object',
+                properties: {
+                  relevance: {
+                    type: 'number',
+                    description:
+                      'How well the SQL fits the user request, 0 to 1.',
+                  },
                 },
+                required: ['relevance'],
               },
-              required: ['relevance'],
             },
           },
         ],
-        tool_choice: { type: 'tool' as const, name: 'submit_score' },
-      },
-    });
+        tool_choice: { type: 'function', function: { name: 'submit_score' } },
+      }),
+    )) as ChatCompletion;
 
-    const toolUse = (
-      result as {
-        content: Array<{ type: string; name?: string; input?: unknown }>;
-      }
-    ).content.find(
-      (block) => block.type === 'tool_use' && block.name === 'submit_score',
+    const toolCall = result.choices[0]?.message.tool_calls?.find(
+      (c) => c.function.name === 'submit_score',
     );
-    const relevance = (toolUse?.input as { relevance?: number } | undefined)
-      ?.relevance;
+    const relevance = toolCall
+      ? (parseToolArguments(toolCall.function.arguments).relevance as
+          | number
+          | undefined)
+      : undefined;
 
     return {
       name: sql
@@ -192,14 +222,13 @@ export const runInsightsAgent = inngest.createFunction(
       'query-writer-model',
       {
         variants: {
-          'claude-sonnet-4-5': () =>
-            step.run('select-model', () => 'claude-sonnet-4-5'),
-          'claude-opus-4-8': () =>
-            step.run('select-model', () => 'claude-opus-4-8'),
+          'claude-opus-5': () =>
+            step.run('select-model', () => 'claude-opus-5'),
+          'glm-5.2': () => step.run('select-model', () => 'glm-5.2'),
         },
         select: experiment.weighted({
-          'claude-sonnet-4-5': 50,
-          'claude-opus-4-8': 50,
+          'claude-opus-5': 50,
+          'glm-5.2': 50,
         }),
       },
     );
@@ -226,8 +255,7 @@ export const runInsightsAgent = inngest.createFunction(
 
     const result = await runAgentLoop({
       step,
-      client: new Anthropic(),
-      model,
+      complete: (body) => chatCompletion(model, body),
       system: buildSystemPrompt({ currentQuery: clientState.currentQuery }),
       messages: [
         ...historyMessages,
@@ -252,11 +280,6 @@ export const runInsightsAgent = inngest.createFunction(
     });
 
     const latencyMs = Date.now() - startedAt;
-    const pricing = PRICING[model];
-    const costUsd = pricing
-      ? (result.tokensIn / 1_000_000) * pricing.inputPerMTok +
-        (result.tokensOut / 1_000_000) * pricing.outputPerMTok
-      : 0;
 
     await step.run('emit-scores', async () => {
       // .experiment() tags each score with its variant; runId writes them to the run span, one clean row per run.
@@ -274,7 +297,7 @@ export const runInsightsAgent = inngest.createFunction(
       });
       await inngest.score.experiment({
         name: 'query_writer_cost_usd',
-        value: costUsd,
+        value: result.costUsd,
         experiment: experimentRef,
         runId,
       });


### PR DESCRIPTION
## Description

- refactor insights ai to use open router
- update experiment to opus 5 vs glm 5.2
- source cost directly from open router (yay! 🥳)

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
