### PR TITLE
feat(sandbox): support create environment variables

### DIFF
--- a/pkg/util/sandbox/protocol.go
+++ b/pkg/util/sandbox/protocol.go
@@ -75,9 +75,10 @@ type ProcessTarget struct {
 }
 
 type CreateInput struct {
-	Name     string `json:"name"`
-	VCPU     uint32 `json:"vcpu"`
-	MemoryMB uint32 `json:"memoryMb"`
+	Name        string            `json:"name"`
+	VCPU        uint32            `json:"vcpu"`
+	MemoryMB    uint32            `json:"memoryMb"`
+	Environment map[string]string `json:"environment,omitempty"`
 }
 
 type ListInput struct {
@@ -761,7 +762,7 @@ func (i CreateInput) Validate() error {
 	if i.VCPU == 0 || i.MemoryMB == 0 {
 		return errors.New("vcpu and memoryMb must be positive uint32 values")
 	}
-	return nil
+	return validateEnvironment(i.Environment)
 }
 
 func (i ListInput) Validate() error {
@@ -792,18 +793,8 @@ func (i ProcessSpecInput) Validate() error {
 	if argvBytes > 32<<10 {
 		return errors.New("command exceeds 32768 bytes")
 	}
-	if len(i.Environment) > 256 {
-		return errors.New("environment exceeds 256 entries")
-	}
-	envBytes := 0
-	for key, value := range i.Environment {
-		if key == "" || strings.ContainsAny(key, "=\x00") || !portableString(key) || !portableString(value) {
-			return errors.New("environment keys must be nonempty without '=' or NUL and values must not contain NUL")
-		}
-		envBytes += len(key) + 1 + len(value)
-	}
-	if envBytes > 64<<10 {
-		return errors.New("environment exceeds 65536 bytes")
+	if err := validateEnvironment(i.Environment); err != nil {
+		return err
 	}
 	if !portableString(i.CWD) || len(i.CWD) > 4096 {
 		return errors.New("cwd must be valid UTF-8 without NUL and at most 4096 bytes")
@@ -815,6 +806,23 @@ func (i ProcessSpecInput) Validate() error {
 	}{Argv: i.Command, Env: i.Environment, CWD: i.CWD})
 	if err != nil || len(wire) > 96<<10 {
 		return errors.New("process spec exceeds 98304 encoded bytes")
+	}
+	return nil
+}
+
+func validateEnvironment(environment map[string]string) error {
+	if len(environment) > 256 {
+		return errors.New("environment exceeds 256 entries")
+	}
+	envBytes := 0
+	for key, value := range environment {
+		if key == "" || strings.ContainsAny(key, "=\x00") || !portableString(key) || !portableString(value) {
+			return errors.New("environment keys must be nonempty without '=' or NUL and values must not contain NUL")
+		}
+		envBytes += len(key) + 1 + len(value)
+	}
+	if envBytes > 64<<10 {
+		return errors.New("environment exceeds 65536 bytes")
 	}
 	return nil
 }

--- a/pkg/util/sandbox/sandbox_test.go
+++ b/pkg/util/sandbox/sandbox_test.go
@@ -26,7 +26,10 @@ func canonicalOpcodeOpts(action Action) map[string]any {
 	processTarget := map[string]any{"sandboxId": testSandboxID, "processId": testProcessID}
 	switch action {
 	case ActionCreate:
-		operation["input"] = []any{map[string]any{"name": "eval_run-1", "vcpu": 2, "memoryMb": 2048}}
+		operation["input"] = []any{map[string]any{
+			"name": "eval_run-1", "vcpu": 2, "memoryMb": 2048,
+			"environment": map[string]string{"1.WITH-DOT": "ok", "SHARED": "sandbox"},
+		}}
 	case ActionList:
 		operation["input"] = []any{map[string]any{"limit": 50}}
 	case ActionGet:
@@ -88,6 +91,14 @@ func TestParseCanonicalOpcodeOpts(t *testing.T) {
 	_, err := ParseOpcodeOpts(invalidEnv)
 	require.ErrorContains(t, err, "environment keys")
 
+	invalidCreateEnv := canonicalOpcodeOpts(ActionCreate)
+	invalidCreateEnv["sandbox"].(map[string]any)["input"] = []any{map[string]any{
+		"name": "eval_run-1", "vcpu": 2, "memoryMb": 2048,
+		"environment": map[string]string{"A=B": "x"},
+	}}
+	_, err = ParseOpcodeOpts(invalidCreateEnv)
+	require.ErrorContains(t, err, "environment keys")
+
 	relative := canonicalOpcodeOpts(ActionExec)
 	relative["sandbox"].(map[string]any)["input"] = []any{map[string]any{
 		"command": []string{"bin/true"}, "timeoutMs": 1000,
@@ -123,6 +134,12 @@ func TestRESTProviderCanonicalLifecycle(t *testing.T) {
 		require.Equal(t, "workspace-"+r.Header.Get("X-Test-Workspace"), r.Header.Get("X-Inngest-Env"))
 		switch {
 		case r.Method == http.MethodPost && r.URL.Path == "/v2/sandboxes":
+			var body CreateInput
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			require.Equal(t, map[string]string{
+				"1.WITH-DOT": "ok",
+				"SHARED":     "sandbox",
+			}, body.Environment)
 			writeData(w, http.StatusCreated, resource)
 		case r.Method == http.MethodGet && r.URL.Path == "/v2/sandboxes":
 			writeData(w, http.StatusOK, []any{resource}, map[string]any{"hasMore": false, "limit": 50})


### PR DESCRIPTION
## Summary

- add environment to the durable sandbox Create protocol
- apply the same 256-entry and 64 KiB validation used by process operations
- forward environment through the REST provider
- include environment in the crash-safe dispatch intent digest

This is stacked on jakob/sandbox-opcode.

## Tests

- go test ./pkg/util/sandbox ./pkg/execution/executor
