### PR TITLE
fix(insights): recover Insights AI results from a missed run.completed

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
@@ -179,6 +179,13 @@ export function InsightsChatProvider({
   // Runs whose result we haven't seen yet, keyed by thread.
   const pendingRunsRef = useRef<Map<string, PendingRun>>(new Map());
 
+  // Threads awaiting a result, from send until the first terminal outcome
+  // lands. Realtime and the run-output fallback can both deliver the same
+  // result, so whichever arrives first clears this and the other one no-ops.
+  // Kept separate from pendingRunsRef, which only exists when /api/chat
+  // returned an event id: gating on that would silently drop results.
+  const awaitingResultRef = useRef<Set<string>>(new Set());
+
   const clearPending = useCallback((threadId: string) => {
     const pending = pendingRunsRef.current.get(threadId);
     if (pending) window.clearTimeout(pending.timer);
@@ -188,6 +195,8 @@ export function InsightsChatProvider({
   // Terminal state for a thread, whichever channel delivered it.
   const finishThread = useCallback(
     (threadId: string, parts: Message['parts']) => {
+      awaitingResultRef.current.delete(threadId);
+
       if (parts.length > 0) {
         const assistantMsg: Message = {
           id: crypto.randomUUID(),
@@ -215,6 +224,8 @@ export function InsightsChatProvider({
   // which carry the same payload.
   const applyRunResult = useCallback(
     (threadId: string, data: Record<string, unknown>) => {
+      if (!awaitingResultRef.current.has(threadId)) return;
+
       const parts: Message['parts'] = [];
 
       const sql = typeof data.sql === 'string' ? data.sql : undefined;
@@ -247,6 +258,7 @@ export function InsightsChatProvider({
 
   const failThread = useCallback(
     (threadId: string, message: string) => {
+      if (!awaitingResultRef.current.has(threadId)) return;
       finishThread(threadId, [{ type: 'text', content: `Error: ${message}` }]);
     },
     [finishThread],
@@ -497,6 +509,10 @@ export function InsightsChatProvider({
 
       const clientState = threadClientStateRef.current.get(threadId);
 
+      // Marked before the await: a fast run could publish run.completed before
+      // this request even returns.
+      awaitingResultRef.current.add(threadId);
+
       try {
         const { eventId } = await sendChatMessage({
           content,
@@ -526,6 +542,8 @@ export function InsightsChatProvider({
           scheduleReconcile(threadId, IDLE_BEFORE_RECONCILE_MS);
         }
       } catch (error) {
+        awaitingResultRef.current.delete(threadId);
+
         // Remove the optimistic user message and show error
         setMessagesByThread((prev) => ({
           ...prev,
@@ -568,7 +586,9 @@ export function InsightsChatProvider({
         return next;
       });
       latestSqlByThreadRef.current.delete(threadId);
-      // Don't let a discarded thread's run report back into the cleared view.
+      // Don't let a discarded thread's run report back into the cleared view,
+      // on either channel.
+      awaitingResultRef.current.delete(threadId);
       clearPending(threadId);
     },
     [clearPending],

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 
 import {
+  fetchRunResult,
   useInsightsRealtime,
   sendChatMessage,
   type ClientState,
@@ -49,6 +50,17 @@ type ContextValue = {
 const defaultFlags: ThreadFlags = {
   networkActive: false,
 };
+
+// Realtime has no replay, so a run that finishes while the browser is
+// disconnected leaves the thread spinning on a run.completed that will never
+// arrive. Each in-flight run gets a watchdog: after this long with no traffic
+// for the thread, read the result back from the run itself.
+const IDLE_BEFORE_RECONCILE_MS = 45_000;
+// The runs endpoint caches for 15s, so polling faster only re-reads the cache.
+const RECONCILE_INTERVAL_MS = 20_000;
+const MAX_RECONCILE_ATTEMPTS = 8;
+
+type PendingRun = { eventId: string; attempts: number; timer: number };
 
 const InsightsChatContext = createContext<ContextValue | undefined>(undefined);
 
@@ -164,6 +176,166 @@ export function InsightsChatProvider({
     return 'ready';
   }, [connectionStatus]);
 
+  // Runs whose result we haven't seen yet, keyed by thread.
+  const pendingRunsRef = useRef<Map<string, PendingRun>>(new Map());
+
+  const clearPending = useCallback((threadId: string) => {
+    const pending = pendingRunsRef.current.get(threadId);
+    if (pending) window.clearTimeout(pending.timer);
+    pendingRunsRef.current.delete(threadId);
+  }, []);
+
+  // Terminal state for a thread, whichever channel delivered it.
+  const finishThread = useCallback(
+    (threadId: string, parts: Message['parts']) => {
+      if (parts.length > 0) {
+        const assistantMsg: Message = {
+          id: crypto.randomUUID(),
+          role: 'assistant',
+          threadId,
+          parts,
+        };
+
+        setMessagesByThread((prev) => ({
+          ...prev,
+          [threadId]: [...(prev[threadId] || []), assistantMsg],
+        }));
+      }
+
+      setThreadFlags((prev) => ({
+        ...prev,
+        [threadId]: { networkActive: false },
+      }));
+      clearPending(threadId);
+    },
+    [clearPending],
+  );
+
+  // Shared by the realtime run.completed event and the run-output fallback,
+  // which carry the same payload.
+  const applyRunResult = useCallback(
+    (threadId: string, data: Record<string, unknown>) => {
+      const parts: Message['parts'] = [];
+
+      const sql = typeof data.sql === 'string' ? data.sql : undefined;
+      if (sql) {
+        parts.push({
+          type: 'tool-call',
+          toolName: 'generate_sql',
+          data: {
+            sql,
+            title: typeof data.title === 'string' ? data.title : undefined,
+            reasoning:
+              typeof data.reasoning === 'string' ? data.reasoning : undefined,
+          },
+        });
+
+        latestSqlByThreadRef.current.set(threadId, sql);
+        setLatestSqlVersion((v) => v + 1);
+      }
+
+      const summary =
+        typeof data.summary === 'string' ? data.summary : undefined;
+      if (summary) {
+        parts.push({ type: 'text', content: summary });
+      }
+
+      finishThread(threadId, parts);
+    },
+    [finishThread],
+  );
+
+  const failThread = useCallback(
+    (threadId: string, message: string) => {
+      finishThread(threadId, [{ type: 'text', content: `Error: ${message}` }]);
+    },
+    [finishThread],
+  );
+
+  // Indirection so the watchdog can reschedule itself without the callbacks
+  // forming a cycle.
+  const reconcileRef = useRef<(threadId: string) => void>(() => {});
+
+  const scheduleReconcile = useCallback((threadId: string, delayMs: number) => {
+    const pending = pendingRunsRef.current.get(threadId);
+    if (!pending) return;
+    window.clearTimeout(pending.timer);
+    pending.timer = window.setTimeout(
+      () => reconcileRef.current(threadId),
+      delayMs,
+    );
+  }, []);
+
+  const reconcile = useCallback(
+    async (threadId: string) => {
+      const pending = pendingRunsRef.current.get(threadId);
+      if (!pending) return;
+      pending.attempts += 1;
+
+      const result = await fetchRunResult(pending.eventId, threadId).catch(
+        () => null,
+      );
+      // Identity, not presence: run.completed may have landed while the request
+      // was in flight, and the thread may already be waiting on a newer run.
+      if (pendingRunsRef.current.get(threadId) !== pending) return;
+
+      if (result?.status === 'Completed' && result.output) {
+        applyRunResult(threadId, result.output);
+        return;
+      }
+
+      if (result?.status === 'Failed' || result?.status === 'Cancelled') {
+        failThread(
+          threadId,
+          'The Insights agent could not complete this request. Please try again.',
+        );
+        return;
+      }
+
+      if (pending.attempts >= MAX_RECONCILE_ATTEMPTS) {
+        failThread(
+          threadId,
+          "This request didn't come back. Please try sending it again.",
+        );
+        return;
+      }
+
+      scheduleReconcile(threadId, RECONCILE_INTERVAL_MS);
+    },
+    [applyRunResult, failThread, scheduleReconcile],
+  );
+
+  useEffect(() => {
+    reconcileRef.current = (threadId: string) => void reconcile(threadId);
+  }, [reconcile]);
+
+  // Reconnecting means we were away while the run may have finished; don't
+  // wait out the watchdog to find out.
+  const prevConnectionStatusRef = useRef(connectionStatus);
+  useEffect(() => {
+    const prev = prevConnectionStatusRef.current;
+    prevConnectionStatusRef.current = connectionStatus;
+
+    if (
+      connectionStatus === 'open' &&
+      (prev === 'closed' || prev === 'error' || prev === 'paused')
+    ) {
+      for (const threadId of pendingRunsRef.current.keys()) {
+        reconcileRef.current(threadId);
+      }
+    }
+  }, [connectionStatus]);
+
+  useEffect(() => {
+    const pendingRuns = pendingRunsRef.current;
+    return () => {
+      for (const pending of pendingRuns.values()) {
+        window.clearTimeout(pending.timer);
+      }
+      pendingRuns.clear();
+    };
+  }, []);
+
   // Process new realtime events
   useEffect(() => {
     for (const msg of realtimeMessages.delta) {
@@ -174,6 +346,11 @@ export function InsightsChatProvider({
       const tid =
         typeof evt.data.threadId === 'string' ? evt.data.threadId : undefined;
       if (!tid) continue;
+
+      // Any traffic for this thread means the run is alive; push the watchdog out.
+      if (pendingRunsRef.current.has(tid)) {
+        scheduleReconcile(tid, IDLE_BEFORE_RECONCILE_MS);
+      }
 
       try {
         switch (evt.event) {
@@ -199,61 +376,7 @@ export function InsightsChatProvider({
           }
 
           case 'run.completed': {
-            // Build assistant message from the completed run
-            const parts: Message['parts'] = [];
-
-            // Add SQL tool call part if present
-            const sql =
-              typeof evt.data.sql === 'string' ? evt.data.sql : undefined;
-            if (sql) {
-              parts.push({
-                type: 'tool-call',
-                toolName: 'generate_sql',
-                data: {
-                  sql,
-                  title:
-                    typeof evt.data.title === 'string'
-                      ? evt.data.title
-                      : undefined,
-                  reasoning:
-                    typeof evt.data.reasoning === 'string'
-                      ? evt.data.reasoning
-                      : undefined,
-                },
-              });
-
-              // Also update the SQL cache
-              latestSqlByThreadRef.current.set(tid, sql);
-              setLatestSqlVersion((v) => v + 1);
-            }
-
-            // Add summary text part if present
-            const summary =
-              typeof evt.data.summary === 'string'
-                ? evt.data.summary
-                : undefined;
-            if (summary) {
-              parts.push({ type: 'text', content: summary });
-            }
-
-            if (parts.length > 0) {
-              const assistantMsg: Message = {
-                id: crypto.randomUUID(),
-                role: 'assistant',
-                threadId: tid,
-                parts,
-              };
-
-              setMessagesByThread((prev) => ({
-                ...prev,
-                [tid]: [...(prev[tid] || []), assistantMsg],
-              }));
-            }
-
-            setThreadFlags((prev) => ({
-              ...prev,
-              [tid]: { networkActive: false },
-            }));
+            applyRunResult(tid, evt.data);
             break;
           }
 
@@ -275,22 +398,7 @@ export function InsightsChatProvider({
                 ? evt.data.error
                 : 'An unknown error occurred';
 
-            const errorMsg: Message = {
-              id: crypto.randomUUID(),
-              role: 'assistant',
-              threadId: tid,
-              parts: [{ type: 'text', content: `Error: ${errorMessage}` }],
-            };
-
-            setMessagesByThread((prev) => ({
-              ...prev,
-              [tid]: [...(prev[tid] || []), errorMsg],
-            }));
-
-            setThreadFlags((prev) => ({
-              ...prev,
-              [tid]: { networkActive: false },
-            }));
+            failThread(tid, errorMessage);
             break;
           }
         }
@@ -298,7 +406,13 @@ export function InsightsChatProvider({
         // Silently handle event processing errors
       }
     }
-  }, [realtimeMessages.delta, validateSql]);
+  }, [
+    realtimeMessages.delta,
+    validateSql,
+    applyRunResult,
+    failThread,
+    scheduleReconcile,
+  ]);
 
   // Fetch event types and schemas using the same hook as SchemaExplorer
   const getEventTypeSchemas = useEventTypeSchemas();
@@ -384,7 +498,7 @@ export function InsightsChatProvider({
       const clientState = threadClientStateRef.current.get(threadId);
 
       try {
-        await sendChatMessage({
+        const { eventId } = await sendChatMessage({
           content,
           messageId,
           threadId,
@@ -402,6 +516,15 @@ export function InsightsChatProvider({
               },
           history: buildHistory(threadId),
         });
+
+        if (eventId) {
+          pendingRunsRef.current.set(threadId, {
+            eventId,
+            attempts: 0,
+            timer: 0,
+          });
+          scheduleReconcile(threadId, IDLE_BEFORE_RECONCILE_MS);
+        }
       } catch (error) {
         // Remove the optimistic user message and show error
         setMessagesByThread((prev) => ({
@@ -427,17 +550,29 @@ export function InsightsChatProvider({
         }));
       }
     },
-    [userId, channelKey, eventsData?.names, schemas, buildHistory],
+    [
+      userId,
+      channelKey,
+      eventsData?.names,
+      schemas,
+      buildHistory,
+      scheduleReconcile,
+    ],
   );
 
-  const clearThreadMessages = useCallback((threadId: string) => {
-    setMessagesByThread((prev) => {
-      const next = { ...prev };
-      delete next[threadId];
-      return next;
-    });
-    latestSqlByThreadRef.current.delete(threadId);
-  }, []);
+  const clearThreadMessages = useCallback(
+    (threadId: string) => {
+      setMessagesByThread((prev) => {
+        const next = { ...prev };
+        delete next[threadId];
+        return next;
+      });
+      latestSqlByThreadRef.current.delete(threadId);
+      // Don't let a discarded thread's run report back into the cleared view.
+      clearPending(threadId);
+    },
+    [clearPending],
+  );
 
   const messages = useMemo(
     () => messagesByThread[currentThreadId || ''] || [],

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/useInsightsAgent.test.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/useInsightsAgent.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchRunResult } from './useInsightsAgent';
+
+function mockResponse(body: unknown, ok = true) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      json: async () => body,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchRunResult', () => {
+  it('returns the run whose output matches the thread', async () => {
+    mockResponse({
+      runs: [
+        { status: 'Completed', output: { threadId: 'other', summary: 'no' } },
+        { status: 'Completed', output: { threadId: 'mine', summary: 'yes' } },
+      ],
+    });
+
+    const result = await fetchRunResult('evt_1', 'mine');
+    expect(result?.output).toMatchObject({ summary: 'yes' });
+  });
+
+  it('falls back to the only run when no output carries a thread id', async () => {
+    mockResponse({ runs: [{ status: 'Running', output: null }] });
+
+    const result = await fetchRunResult('evt_1', 'mine');
+    expect(result?.status).toBe('Running');
+  });
+
+  it('returns null when the lookup finds nothing', async () => {
+    mockResponse({ runs: [] });
+    expect(await fetchRunResult('evt_1', 'mine')).toBeNull();
+  });
+
+  it('returns null on a non-ok response', async () => {
+    mockResponse({}, false);
+    expect(await fetchRunResult('evt_1', 'mine')).toBeNull();
+  });
+});

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/useInsightsAgent.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/useInsightsAgent.ts
@@ -48,6 +48,10 @@ export function useInsightsRealtime({
     autoCloseOnTerminal: false,
     reconnect: true,
     historyLimit: 200,
+    // Hiding the tab would otherwise tear the subscription down entirely, and
+    // realtime has no replay: anything the run publishes while we're away is
+    // lost. Agent runs routinely outlast a tab switch.
+    pauseOnHidden: false,
   });
 }
 
@@ -62,7 +66,7 @@ export async function sendChatMessage(params: {
   channelKey?: string;
   state?: Record<string, unknown>;
   history?: Array<Record<string, unknown>>;
-}): Promise<{ success: boolean; threadId?: string }> {
+}): Promise<{ success: boolean; threadId?: string; eventId?: string }> {
   const res = await fetch('/api/chat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -86,4 +90,42 @@ export async function sendChatMessage(params: {
   }
 
   return res.json();
+}
+
+export type RunResult = {
+  status: string;
+  output: Record<string, unknown> | null;
+};
+
+/**
+ * Read a chat run back from its triggering event, for when the realtime
+ * run.completed never arrived. Resolves to null when the run can't be
+ * determined, which the caller treats the same as a failure.
+ */
+export async function fetchRunResult(
+  eventId: string,
+  threadId: string,
+): Promise<RunResult | null> {
+  const res = await fetch('/api/chat-result', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ eventId }),
+  });
+  if (!res.ok) return null;
+
+  const { runs } = (await res.json()) as { runs?: RunResult[] };
+  if (!runs?.length) return null;
+
+  // One event triggers one agent run today, but match on the thread so a
+  // second run on the same event could never answer for this one.
+  return (
+    runs.find(
+      (run) =>
+        run.output &&
+        typeof run.output === 'object' &&
+        (run.output as { threadId?: unknown }).threadId === threadId,
+    ) ??
+    runs[0] ??
+    null
+  );
 }

--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -362,11 +362,14 @@ export const runInsightsAgent = inngest.createFunction(
       timestamp: Date.now(),
     });
 
+    // Mirrors the run.completed payload above: the chat UI reads this run
+    // output back when the realtime message doesn't reach the browser.
     return {
       success: true,
       threadId,
       sql: draft.sql ?? '',
       title: draft.title ?? '',
+      reasoning: draft.reasoning ?? '',
       summary,
       kind: draft.sql ? 'query' : 'answer',
       selectedEvents: draft.selectedEvents,

--- a/ui/apps/dashboard/src/lib/inngest/runLookup.test.ts
+++ b/ui/apps/dashboard/src/lib/inngest/runLookup.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchRunsForEvent } from './runLookup';
+
+const RUNS = [{ status: 'Completed', output: { summary: 'secret' } }];
+
+// Responds to /v1/events/{id} with the given owner, and to the runs path with RUNS.
+function fakeFetch(ownerUserId: string | undefined, runs = RUNS) {
+  return vi.fn(async (url: string) => {
+    const body = String(url).endsWith('/runs')
+      ? { data: runs }
+      : { data: { data: { userId: ownerUserId } } };
+    return { ok: true, json: async () => body } as Response;
+  }) as unknown as typeof fetch;
+}
+
+const args = { eventId: 'evt_1', signingKey: 'signkey' };
+
+describe('fetchRunsForEvent', () => {
+  it('returns runs to the user who triggered the event', async () => {
+    const result = await fetchRunsForEvent({
+      ...args,
+      userId: 'user_a',
+      fetchImpl: fakeFetch('user_a'),
+    });
+
+    expect(result).toEqual([{ status: 'Completed', output: RUNS[0].output }]);
+  });
+
+  it('returns nothing to a different user', async () => {
+    const fetchImpl = fakeFetch('user_a');
+    const result = await fetchRunsForEvent({
+      ...args,
+      userId: 'user_b',
+      fetchImpl,
+    });
+
+    expect(result).toEqual([]);
+    // Bailed before ever asking for the output.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns nothing when the event has no owner recorded', async () => {
+    const result = await fetchRunsForEvent({
+      ...args,
+      userId: 'user_a',
+      fetchImpl: fakeFetch(undefined),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns nothing when the event lookup fails', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    expect(
+      await fetchRunsForEvent({ ...args, userId: 'user_a', fetchImpl }),
+    ).toEqual([]);
+  });
+
+  it('returns nothing without a signing key', async () => {
+    const fetchImpl = fakeFetch('user_a');
+
+    expect(
+      await fetchRunsForEvent({
+        eventId: 'evt_1',
+        userId: 'user_a',
+        signingKey: undefined,
+        fetchImpl,
+      }),
+    ).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/ui/apps/dashboard/src/lib/inngest/runLookup.ts
+++ b/ui/apps/dashboard/src/lib/inngest/runLookup.ts
@@ -1,0 +1,77 @@
+//
+// Server-only: reads INNGEST_SIGNING_KEY. Never import this from client code.
+//
+// Reads an agent chat run back from its triggering event, for when the realtime
+// run.completed never reached the browser.
+//
+// Every tenant's Insights chats run through one shared Inngest app, so the
+// signing key scopes a lookup to that app and nothing finer. Ownership has to
+// be enforced here: /api/chat stamps userId into the event from the Clerk
+// session (never from the request body), so an event is only readable by the
+// user who triggered it.
+
+const INNGEST_API_BASE_URL =
+  process.env.INNGEST_API_BASE_URL ?? 'https://api.inngest.com';
+
+export type EventRun = {
+  status: string;
+  output: Record<string, unknown> | null;
+};
+
+type FetchLike = typeof fetch;
+
+async function getJson(
+  path: string,
+  signingKey: string,
+  fetchImpl: FetchLike,
+): Promise<unknown | null> {
+  const res = await fetchImpl(`${INNGEST_API_BASE_URL}${path}`, {
+    headers: { Authorization: `Bearer ${signingKey}` },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+/**
+ * Runs for an event, but only if the authenticated user is the one who
+ * triggered it. Returns [] for "no such event", "not yours", and "lookup
+ * failed" alike, so the caller can't use this to probe for other users' events.
+ */
+export async function fetchRunsForEvent({
+  eventId,
+  userId,
+  signingKey = process.env.INNGEST_SIGNING_KEY,
+  fetchImpl = fetch,
+}: {
+  eventId: string;
+  userId: string;
+  signingKey?: string;
+  fetchImpl?: FetchLike;
+}): Promise<EventRun[]> {
+  if (!signingKey || !userId) return [];
+
+  const encodedId = encodeURIComponent(eventId);
+
+  try {
+    const event = (await getJson(
+      `/v1/events/${encodedId}`,
+      signingKey,
+      fetchImpl,
+    )) as { data?: { data?: { userId?: unknown } } } | null;
+
+    if (event?.data?.data?.userId !== userId) return [];
+
+    const runs = (await getJson(
+      `/v1/events/${encodedId}/runs`,
+      signingKey,
+      fetchImpl,
+    )) as { data?: { status?: string; output?: unknown }[] } | null;
+
+    return (runs?.data ?? []).map((run) => ({
+      status: run.status ?? 'Unknown',
+      output: (run.output ?? null) as Record<string, unknown> | null,
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/ui/apps/dashboard/src/routeTree.gen.ts
+++ b/ui/apps/dashboard/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ApiInngestRouteImport } from './routes/api/inngest'
 import { Route as ApiFeedbackRouteImport } from './routes/api/feedback'
 import { Route as ApiCspReportRouteImport } from './routes/api/csp-report'
 import { Route as ApiChatValidateRouteImport } from './routes/api/chat-validate'
+import { Route as ApiChatResultRouteImport } from './routes/api/chat-result'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
 import { Route as authUserSetupRouteImport } from './routes/(auth)/user-setup'
 import { Route as authSwitchOrganizationRouteImport } from './routes/(auth)/switch-organization'
@@ -159,6 +160,11 @@ const ApiCspReportRoute = ApiCspReportRouteImport.update({
 const ApiChatValidateRoute = ApiChatValidateRouteImport.update({
   id: '/api/chat-validate',
   path: '/api/chat-validate',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiChatResultRoute = ApiChatResultRouteImport.update({
+  id: '/api/chat-result',
+  path: '/api/chat-result',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiChatRoute = ApiChatRouteImport.update({
@@ -705,6 +711,7 @@ export interface FileRoutesByFullPath {
   '/switch-organization': typeof authSwitchOrganizationRoute
   '/user-setup': typeof authUserSetupRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/chat-result': typeof ApiChatResultRoute
   '/api/chat-validate': typeof ApiChatValidateRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/feedback': typeof ApiFeedbackRoute
@@ -807,6 +814,7 @@ export interface FileRoutesByTo {
   '/switch-organization': typeof authSwitchOrganizationRoute
   '/user-setup': typeof authUserSetupRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/chat-result': typeof ApiChatResultRoute
   '/api/chat-validate': typeof ApiChatValidateRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/feedback': typeof ApiFeedbackRoute
@@ -900,6 +908,7 @@ export interface FileRoutesById {
   '/(auth)/switch-organization': typeof authSwitchOrganizationRoute
   '/(auth)/user-setup': typeof authUserSetupRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/chat-result': typeof ApiChatResultRoute
   '/api/chat-validate': typeof ApiChatValidateRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/feedback': typeof ApiFeedbackRoute
@@ -1005,6 +1014,7 @@ export interface FileRouteTypes {
     | '/switch-organization'
     | '/user-setup'
     | '/api/chat'
+    | '/api/chat-result'
     | '/api/chat-validate'
     | '/api/csp-report'
     | '/api/feedback'
@@ -1107,6 +1117,7 @@ export interface FileRouteTypes {
     | '/switch-organization'
     | '/user-setup'
     | '/api/chat'
+    | '/api/chat-result'
     | '/api/chat-validate'
     | '/api/csp-report'
     | '/api/feedback'
@@ -1199,6 +1210,7 @@ export interface FileRouteTypes {
     | '/(auth)/switch-organization'
     | '/(auth)/user-setup'
     | '/api/chat'
+    | '/api/chat-result'
     | '/api/chat-validate'
     | '/api/csp-report'
     | '/api/feedback'
@@ -1301,6 +1313,7 @@ export interface RootRouteChildren {
   authSwitchOrganizationRoute: typeof authSwitchOrganizationRoute
   authUserSetupRoute: typeof authUserSetupRoute
   ApiChatRoute: typeof ApiChatRoute
+  ApiChatResultRoute: typeof ApiChatResultRoute
   ApiChatValidateRoute: typeof ApiChatValidateRoute
   ApiCspReportRoute: typeof ApiCspReportRoute
   ApiFeedbackRoute: typeof ApiFeedbackRoute
@@ -1386,6 +1399,13 @@ declare module '@tanstack/react-router' {
       path: '/api/chat-validate'
       fullPath: '/api/chat-validate'
       preLoaderRoute: typeof ApiChatValidateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/chat-result': {
+      id: '/api/chat-result'
+      path: '/api/chat-result'
+      fullPath: '/api/chat-result'
+      preLoaderRoute: typeof ApiChatResultRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/chat': {
@@ -2445,6 +2465,7 @@ const rootRouteChildren: RootRouteChildren = {
   authSwitchOrganizationRoute: authSwitchOrganizationRoute,
   authUserSetupRoute: authUserSetupRoute,
   ApiChatRoute: ApiChatRoute,
+  ApiChatResultRoute: ApiChatResultRoute,
   ApiChatValidateRoute: ApiChatValidateRoute,
   ApiCspReportRoute: ApiCspReportRoute,
   ApiFeedbackRoute: ApiFeedbackRoute,

--- a/ui/apps/dashboard/src/routes/api/chat-result.ts
+++ b/ui/apps/dashboard/src/routes/api/chat-result.ts
@@ -2,23 +2,21 @@ import { createFileRoute } from '@tanstack/react-router';
 import { auth } from '@clerk/tanstack-react-start/server';
 import { z } from 'zod/v3';
 
+import { fetchRunsForEvent } from '@/lib/inngest/runLookup';
+
 //
 // Recovery path for the agent chat. Realtime has no replay: if the browser is
 // disconnected when the run publishes run.completed, that message is gone for
 // good and the UI would spin forever. The run's own output is the same payload
 // the publish carries, so the chat UI polls here with the event id it got back
-// from /api/chat and reconciles from the run instead.
+// from /api/chat.
+//
+// The lookup is pinned to the caller's Clerk session, the same way
+// chat-validate pins its write, because one shared Inngest app serves every
+// tenant's chats.
 const requestSchema = z.object({
   eventId: z.string().min(1).max(64),
 });
-
-const INNGEST_API_BASE_URL =
-  process.env.INNGEST_API_BASE_URL ?? 'https://api.inngest.com';
-
-type EventRun = {
-  status?: string;
-  output?: unknown;
-};
 
 function json(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), {
@@ -43,32 +41,15 @@ export const Route = createFileRoute('/api/chat-result')({
           );
         }
 
-        const signingKey = process.env.INNGEST_SIGNING_KEY;
-        if (!signingKey) return json({ runs: [] });
+        // userId comes from the Clerk session, never the request body. An
+        // unowned or unknown event returns an empty list either way, so this
+        // can't be used to probe for other users' events.
+        const runs = await fetchRunsForEvent({
+          eventId: parsed.data.eventId,
+          userId,
+        });
 
-        try {
-          // The signing key scopes this to the agent app's own environment, so
-          // the lookup can only ever see this deployment's runs.
-          const res = await fetch(
-            `${INNGEST_API_BASE_URL}/v1/events/${encodeURIComponent(
-              parsed.data.eventId,
-            )}/runs`,
-            { headers: { Authorization: `Bearer ${signingKey}` } },
-          );
-          if (!res.ok) return json({ runs: [] });
-
-          const payload = (await res.json()) as { data?: EventRun[] };
-          const runs = (payload.data ?? []).map((run) => ({
-            status: run.status ?? 'Unknown',
-            output: run.output ?? null,
-          }));
-
-          return json({ runs });
-        } catch {
-          // A failed lookup is not a UI error: the caller falls back to telling
-          // the user to retry rather than surfacing a 500.
-          return json({ runs: [] });
-        }
+        return json({ runs });
       },
     },
   },

--- a/ui/apps/dashboard/src/routes/api/chat-result.ts
+++ b/ui/apps/dashboard/src/routes/api/chat-result.ts
@@ -1,0 +1,75 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { auth } from '@clerk/tanstack-react-start/server';
+import { z } from 'zod/v3';
+
+//
+// Recovery path for the agent chat. Realtime has no replay: if the browser is
+// disconnected when the run publishes run.completed, that message is gone for
+// good and the UI would spin forever. The run's own output is the same payload
+// the publish carries, so the chat UI polls here with the event id it got back
+// from /api/chat and reconciles from the run instead.
+const requestSchema = z.object({
+  eventId: z.string().min(1).max(64),
+});
+
+const INNGEST_API_BASE_URL =
+  process.env.INNGEST_API_BASE_URL ?? 'https://api.inngest.com';
+
+type EventRun = {
+  status?: string;
+  output?: unknown;
+};
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const Route = createFileRoute('/api/chat-result')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const { userId } = await auth();
+        if (!userId) return json({ error: 'Please sign in' }, 401);
+
+        const body: unknown = await request.json().catch(() => null);
+        const parsed = requestSchema.safeParse(body);
+        if (!parsed.success) {
+          return json(
+            { error: parsed.error.errors[0]?.message ?? 'Invalid request' },
+            400,
+          );
+        }
+
+        const signingKey = process.env.INNGEST_SIGNING_KEY;
+        if (!signingKey) return json({ runs: [] });
+
+        try {
+          // The signing key scopes this to the agent app's own environment, so
+          // the lookup can only ever see this deployment's runs.
+          const res = await fetch(
+            `${INNGEST_API_BASE_URL}/v1/events/${encodeURIComponent(
+              parsed.data.eventId,
+            )}/runs`,
+            { headers: { Authorization: `Bearer ${signingKey}` } },
+          );
+          if (!res.ok) return json({ runs: [] });
+
+          const payload = (await res.json()) as { data?: EventRun[] };
+          const runs = (payload.data ?? []).map((run) => ({
+            status: run.status ?? 'Unknown',
+            output: run.output ?? null,
+          }));
+
+          return json({ runs });
+        } catch {
+          // A failed lookup is not a UI error: the caller falls back to telling
+          // the user to retry rather than surfacing a 500.
+          return json({ runs: [] });
+        }
+      },
+    },
+  },
+});

--- a/ui/apps/dashboard/src/routes/api/chat.ts
+++ b/ui/apps/dashboard/src/routes/api/chat.ts
@@ -89,7 +89,7 @@ export const Route = createFileRoute('/api/chat')({
 
           //
           // Send event to Inngest to trigger the agent chat
-          await inngest.send({
+          const { ids } = await inngest.send({
             name: 'insights-agent/chat.requested',
             data: {
               threadId: threadId ?? undefined,
@@ -110,6 +110,9 @@ export const Route = createFileRoute('/api/chat')({
             JSON.stringify({
               success: true,
               threadId: threadId,
+              // Lets the chat UI recover the result via /api/chat-result if the
+              // realtime run.completed never reaches the browser.
+              eventId: ids[0],
             }),
             {
               status: 200,


### PR DESCRIPTION
## Description

Had two runs in prod where the agent finished fine but the output never made it back to the browser. Realtime has no replay, so if the tab gets hidden or the socket drops while the run is going, the `run.completed` message is just gone and the chat spins forever.

Two things here:

- `pauseOnHidden: false` on the subscription. It defaults to true, which tears the whole subscription down when you switch tabs, and these runs routinely outlast a tab switch.
- The chat can now read the result back from the run itself. `/api/chat` returns the event id, and a per-thread watchdog hits a new `/api/chat-result` if nothing shows up. The run output is already the same payload the publish carries, so nothing new gets stored. A lost message now ends in either the actual result or a retry prompt instead of an infinite spinner.

The `run.completed` handler moved into a shared `applyRunResult` so both paths go through the same code.

## Release note

None.

## Migration note

None.