### PR TITLE
feat(ui): nudge metadata usage in run details

### DIFF
--- a/ui/apps/dashboard/src/utils/urls.ts
+++ b/ui/apps/dashboard/src/utils/urls.ts
@@ -50,6 +50,9 @@ export const pathCreator = {
   dashboard({ envSlug }: { envSlug: string }) {
     return `/env/${envSlug}/`;
   },
+  aiOverview({ envSlug }: { envSlug: string }) {
+    return `/env/${envSlug}/ai-overview`;
+  },
   apps({ envSlug }: { envSlug: string }) {
     return `/env/${envSlug}/apps`;
   },

--- a/ui/apps/dashboard/src/utils/usePathCreator.ts
+++ b/ui/apps/dashboard/src/utils/usePathCreator.ts
@@ -9,6 +9,7 @@ export const usePathCreator = () => {
 
   const pathCreator = useMemo((): PathCreator => {
     return {
+      aiOverview: () => internalPathCreator.aiOverview({ envSlug: env.slug }),
       app: (params: { externalAppID: string }) =>
         internalPathCreator.app({
           envSlug: env.slug,

--- a/ui/packages/components/src/RunDetailsV4/AIMetadata.test.tsx
+++ b/ui/packages/components/src/RunDetailsV4/AIMetadata.test.tsx
@@ -1,7 +1,38 @@
-import { describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { traceHasAIMetadata } from './AIMetadata';
+import { AIMetadataNudge, traceHasAIMetadata } from './AIMetadata';
 import type { SpanMetadata, Trace } from './types';
+
+const booleanFlagMock = vi.hoisted(() => vi.fn());
+const pathCreatorMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../SharedContext/useBooleanFlag', () => ({
+  useBooleanFlag: () => ({ booleanFlag: booleanFlagMock }),
+}));
+
+vi.mock('../SharedContext/usePathCreator', () => ({
+  usePathCreator: () => ({ pathCreator: pathCreatorMock() }),
+}));
+
+const renderNudge = ({
+  aiOverviewEnabled,
+  hasAIOverviewPath = true,
+}: {
+  aiOverviewEnabled: boolean;
+  hasAIOverviewPath?: boolean;
+}) => {
+  booleanFlagMock.mockReturnValue({ isReady: true, value: aiOverviewEnabled });
+  pathCreatorMock.mockReturnValue(
+    hasAIOverviewPath ? { aiOverview: () => '/env/prod/ai-overview' } : {}
+  );
+
+  render(<AIMetadataNudge />);
+};
+
+afterEach(() => {
+  cleanup();
+});
 
 const makeSpan = (overrides: Partial<Trace> = {}): Trace => ({
   attempts: 0,
@@ -53,5 +84,36 @@ describe('traceHasAIMetadata', () => {
     });
 
     expect(traceHasAIMetadata(trace)).toBe(false);
+  });
+});
+
+describe('AIMetadataNudge', () => {
+  it('always offers the documentation links', () => {
+    renderNudge({ aiOverviewEnabled: false });
+
+    expect(screen.getByRole('link', { name: 'Set up AI metadata' }).getAttribute('href')).toContain(
+      '/docs/examples/ai-metadata-quickstart'
+    );
+    expect(screen.getByRole('link', { name: 'Add custom metadata' })).toBeTruthy();
+  });
+
+  it('links to the AI Overview when the dashboard is enabled', () => {
+    renderNudge({ aiOverviewEnabled: true });
+
+    expect(screen.getByRole('link', { name: 'View AI Overview' }).getAttribute('href')).toBe(
+      '/env/prod/ai-overview'
+    );
+  });
+
+  it('omits the AI Overview link when the dashboard is disabled', () => {
+    renderNudge({ aiOverviewEnabled: false });
+
+    expect(screen.queryByRole('link', { name: 'View AI Overview' })).toBeNull();
+  });
+
+  it('omits the AI Overview link where the route does not exist', () => {
+    renderNudge({ aiOverviewEnabled: true, hasAIOverviewPath: false });
+
+    expect(screen.queryByRole('link', { name: 'View AI Overview' })).toBeNull();
   });
 });

--- a/ui/packages/components/src/RunDetailsV4/AIMetadata.test.tsx
+++ b/ui/packages/components/src/RunDetailsV4/AIMetadata.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { traceHasAIMetadata } from './AIMetadata';
+import type { SpanMetadata, Trace } from './types';
+
+const makeSpan = (overrides: Partial<Trace> = {}): Trace => ({
+  attempts: 0,
+  endedAt: '2026-01-01T00:00:05Z',
+  isRoot: false,
+  name: 'span',
+  outputID: null,
+  queuedAt: '2026-01-01T00:00:00Z',
+  scheduledAt: null,
+  spanID: 'span-1',
+  startedAt: '2026-01-01T00:00:01Z',
+  status: 'COMPLETED',
+  stepInfo: null,
+  userlandSpan: null,
+  isUserland: false,
+  ...overrides,
+});
+
+const aiMetadata: SpanMetadata = {
+  scope: 'extended_trace',
+  kind: 'inngest.ai',
+  updatedAt: '2026-01-01T00:00:02Z',
+  values: { request_model: 'claude-opus-4', input_tokens: 10, output_tokens: 20 },
+};
+
+const timingMetadata: SpanMetadata = {
+  scope: 'step_attempt',
+  kind: 'inngest.timing',
+  updatedAt: '2026-01-01T00:00:02Z',
+  values: { total_inngest_ms: 12 },
+};
+
+describe('traceHasAIMetadata', () => {
+  it('finds AI metadata nested under descendant spans', () => {
+    const trace = makeSpan({
+      isRoot: true,
+      metadata: [timingMetadata],
+      childrenSpans: [makeSpan({ childrenSpans: [makeSpan({ metadata: [aiMetadata] })] })],
+    });
+
+    expect(traceHasAIMetadata(trace)).toBe(true);
+  });
+
+  it('reports no AI metadata when only other kinds are present', () => {
+    const trace = makeSpan({
+      isRoot: true,
+      metadata: [timingMetadata],
+      childrenSpans: [makeSpan({ metadata: [] })],
+    });
+
+    expect(traceHasAIMetadata(trace)).toBe(false);
+  });
+});

--- a/ui/packages/components/src/RunDetailsV4/AIMetadata.tsx
+++ b/ui/packages/components/src/RunDetailsV4/AIMetadata.tsx
@@ -1,0 +1,62 @@
+import { RiSparkling2Line } from '@remixicon/react';
+
+import { Button } from '../Button/Button';
+import { InlineCode } from '../Code';
+import { KindInngestAI } from '../generated';
+import { traceWalk } from './runDetailsUtils';
+import type { Trace } from './types';
+
+const AI_METADATA_DOCS_URL =
+  'https://www.inngest.com/docs/examples/open-telemetry?ref=app-run-metadata';
+
+const CUSTOM_METADATA_DOCS_URL =
+  'https://www.inngest.com/docs/reference/typescript/v4/functions/metadata?ref=app-run-metadata';
+
+const links = [
+  { label: 'Set up AI metadata', href: AI_METADATA_DOCS_URL },
+  { label: 'Add custom metadata', href: CUSTOM_METADATA_DOCS_URL },
+];
+
+export const traceHasAIMetadata = (trace: Trace | undefined): boolean => {
+  if (!trace) {
+    return false;
+  }
+
+  let found = false;
+  traceWalk(trace, (span) => {
+    if (span.metadata?.some((md) => md.kind === KindInngestAI)) {
+      found = true;
+    }
+  });
+
+  return found;
+};
+
+export const AIMetadataNudge = () => (
+  <div className="px-4 pb-4 pt-2">
+    <div className="border-subtle bg-canvasBase flex items-start gap-3 rounded-md border p-4">
+      <RiSparkling2Line className="text-muted mt-0.5 h-4 w-4 shrink-0" />
+      <div className="flex min-w-0 grow flex-col gap-1">
+        <p className="text-basis text-sm font-medium">Get more from metadata</p>
+        <p className="text-muted text-sm leading-relaxed">
+          Track models, tokens, and cost with AI metadata, or use{' '}
+          <InlineCode>step.metadata()</InlineCode> to attach your own key/values.
+        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {links.map((link) => (
+            <Button
+              key={link.href}
+              kind="secondary"
+              appearance="outlined"
+              size="small"
+              label={link.label}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  </div>
+);

--- a/ui/packages/components/src/RunDetailsV4/AIMetadata.tsx
+++ b/ui/packages/components/src/RunDetailsV4/AIMetadata.tsx
@@ -2,17 +2,19 @@ import { RiSparkling2Line } from '@remixicon/react';
 
 import { Button } from '../Button/Button';
 import { InlineCode } from '../Code';
+import { useBooleanFlag } from '../SharedContext/useBooleanFlag';
+import { usePathCreator } from '../SharedContext/usePathCreator';
 import { KindInngestAI } from '../generated';
 import { traceWalk } from './runDetailsUtils';
 import type { Trace } from './types';
 
 const AI_METADATA_DOCS_URL =
-  'https://www.inngest.com/docs/examples/open-telemetry?ref=app-run-metadata';
+  'https://www.inngest.com/docs/examples/ai-metadata-quickstart?ref=app-run-metadata';
 
 const CUSTOM_METADATA_DOCS_URL =
   'https://www.inngest.com/docs/reference/typescript/v4/functions/metadata?ref=app-run-metadata';
 
-const links = [
+const docsLinks = [
   { label: 'Set up AI metadata', href: AI_METADATA_DOCS_URL },
   { label: 'Add custom metadata', href: CUSTOM_METADATA_DOCS_URL },
 ];
@@ -32,31 +34,48 @@ export const traceHasAIMetadata = (trace: Trace | undefined): boolean => {
   return found;
 };
 
-export const AIMetadataNudge = () => (
-  <div className="px-4 pb-4 pt-2">
-    <div className="border-subtle bg-canvasBase flex items-start gap-3 rounded-md border p-4">
-      <RiSparkling2Line className="text-muted mt-0.5 h-4 w-4 shrink-0" />
-      <div className="flex min-w-0 grow flex-col gap-1">
-        <p className="text-basis text-sm font-medium">Get more from metadata</p>
-        <p className="text-muted text-sm leading-relaxed">
-          Track models, tokens, and cost with AI metadata, or use{' '}
-          <InlineCode>step.metadata()</InlineCode> to attach your own key/values.
-        </p>
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          {links.map((link) => (
-            <Button
-              key={link.href}
-              kind="secondary"
-              appearance="outlined"
-              size="small"
-              label={link.label}
-              href={link.href}
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          ))}
+export const AIMetadataNudge = () => {
+  const { booleanFlag } = useBooleanFlag();
+  const { pathCreator } = usePathCreator();
+  const { value: aiOverviewEnabled } = booleanFlag('ai-overview-dashboard', false);
+  const aiOverviewPath = aiOverviewEnabled ? pathCreator.aiOverview?.() : null;
+
+  return (
+    <div className="px-4 pb-4 pt-2">
+      <div className="border-subtle bg-canvasBase flex items-start gap-3 rounded-md border p-4">
+        <RiSparkling2Line className="text-muted mt-0.5 h-4 w-4 shrink-0" />
+        <div className="flex min-w-0 grow flex-col gap-1">
+          <p className="text-basis text-sm font-medium">Get more from metadata</p>
+          <p className="text-muted text-sm leading-relaxed">
+            With OpenTelemetry enabled, Inngest captures model, tokens, cost, and latency from AI
+            calls automatically. You can also attach your own key/values with{' '}
+            <InlineCode>step.metadata()</InlineCode>.
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {docsLinks.map((link) => (
+              <Button
+                key={link.href}
+                kind="secondary"
+                appearance="outlined"
+                size="small"
+                label={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              />
+            ))}
+            {aiOverviewPath && (
+              <Button
+                kind="secondary"
+                appearance="outlined"
+                size="small"
+                label="View AI Overview"
+                href={aiOverviewPath}
+              />
+            )}
+          </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
+};

--- a/ui/packages/components/src/RunDetailsV4/MetadataAttrs.tsx
+++ b/ui/packages/components/src/RunDetailsV4/MetadataAttrs.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef, type ReactNode } from 'react';
 
 import { ElementWrapper, TextElement, TimeElement } from '../DetailsCard/Element';
 import type { SpanMetadata, SpanMetadataKind } from './types';
@@ -113,7 +113,13 @@ const MetadataAttrRow = ({ kind, scope, values, updatedAt, isLast }: MetadataAtt
 };
 
 /** Displays metadata attributes as key-value pairs. Status Code is pinned to the top, remaining entries sorted alphabetically. */
-export const MetadataAttrs = ({ metadata }: { metadata: SpanMetadata[] }) => {
+export const MetadataAttrs = ({
+  metadata,
+  footer,
+}: {
+  metadata: SpanMetadata[];
+  footer?: ReactNode;
+}) => {
   const ref = useRef<HTMLDivElement>(null);
   useLayoutEffect(() => {
     if (ref.current && ref.current.clientHeight > 0) {
@@ -139,6 +145,7 @@ export const MetadataAttrs = ({ metadata }: { metadata: SpanMetadata[] }) => {
           />
         );
       })}
+      {footer}
     </div>
   );
 };

--- a/ui/packages/components/src/RunDetailsV4/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TopInfo.tsx
@@ -23,6 +23,7 @@ import { usePrettyErrorBody, usePrettyJson } from '../hooks/usePrettyJson';
 import { IconCloudArrowDown } from '../icons/CloudArrowDown';
 import { getCronTriggerMetadata } from '../utils/cronTrigger';
 import { devServerURL, useDevServer } from '../utils/useDevServer';
+import { AIMetadataNudge, traceHasAIMetadata } from './AIMetadata';
 import { ErrorInfo } from './ErrorInfo';
 import { IO } from './IO';
 import { LinkedRuns } from './LinkedRuns';
@@ -123,10 +124,11 @@ export const TopInfo = ({
     retry: 3,
   });
 
-  const metadataIsEnabled = true;
   const scoreMetadata = useMemo(() => collectScoreMetadata(trace), [trace]);
   const nonScoreMetadata = trace?.metadata?.filter((md) => !isScoreMetadata(md)) ?? [];
-  const hasMetadataTab = metadataIsEnabled && nonScoreMetadata.length > 0;
+  const hasAIMetadata = useMemo(() => traceHasAIMetadata(trace), [trace]);
+  const showNudge = Boolean(trace?.endedAt) && !hasAIMetadata;
+  const hasMetadataTab = nonScoreMetadata.length > 0 || showNudge;
 
   const prettyPayload = useMemo(() => {
     try {
@@ -367,7 +369,12 @@ export const TopInfo = ({
                   {
                     label: 'Metadata',
                     id: 'metadata',
-                    node: <MetadataAttrs metadata={nonScoreMetadata} />,
+                    node: (
+                      <MetadataAttrs
+                        metadata={nonScoreMetadata}
+                        footer={showNudge ? <AIMetadataNudge /> : null}
+                      />
+                    ),
                   },
                 ]
               : []),

--- a/ui/packages/components/src/SharedContext/usePathCreator.ts
+++ b/ui/packages/components/src/SharedContext/usePathCreator.ts
@@ -3,6 +3,7 @@ import type { Route } from 'next';
 import { useShared } from './SharedContext';
 
 export type PathCreator = {
+  aiOverview?: () => Route;
   app: (params: { externalAppID: string }) => Route;
   eventPopout: (params: { eventID: string }) => Route;
   eventType?: (params: { eventName: string }) => Route;


### PR DESCRIPTION
## Description

Show the Metadata tab on completed runs, even when no metadata exists, rendering a nudge that links to AI metadata and `step.metadata()` docs. The nudge also appears beneath existing metadata when the run has no `inngest.ai` metadata anywhere in its trace.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
