### PR TITLE
internal(queue): warn and count dropped retries on missing queue item

### DIFF
--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -484,26 +484,36 @@ func (q *queueProcessor) ProcessItem(
 			if requeueErr := q.Requeue(context.WithoutCancel(ctx), shard.Name(), requeueItem, at); requeueErr != nil {
 				if requeueErr == ErrQueueItemNotFound {
 					// The item is gone, so there is nothing to requeue and this retry is
-					// dropped.  That is benign when finalize() legitimately dequeued the
-					// item (cancellations, parallelism) and the run is already terminal.
+					// dropped.
 					//
-					// It is NOT benign if the run is still live: nothing remains to drive
-					// it to a terminal state, so it stays non-terminal and holds its
-					// function concurrency capacity until it is cancelled by hand.
+					// A cancelled run is the expected, high-volume case: Finalize()
+					// dequeues the run's jobs, and the in-flight job then returns
+					// ErrFunctionCancelled, which ShouldRetry treats as retryable because
+					// it is a plain error.  The run is already terminal, so dropping the
+					// retry is correct.  Count it, but do not log it -- this fires on
+					// every cancellation that catches a job in flight.
 					//
-					// We cannot cheaply tell those cases apart here, so record the
-					// occurrence instead of returning silently.
-					l.Warn("dropped retry; queue item not found on requeue",
-						"cause", err,
-						"next_attempt", qi.Data.Attempt,
-						"max_attempts", qi.Data.GetMaxAttempts(),
-						"lease_id", requeueItem.LeaseID,
-						"requeue_at", at,
-					)
+					// Any other cause is suspicious: if the run is still live, nothing
+					// remains to drive it to a terminal state, so it stays non-terminal
+					// and holds its function concurrency capacity until cancelled by
+					// hand.  We cannot cheaply confirm liveness here, so warn and let the
+					// metric split show how often each case occurs.
+					status := "requeue_item_missing"
+					if errors.Is(err, state.ErrFunctionCancelled) {
+						status = "requeue_item_missing_cancelled"
+					} else {
+						l.Warn("dropped retry; queue item not found on requeue",
+							"cause", err,
+							"next_attempt", qi.Data.Attempt,
+							"max_attempts", qi.Data.GetMaxAttempts(),
+							"lease_id", requeueItem.LeaseID,
+							"requeue_at", at,
+						)
+					}
 					metrics.IncrQueueItemStatusCounter(ctx, metrics.CounterOpt{
 						PkgName: pkgName,
 						Tags: map[string]any{
-							"status":      "requeue_item_missing",
+							"status":      status,
 							"queue_shard": shard.Name(),
 						},
 					})

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -490,18 +490,13 @@ func (q *queueProcessor) ProcessItem(
 					// dequeues the run's jobs, and the in-flight job then returns
 					// ErrFunctionCancelled, which ShouldRetry treats as retryable because
 					// it is a plain error.  The run is already terminal, so dropping the
-					// retry is correct.  Count it, but do not log it -- this fires on
+					// retry is correct and not worth logging -- it would emit a line for
 					// every cancellation that catches a job in flight.
 					//
 					// Any other cause is suspicious: if the run is still live, nothing
 					// remains to drive it to a terminal state, so it stays non-terminal
-					// and holds its function concurrency capacity until cancelled by
-					// hand.  We cannot cheaply confirm liveness here, so warn and let the
-					// metric split show how often each case occurs.
-					status := "requeue_item_missing"
-					if errors.Is(err, state.ErrFunctionCancelled) {
-						status = "requeue_item_missing_cancelled"
-					} else {
+					// and holds its function concurrency capacity until cancelled by hand.
+					if !errors.Is(err, state.ErrFunctionCancelled) {
 						l.Warn("dropped retry; queue item not found on requeue",
 							"cause", err,
 							"next_attempt", qi.Data.Attempt,
@@ -510,13 +505,6 @@ func (q *queueProcessor) ProcessItem(
 							"requeue_at", at,
 						)
 					}
-					metrics.IncrQueueItemStatusCounter(ctx, metrics.CounterOpt{
-						PkgName: pkgName,
-						Tags: map[string]any{
-							"status":      status,
-							"queue_shard": shard.Name(),
-						},
-					})
 					return ProcessItemResult{}, nil
 				}
 

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -481,14 +481,37 @@ func (q *queueProcessor) ProcessItem(
 
 			qi.AtMS = at.UnixMilli()
 			requeueItem := itemWithCurrentLease(qi)
-			if err := q.Requeue(context.WithoutCancel(ctx), shard.Name(), requeueItem, at); err != nil {
-				if err == ErrQueueItemNotFound {
-					// Safe. The executor may have dequeued.
+			if requeueErr := q.Requeue(context.WithoutCancel(ctx), shard.Name(), requeueItem, at); requeueErr != nil {
+				if requeueErr == ErrQueueItemNotFound {
+					// The item is gone, so there is nothing to requeue and this retry is
+					// dropped.  That is benign when finalize() legitimately dequeued the
+					// item (cancellations, parallelism) and the run is already terminal.
+					//
+					// It is NOT benign if the run is still live: nothing remains to drive
+					// it to a terminal state, so it stays non-terminal and holds its
+					// function concurrency capacity until it is cancelled by hand.
+					//
+					// We cannot cheaply tell those cases apart here, so record the
+					// occurrence instead of returning silently.
+					l.Warn("dropped retry; queue item not found on requeue",
+						"cause", err,
+						"next_attempt", qi.Data.Attempt,
+						"max_attempts", qi.Data.GetMaxAttempts(),
+						"lease_id", requeueItem.LeaseID,
+						"requeue_at", at,
+					)
+					metrics.IncrQueueItemStatusCounter(ctx, metrics.CounterOpt{
+						PkgName: pkgName,
+						Tags: map[string]any{
+							"status":      "requeue_item_missing",
+							"queue_shard": shard.Name(),
+						},
+					})
 					return ProcessItemResult{}, nil
 				}
 
-				l.Error("error requeuing job", "error", err, "item", requeueItem)
-				return ProcessItemResult{}, err
+				l.Error("error requeuing job", "error", requeueErr, "item", requeueItem)
+				return ProcessItemResult{}, requeueErr
 			}
 			if _, ok := err.(QuitError); ok {
 				q.quit <- err


### PR DESCRIPTION


## Description

- I'm trying to investigate [this plain ticket](https://app.plain.com/workspace/w_01H5R1F69XQ35G4P7THFQGN5KB/thread/th_01KY0QP89210PRA65NPFGGDEP7/), where we hit requeueing problems
- It would be much easier some more logs, let's add them in

<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
