### PR TITLE
fix(connect): prevent connection state regression during gateway draining

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -443,15 +443,22 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			err := wsproto.Write(closingWriteCtx, ws, &connectpb.ConnectMessage{
 				Kind: connectpb.GatewayMessageType_GATEWAY_CLOSING,
 			})
+
+			// Report the drain to listeners now, while draining is the connection's
+			// most advanced state. Deferring this until the drain ack window closes
+			// lets it race the disconnect cleanup below, which reports DRAINING
+			// after DISCONNECTED and leaves stale draining state in connection
+			// history.
+			for _, l := range c.lifecycles {
+				go l.OnStartDraining(context.Background(), conn)
+			}
+
 			if err != nil {
 				// Can't tell the worker so we mark as DRAINING immediately.
 				if statusErr := ch.updateConnStatus(connectpb.ConnectionStatus_DRAINING, "gateway drain started after failed closing write", "err", err); statusErr != nil {
 					ch.log.ReportError(statusErr, "could not update connection status after context done")
 				}
 				ch.stopForwardingOnce.Do(func() { close(ch.stopForwarding) })
-				for _, l := range c.lifecycles {
-					go l.OnStartDraining(context.Background(), conn)
-				}
 				return
 			}
 
@@ -464,14 +471,22 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 				ch.log.Debug("timed out waiting for drain ack, marking connection as draining")
 			}
 
-			if statusErr := ch.updateConnStatus(connectpb.ConnectionStatus_DRAINING, "gateway drain completed or timed out", "drain_ack_wait_ms", time.Since(drainStart).Milliseconds()); statusErr != nil {
+			// Cleanup may have started while we waited: the worker closing the
+			// socket ends the read loop, which both moves the phase to
+			// Disconnecting and releases workerDrainedCtx. Unlike the phase,
+			// status is not ordered, so marking the connection as DRAINING here
+			// would move it backwards from DISCONNECTING/DISCONNECTED, leaving
+			// stale draining state behind, or even resurrect it after cleanup
+			// deleted the connection from the state store.
+			if phase := ch.phase(); phase >= gatewayConnPhaseDisconnecting {
+				ch.log.Debug("skipping draining status update because connection is already disconnecting",
+					"phase", phase.String(),
+					"drain_ack_wait_ms", time.Since(drainStart).Milliseconds(),
+				)
+			} else if statusErr := ch.updateConnStatus(connectpb.ConnectionStatus_DRAINING, "gateway drain completed or timed out", "drain_ack_wait_ms", time.Since(drainStart).Milliseconds()); statusErr != nil {
 				ch.log.ReportError(statusErr, "could not update connection status after drain ack")
 			}
 			ch.stopForwardingOnce.Do(func() { close(ch.stopForwarding) })
-
-			for _, l := range c.lifecycles {
-				go l.OnStartDraining(context.Background(), conn)
-			}
 
 			metrics.HistogramConnectGatewayDrainDuration(context.Background(), time.Since(drainStart).Milliseconds(), metrics.HistogramOpt{
 				PkgName: pkgName,

--- a/pkg/connect/lifecycles/history.go
+++ b/pkg/connect/lifecycles/history.go
@@ -51,6 +51,14 @@ func (h *historyLifecycles) OnSynced(ctx context.Context, conn *state.Connection
 }
 
 func (h *historyLifecycles) OnConnected(ctx context.Context, conn *state.Connection) {
+	if conn.Data.GetSystemAttributes() == nil {
+		logger.StdlibLogger(ctx).Warn(
+			"worker connected without system attributes",
+			"connection_id", conn.ConnectionId.String(),
+			"instance_id", conn.Data.GetInstanceId(),
+		)
+	}
+
 	err := h.upsertConnection(ctx, conn, connectpb.ConnectionStatus_CONNECTED, time.Now())
 	if err != nil {
 		logger.StdlibLogger(ctx).Error("could not persist connection history", "error", err)
@@ -71,6 +79,7 @@ func (h *historyLifecycles) OnDisconnected(ctx context.Context, conn *state.Conn
 	if closeReason != "" {
 		disconnectReason = ptr.String(closeReason)
 	}
+	system := conn.Data.GetSystemAttributes()
 
 	for groupHash, group := range conn.Groups {
 		// Persist history in history store
@@ -103,9 +112,9 @@ func (h *historyLifecycles) OnDisconnected(ctx context.Context, conn *state.Conn
 			AppVersion:    group.AppVersion,
 			FunctionCount: len(group.FunctionSlugs),
 
-			CpuCores: conn.Data.SystemAttributes.CpuCores,
-			MemBytes: conn.Data.SystemAttributes.MemBytes,
-			Os:       conn.Data.SystemAttributes.Os,
+			CpuCores: system.GetCpuCores(),
+			MemBytes: system.GetMemBytes(),
+			Os:       system.GetOs(),
 		})
 		if err != nil {
 			logger.StdlibLogger(ctx).Error("could not persist connection history", "error", err)
@@ -120,6 +129,8 @@ func NewHistoryLifecycle(writer cqrs.ConnectionHistoryWriter) connect.ConnectGat
 }
 
 func (h *historyLifecycles) upsertConnection(ctx context.Context, conn *state.Connection, status connectpb.ConnectionStatus, lastHeartbeatAt time.Time) error {
+	system := conn.Data.GetSystemAttributes()
+
 	for groupHash, group := range conn.Groups {
 		// Persist history in history store
 		err := h.writer.InsertWorkerConnection(ctx, &cqrs.WorkerConnection{
@@ -152,9 +163,9 @@ func (h *historyLifecycles) upsertConnection(ctx context.Context, conn *state.Co
 			SDKVersion:  conn.Data.SdkVersion,
 			SDKPlatform: conn.Data.GetPlatform(),
 
-			CpuCores: conn.Data.SystemAttributes.CpuCores,
-			MemBytes: conn.Data.SystemAttributes.MemBytes,
-			Os:       conn.Data.SystemAttributes.Os,
+			CpuCores: system.GetCpuCores(),
+			MemBytes: system.GetMemBytes(),
+			Os:       system.GetOs(),
 		})
 		if err != nil {
 			return fmt.Errorf("could not persist connection history: %w", err)

--- a/pkg/connect/lifecycles/history_test.go
+++ b/pkg/connect/lifecycles/history_test.go
@@ -31,7 +31,7 @@ func TestNewHistoryLifecycle(t *testing.T) {
 	writer := &MockConnectionHistoryWriter{}
 
 	lifecycle := NewHistoryLifecycle(writer)
-	
+
 	require.NotNil(t, lifecycle)
 	assert.Implements(t, (*connect.ConnectGatewayLifecycleListener)(nil), lifecycle)
 }
@@ -108,7 +108,7 @@ func TestHistoryLifecycle_OnConnected(t *testing.T) {
 				CpuCores: 4,
 				MemBytes: 8192,
 				Os:       "linux",
-							},
+			},
 		},
 		Groups: map[string]*state.WorkerGroup{
 			"group1": {
@@ -220,22 +220,22 @@ func TestHistoryLifecycle_OnStartDisconnecting(t *testing.T) {
 
 func TestHistoryLifecycle_OnDisconnected(t *testing.T) {
 	tests := []struct {
-		name               string
-		closeReason        string
-		expectedReason     *string
-		expectedStatus     connectpb.ConnectionStatus
+		name           string
+		closeReason    string
+		expectedReason *string
+		expectedStatus connectpb.ConnectionStatus
 	}{
 		{
-			name:               "with close reason",
-			closeReason:        "client_disconnect",
-			expectedReason:     ptr.String("client_disconnect"),
-			expectedStatus:     connectpb.ConnectionStatus_DISCONNECTED,
+			name:           "with close reason",
+			closeReason:    "client_disconnect",
+			expectedReason: ptr.String("client_disconnect"),
+			expectedStatus: connectpb.ConnectionStatus_DISCONNECTED,
 		},
 		{
-			name:               "empty close reason",
-			closeReason:        "",
-			expectedReason:     nil,
-			expectedStatus:     connectpb.ConnectionStatus_DISCONNECTED,
+			name:           "empty close reason",
+			closeReason:    "",
+			expectedReason: nil,
+			expectedStatus: connectpb.ConnectionStatus_DISCONNECTED,
 		},
 	}
 
@@ -256,6 +256,51 @@ func TestHistoryLifecycle_OnDisconnected(t *testing.T) {
 
 			lifecycle.OnDisconnected(ctx, connection, tt.closeReason)
 
+			writer.AssertExpectations(t)
+		})
+	}
+}
+
+func TestHistoryLifecycle_MissingSystemAttributes(t *testing.T) {
+	tests := []struct {
+		name           string
+		expectedStatus connectpb.ConnectionStatus
+		invoke         func(context.Context, *historyLifecycles, *state.Connection)
+	}{
+		{
+			name:           "connected",
+			expectedStatus: connectpb.ConnectionStatus_CONNECTED,
+			invoke: func(ctx context.Context, lifecycle *historyLifecycles, connection *state.Connection) {
+				lifecycle.OnConnected(ctx, connection)
+			},
+		},
+		{
+			name:           "disconnected",
+			expectedStatus: connectpb.ConnectionStatus_DISCONNECTED,
+			invoke: func(ctx context.Context, lifecycle *historyLifecycles, connection *state.Connection) {
+				lifecycle.OnDisconnected(ctx, connection, "test")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writer := &MockConnectionHistoryWriter{}
+			lifecycle := &historyLifecycles{writer: writer}
+			connection := createTestConnection()
+			connection.Data.SystemAttributes = nil
+			ctx := context.Background()
+
+			writer.On("InsertWorkerConnection", ctx, mock.MatchedBy(func(wc *cqrs.WorkerConnection) bool {
+				return wc.Status == tt.expectedStatus &&
+					wc.CpuCores == 0 &&
+					wc.MemBytes == 0 &&
+					wc.Os == ""
+			})).Return(nil)
+
+			require.NotPanics(t, func() {
+				tt.invoke(ctx, lifecycle, connection)
+			})
 			writer.AssertExpectations(t)
 		})
 	}
@@ -307,9 +352,9 @@ func TestHistoryLifecycle_MultipleGroups(t *testing.T) {
 		GatewayId:    ulid.Make(),
 		WorkerIP:     "192.168.1.100",
 		Data: &connectpb.WorkerConnectRequestData{
-			InstanceId:       "multi-app-instance",
-			SdkLanguage:      "go",
-			SdkVersion:       "1.0.0",
+			InstanceId:  "multi-app-instance",
+			SdkLanguage: "go",
+			SdkVersion:  "1.0.0",
 			SystemAttributes: &connectpb.SystemAttributes{
 				CpuCores: 8,
 				MemBytes: 16384,
@@ -368,7 +413,7 @@ func createTestConnection() *state.Connection {
 				CpuCores: 2,
 				MemBytes: 4096,
 				Os:       "darwin",
-							},
+			},
 		},
 		Groups: map[string]*state.WorkerGroup{
 			"group1": {


### PR DESCRIPTION
## Description

Fixes two issues in Connect gateway lifecycle handling that could leave stale worker connection states:
- Prevents a gateway panic when a worker connects without system attributes.
    - During unexpected crashes, history lifecycles are not updated for current connections which leaves the worker in READY state forever in the UI.  
- Reduces the race window where a connection can be recorded as DRAINING after it has already begun disconnecting.
    - The drain handler for each connection runs in a separate goroutine and waits for the gateway context to be cancelled. When cancellation occurs, it begins draining the connection, sends GATEWAY_CLOSING to the worker, and waits for either the worker to close its WebSocket or the drain timeout to expire. 
  - Meanwhile, the main connection-handler goroutine owns the WebSocket read loop. When the worker closes the socket, that read loop ends and the handler begins its deferred cleanup, which records the connection as DISCONNECTING and then DISCONNECTED.
  - The change reports the drain lifecycle earlier—immediately after attempting to notify the worker and before waiting for it to close. It also avoids updating the Redis-backed status to DRAINING after the local connection phase has already advanced to DISCONNECTING or CLOSED.



Investigation in plain ticket: https://app.plain.com/workspace/w_01H5R1F69XQ35G4P7THFQGN5KB/thread/th_01KXHC4QATX6SC3R5G1GV3WGA5/

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
