### PR TITLE
fix(epxressions):  add support for falsy terns

### DIFF
--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -1185,6 +1185,23 @@ func TestEvaluateExpression(t *testing.T) {
 	}
 }
 
+func TestEvaluateTernaryWithMissingConditionField(t *testing.T) {
+	result, err := Evaluate(
+		context.Background(),
+		"event.data.primaryCandidateId ? event.data.primaryCandidateId : event.data.candidateId",
+		map[string]interface{}{
+			"event": map[string]interface{}{
+				"data": map[string]interface{}{
+					"candidateId": "candidate-123",
+				},
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "candidate-123", result)
+}
+
 func TestFilteredAttributes(t *testing.T) {
 	tests := []struct {
 		expr     string

--- a/pkg/expressions/unknown.go
+++ b/pkg/expressions/unknown.go
@@ -20,6 +20,10 @@ import (
 // cached for the lifetime of the expression rather than rebuilt on every evaluation.
 func unknownDecorator() interpreter.InterpretableDecorator {
 	return func(i interpreter.Interpretable) (interpreter.Interpretable, error) {
+		if wrapConditionalCondition(i) {
+			return i, nil
+		}
+
 		// Handle logical OR/AND nodes.  CEL represents || and && as special
 		// evalOr/evalAnd (or evalExhaustiveOr/evalExhaustiveAnd) structs that
 		// are NOT InterpretableCall.  They require boolean operands, but users
@@ -38,6 +42,44 @@ func unknownDecorator() interpreter.InterpretableDecorator {
 
 		return &runtimeUnknownCall{InterpretableCall: call}, nil
 	}
+}
+
+func wrapConditionalCondition(i interpreter.Interpretable) bool {
+	attr, ok := i.(interpreter.InterpretableAttribute)
+	if !ok {
+		return false
+	}
+
+	conditional := reflect.ValueOf(attr.Attr())
+	if conditional.Kind() != reflect.Pointer || !strings.Contains(conditional.Type().String(), "conditionalAttribute") {
+		return false
+	}
+
+	conditionField := conditional.Elem().FieldByName("expr")
+	if !conditionField.IsValid() {
+		return false
+	}
+
+	condition := *(*interpreter.Interpretable)(unsafe.Pointer(conditionField.UnsafeAddr()))
+	*(*interpreter.Interpretable)(unsafe.Pointer(conditionField.UnsafeAddr())) = &evalTruthyCondition{
+		inner: condition,
+	}
+	return true
+}
+
+type evalTruthyCondition struct {
+	inner interpreter.Interpretable
+}
+
+func (e *evalTruthyCondition) ID() int64 {
+	return e.inner.ID()
+}
+
+func (e *evalTruthyCondition) Eval(ctx interpreter.Activation) ref.Val {
+	if isTruthy(e.inner.Eval(ctx)) {
+		return types.True
+	}
+	return types.False
 }
 
 // runtimeUnknownCall wraps an InterpretableCall and applies the same unknown/null/coercion

--- a/pkg/expressions/unknown_test.go
+++ b/pkg/expressions/unknown_test.go
@@ -500,6 +500,65 @@ func TestTruthyLogicalCoercion(t *testing.T) {
 	}
 }
 
+func TestTruthyConditionalCoercion(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		data     map[string]interface{}
+		expected string
+	}{
+		{
+			name:     "missing field selects the falsy branch",
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{}}},
+			expected: "falsy",
+		},
+		{
+			name:     "null field selects the falsy branch",
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"value": nil}}},
+			expected: "falsy",
+		},
+		{
+			name:     "false selects the falsy branch",
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"value": false}}},
+			expected: "falsy",
+		},
+		{
+			name:     "empty string selects the falsy branch",
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"value": ""}}},
+			expected: "falsy",
+		},
+		{
+			name:     "integer zero selects the falsy branch",
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"value": 0}}},
+			expected: "falsy",
+		},
+		{
+			name:     "double zero selects the falsy branch",
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"value": 0.0}}},
+			expected: "falsy",
+		},
+		{
+			name:     "true selects the truthy branch",
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"value": true}}},
+			expected: "truthy",
+		},
+		{
+			name:     "nonempty string selects the truthy branch",
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"value": "candidate-123"}}},
+			expected: "truthy",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := Evaluate(ctx, `event.data.value ? "truthy" : "falsy"`, test.data)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
 // TestMacrosWithUnknowns tests that macros (exists, all) handle unknowns correctly.
 // The key invariant: lambda variables produce "no such attribute" errors which must
 // pass through the decorator unchanged, not be treated as unknown call failures.


### PR DESCRIPTION
this commit adds full support for dynamic typing of false/empty/null and missing event data in ternary expressions without needing the `has` macro
