### PR TITLE
fix: race creating workflow and checkpointing durable endpoint step

### DIFF
--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -240,6 +240,7 @@ func (a checkpointAPI) CheckpointNewRun(w http.ResponseWriter, r *http.Request) 
 			EnvID:     auth.WorkspaceID(),
 			Steps:     input.Steps,
 			Metadata:  md,
+			Function:  &fn,
 		})
 		if err != nil {
 			logger.StdlibLogger(ctx).Error("error checkpointing sync steps", "error", err)

--- a/pkg/connect/service.go
+++ b/pkg/connect/service.go
@@ -453,6 +453,14 @@ func (c *connectGatewaySvc) Run(ctx context.Context) error {
 		Handler: c.gatewayRoutes,
 	}
 
+	grpcAddr := fmt.Sprintf(":%d", c.grpcConfig.Gateway.Port)
+	grpcListener, err := net.Listen("tcp", grpcAddr)
+	if err != nil {
+		c.logger.Error("could not listen for connect gateway grpc", "error", err, "addr", grpcAddr)
+		return fmt.Errorf("could not listen for connect gateway grpc: %w", err)
+	}
+	c.logger.Info("starting connect gateway grpc server", "addr", grpcAddr)
+
 	go func() {
 		<-ctx.Done()
 
@@ -486,14 +494,7 @@ func (c *connectGatewaySvc) Run(ctx context.Context) error {
 	})
 
 	eg.Go(func() error {
-		addr := fmt.Sprintf(":%d", c.grpcConfig.Gateway.Port)
-
-		l, err := net.Listen("tcp", addr)
-		if err != nil {
-			return fmt.Errorf("could not listen for: %w", err)
-		}
-		logger.StdlibLogger(ctx).Info("starting connect gateway grpc server", "addr", addr)
-		return c.grpcServer.Serve(l)
+		return c.grpcServer.Serve(grpcListener)
 	})
 
 	if !c.isDraining.Load() {

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -152,11 +152,14 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 
 	l := logger.StdlibLogger(ctx).With("run_id", input.Metadata.ID.RunID)
 
-	// Load the function config.
-	fn, err := c.fn(ctx, input.Metadata.ID.FunctionID)
-	if err != nil {
-		logger.StdlibLogger(ctx).Warn("error loading fn for background checkpoint steps", "error", err)
-		return err
+	fn := input.Function
+	if fn == nil {
+		var err error
+		fn, err = c.fn(ctx, input.Metadata.ID.FunctionID)
+		if err != nil {
+			logger.StdlibLogger(ctx).Warn("error loading fn for background checkpoint steps", "error", err)
+			return err
+		}
 	}
 
 	runCtx := c.runContext(*input.Metadata, fn)

--- a/pkg/execution/checkpoint/types.go
+++ b/pkg/execution/checkpoint/types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -23,6 +24,9 @@ type SyncCheckpoint struct {
 	// Optional metadata.  If not provided this will be loaded.
 	// This is never exposed via JSON, as this type us unmarshalled.
 	Metadata *state.Metadata `json:"-"`
+
+	// Optional function. When set, CheckpointSyncSteps skips loading it from the DB.
+	Function *inngest.Function `json:"-"`
 }
 
 func (s SyncCheckpoint) ID() state.ID {


### PR DESCRIPTION
## Description
The workflow creation happens async and if it's slower than the run
checkpointing, it basically fails.
https://github.com/inngest/inngest/blob/d2f0381f82ce35d5495fa7f402eea0aab08ce669/pkg/api/apiv1/checkpoint.go#L176-L181


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
