### PR TITLE
fix(executor): recover from panics in event lifecycle listeners

### DIFF
--- a/pkg/execution/executor/evt_lifecycle_panic_test.go
+++ b/pkg/execution/executor/evt_lifecycle_panic_test.go
@@ -1,0 +1,66 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/logger"
+)
+
+func TestRunEventLifecyclesRecoversFromListenerPanic(t *testing.T) {
+	panicking := &panickingEventLifecycle{called: make(chan struct{}, 2)}
+	healthy := &recordingEventLifecycle{called: make(chan struct{}, 2)}
+
+	e := &executor{
+		log:           logger.From(context.Background()),
+		evtLifecycles: []execution.EventLifecycleListener{panicking, healthy},
+	}
+
+	e.runEventLifecycles(context.Background(), func(ctx context.Context, l execution.EventLifecycleListener) {
+		l.OnNoFunctionMatch(ctx, nil)
+	})
+
+	waitForLifecycleCall(t, panicking.called, "panicking listener")
+	waitForLifecycleCall(t, healthy.called, "healthy listener")
+
+	// A panic in one listener must not affect subsequent lifecycle runs.
+	e.runEventLifecycles(context.Background(), func(ctx context.Context, l execution.EventLifecycleListener) {
+		l.OnNoFunctionMatch(ctx, nil)
+	})
+
+	waitForLifecycleCall(t, panicking.called, "panicking listener second run")
+	waitForLifecycleCall(t, healthy.called, "healthy listener second run")
+}
+
+func waitForLifecycleCall(t *testing.T, ch chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+type panickingEventLifecycle struct {
+	execution.NoopEventLifecycleListener
+
+	called chan struct{}
+}
+
+func (l *panickingEventLifecycle) OnNoFunctionMatch(context.Context, event.TrackedEvent) {
+	l.called <- struct{}{}
+	panic("event lifecycle listener panic")
+}
+
+type recordingEventLifecycle struct {
+	execution.NoopEventLifecycleListener
+
+	called chan struct{}
+}
+
+func (l *recordingEventLifecycle) OnNoFunctionMatch(context.Context, event.TrackedEvent) {
+	l.called <- struct{}{}
+}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -592,6 +592,18 @@ func (e *executor) runEventLifecycles(ctx context.Context, fn func(context.Conte
 	for _, l := range e.evtLifecycles {
 		l := l
 		service.Go(func() {
+			// Event lifecycle listeners are observability side effects
+			// (metrics, exporters); a panicking implementation must never
+			// crash scheduling or the service.
+			defer func() {
+				if r := recover(); r != nil {
+					e.log.Error(
+						"panic in event lifecycle listener",
+						"error", r,
+						"stack", string(debug.Stack()),
+					)
+				}
+			}()
 			fn(ctx, l)
 		})
 	}


### PR DESCRIPTION
## Description

Event lifecycle listeners are observability side effects (metrics, exporters) that should never crash the scheduler or service. This change adds panic recovery to `runEventLifecycles` to ensure that a panicking listener implementation cannot affect scheduling or subsequent lifecycle calls.

The fix wraps each listener invocation in a defer block that recovers from panics, logs the error with stack trace, and allows execution to continue. This ensures all registered listeners are called even if one panics, and the service remains stable.

## Release note

None.

## Migration note

None.

## Test Plan

Added `TestRunEventLifecyclesRecoversFromListenerPanic` which verifies that:
- A panicking listener is called and its panic is recovered
- Subsequent listeners are still called despite the panic
- Multiple invocations of `runEventLifecycles` work correctly even after a panic

https://claude.ai/code/session_01P33HC2LRVTGmbdkEwUYEMu