### PR TITLE
fix(insights): recover Insights AI results from a missed run.completed

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
@@ -5,11 +5,14 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
   type ReactNode,
 } from 'react';
 
+import { assistantMessage, chatReducer, initialChatState } from './chatReducer';
+import { RunResultWatcher } from './RunResultWatcher';
 import {
   useInsightsRealtime,
   sendChatMessage,
@@ -17,7 +20,7 @@ import {
 } from './useInsightsAgent';
 import { useFetchInsights } from '@/components/Insights/InsightsStateMachineContext/useFetchInsights';
 import { useEventTypeSchemas } from '../SchemaExplorer/SchemasContext/useEventTypeSchemas';
-import type { InsightsRealtimeEvent, Message } from './types';
+import type { InsightsRealtimeEvent, Message, MessagePart } from './types';
 
 type ThreadFlags = {
   networkActive: boolean;
@@ -46,10 +49,6 @@ type ContextValue = {
   schemas: { name: string; schema: string }[];
 };
 
-const defaultFlags: ThreadFlags = {
-  networkActive: false,
-};
-
 const InsightsChatContext = createContext<ContextValue | undefined>(undefined);
 
 export function InsightsChatProvider({
@@ -61,19 +60,24 @@ export function InsightsChatProvider({
   channelKey?: string;
   children: ReactNode;
 }) {
-  // Per-thread UI flags
-  const [threadFlags, setThreadFlags] = useState<Record<string, ThreadFlags>>(
-    {},
+  const [{ messagesByThread, pendingByThread }, dispatch] = useReducer(
+    chatReducer,
+    initialChatState,
   );
-  // Per-thread messages
-  const [messagesByThread, setMessagesByThread] = useState<
-    Record<string, Message[]>
-  >({});
   // Current active thread
   const [currentThreadId, setCurrentThreadId] = useState<string | null>(null);
   // Latest generated SQL per thread
   const latestSqlByThreadRef = useRef<Map<string, string>>(new Map());
   const [latestSqlVersion, setLatestSqlVersion] = useState(0);
+
+  // Bumping the version re-runs the editor's auto-apply, so only publish SQL
+  // we haven't already seen for this thread. The query-writer step and the
+  // completed run report the same SQL.
+  const cacheSql = useCallback((threadId: string, sql: string) => {
+    if (latestSqlByThreadRef.current.get(threadId) === sql) return;
+    latestSqlByThreadRef.current.set(threadId, sql);
+    setLatestSqlVersion((v) => v + 1);
+  }, []);
 
   // Per-thread client state map
   const threadClientStateRef = useRef<Map<string, ClientState>>(new Map());
@@ -85,8 +89,10 @@ export function InsightsChatProvider({
   );
 
   const getFlags = useCallback(
-    (threadId: string): ThreadFlags => threadFlags[threadId] ?? defaultFlags,
-    [threadFlags],
+    (threadId: string): ThreadFlags => ({
+      networkActive: threadId in pendingByThread,
+    }),
+    [pendingByThread],
   );
 
   const getLatestGeneratedSql = useCallback(
@@ -164,6 +170,51 @@ export function InsightsChatProvider({
     return 'ready';
   }, [connectionStatus]);
 
+  // Shared by the realtime run.completed event and the recovery poll, which
+  // carry the same payload.
+  const applyRunResult = useCallback(
+    (threadId: string, data: Record<string, unknown>) => {
+      const parts: MessagePart[] = [];
+
+      const sql = typeof data.sql === 'string' ? data.sql : undefined;
+      if (sql) {
+        parts.push({
+          type: 'tool-call',
+          toolName: 'generate_sql',
+          data: {
+            sql,
+            title: typeof data.title === 'string' ? data.title : undefined,
+            reasoning:
+              typeof data.reasoning === 'string' ? data.reasoning : undefined,
+          },
+        });
+
+        cacheSql(threadId, sql);
+      }
+
+      const summary =
+        typeof data.summary === 'string' ? data.summary : undefined;
+      if (summary) parts.push({ type: 'text', content: summary });
+
+      dispatch({
+        type: 'result',
+        threadId,
+        message: parts.length > 0 ? assistantMessage(threadId, parts) : null,
+      });
+    },
+    [cacheSql],
+  );
+
+  const failThread = useCallback((threadId: string, message: string) => {
+    dispatch({
+      type: 'result',
+      threadId,
+      message: assistantMessage(threadId, [
+        { type: 'text', content: `Error: ${message}` },
+      ]),
+    });
+  }, []);
+
   // Process new realtime events
   useEffect(() => {
     for (const msg of realtimeMessages.delta) {
@@ -177,83 +228,18 @@ export function InsightsChatProvider({
 
       try {
         switch (evt.event) {
-          case 'run.started': {
-            setThreadFlags((prev) => ({
-              ...prev,
-              [tid]: { networkActive: true },
-            }));
-            break;
-          }
-
           case 'step.completed': {
             // Cache SQL when query-writer step completes
             if (evt.data.step === 'query-writer') {
               const sql =
                 typeof evt.data.sql === 'string' ? evt.data.sql : undefined;
-              if (sql && sql.length > 0) {
-                latestSqlByThreadRef.current.set(tid, sql);
-                setLatestSqlVersion((v) => v + 1);
-              }
+              if (sql && sql.length > 0) cacheSql(tid, sql);
             }
             break;
           }
 
           case 'run.completed': {
-            // Build assistant message from the completed run
-            const parts: Message['parts'] = [];
-
-            // Add SQL tool call part if present
-            const sql =
-              typeof evt.data.sql === 'string' ? evt.data.sql : undefined;
-            if (sql) {
-              parts.push({
-                type: 'tool-call',
-                toolName: 'generate_sql',
-                data: {
-                  sql,
-                  title:
-                    typeof evt.data.title === 'string'
-                      ? evt.data.title
-                      : undefined,
-                  reasoning:
-                    typeof evt.data.reasoning === 'string'
-                      ? evt.data.reasoning
-                      : undefined,
-                },
-              });
-
-              // Also update the SQL cache
-              latestSqlByThreadRef.current.set(tid, sql);
-              setLatestSqlVersion((v) => v + 1);
-            }
-
-            // Add summary text part if present
-            const summary =
-              typeof evt.data.summary === 'string'
-                ? evt.data.summary
-                : undefined;
-            if (summary) {
-              parts.push({ type: 'text', content: summary });
-            }
-
-            if (parts.length > 0) {
-              const assistantMsg: Message = {
-                id: crypto.randomUUID(),
-                role: 'assistant',
-                threadId: tid,
-                parts,
-              };
-
-              setMessagesByThread((prev) => ({
-                ...prev,
-                [tid]: [...(prev[tid] || []), assistantMsg],
-              }));
-            }
-
-            setThreadFlags((prev) => ({
-              ...prev,
-              [tid]: { networkActive: false },
-            }));
+            applyRunResult(tid, evt.data);
             break;
           }
 
@@ -269,28 +255,12 @@ export function InsightsChatProvider({
           }
 
           case 'error': {
-            // Add error as an assistant message
-            const errorMessage =
+            failThread(
+              tid,
               typeof evt.data.error === 'string'
                 ? evt.data.error
-                : 'An unknown error occurred';
-
-            const errorMsg: Message = {
-              id: crypto.randomUUID(),
-              role: 'assistant',
-              threadId: tid,
-              parts: [{ type: 'text', content: `Error: ${errorMessage}` }],
-            };
-
-            setMessagesByThread((prev) => ({
-              ...prev,
-              [tid]: [...(prev[tid] || []), errorMsg],
-            }));
-
-            setThreadFlags((prev) => ({
-              ...prev,
-              [tid]: { networkActive: false },
-            }));
+                : 'An unknown error occurred',
+            );
             break;
           }
         }
@@ -298,7 +268,13 @@ export function InsightsChatProvider({
         // Silently handle event processing errors
       }
     }
-  }, [realtimeMessages.delta, validateSql]);
+  }, [
+    realtimeMessages.delta,
+    validateSql,
+    applyRunResult,
+    failThread,
+    cacheSql,
+  ]);
 
   // Fetch event types and schemas using the same hook as SchemaExplorer
   const getEventTypeSchemas = useEventTypeSchemas();
@@ -376,15 +352,15 @@ export function InsightsChatProvider({
         parts: [{ type: 'text', content }],
       };
 
-      setMessagesByThread((prev) => ({
-        ...prev,
-        [threadId]: [...(prev[threadId] || []), userMsg],
-      }));
+      // Marks the thread pending, which is what turns the spinner on. Done
+      // before the await so a run that answers immediately still has a thread
+      // to answer into.
+      dispatch({ type: 'send', threadId, message: userMsg });
 
       const clientState = threadClientStateRef.current.get(threadId);
 
       try {
-        await sendChatMessage({
+        const { eventId } = await sendChatMessage({
           content,
           messageId,
           threadId,
@@ -402,40 +378,34 @@ export function InsightsChatProvider({
               },
           history: buildHistory(threadId),
         });
+
+        // Lets RunResultWatcher recover the result if the realtime
+        // run.completed never reaches the browser.
+        if (eventId) dispatch({ type: 'sent', threadId, eventId });
       } catch (error) {
         // Remove the optimistic user message and show error
-        setMessagesByThread((prev) => ({
-          ...prev,
-          [threadId]: [
-            ...(prev[threadId] || []).filter((m) => m.id !== messageId),
+        dispatch({
+          type: 'sendFailed',
+          threadId,
+          messageId,
+          message: assistantMessage(threadId, [
             {
-              id: crypto.randomUUID(),
-              role: 'assistant' as const,
-              threadId,
-              parts: [
-                {
-                  type: 'text' as const,
-                  content: `Error: ${
-                    error instanceof Error
-                      ? error.message
-                      : 'Failed to send message'
-                  }`,
-                },
-              ],
+              type: 'text',
+              content: `Error: ${
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to send message'
+              }`,
             },
-          ],
-        }));
+          ]),
+        });
       }
     },
     [userId, channelKey, eventsData?.names, schemas, buildHistory],
   );
 
   const clearThreadMessages = useCallback((threadId: string) => {
-    setMessagesByThread((prev) => {
-      const next = { ...prev };
-      delete next[threadId];
-      return next;
-    });
+    dispatch({ type: 'clearThread', threadId });
     latestSqlByThreadRef.current.delete(threadId);
   }, []);
 
@@ -477,6 +447,17 @@ export function InsightsChatProvider({
 
   return (
     <InsightsChatContext.Provider value={value}>
+      {Object.entries(pendingByThread).map(([threadId, eventId]) =>
+        eventId ? (
+          <RunResultWatcher
+            key={eventId}
+            eventId={eventId}
+            threadId={threadId}
+            onResult={applyRunResult}
+            onFail={failThread}
+          />
+        ) : null,
+      )}
       {children}
     </InsightsChatContext.Provider>
   );

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/RunResultWatcher.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/RunResultWatcher.tsx
@@ -1,0 +1,84 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+import { fetchRunResult } from './useInsightsAgent';
+
+// The runs endpoint is cached and shares one rate-limit bucket across every
+// Insights user, so there's nothing to gain from polling faster than this.
+const POLL_INTERVAL_MS = 20_000;
+
+// Run status and run output are read from different stores, so a run can
+// report Completed a moment before its output is readable. Give that a few
+// polls before calling the result lost.
+const EMPTY_TERMINAL_POLL_LIMIT = 3;
+
+type Props = {
+  eventId: string;
+  threadId: string;
+  onResult: (threadId: string, output: Record<string, unknown>) => void;
+  onFail: (threadId: string, message: string) => void;
+};
+
+/**
+ * Watches one in-flight agent run and reports its result.
+ *
+ * Realtime has no replay: a run that finishes while the browser is hidden or
+ * disconnected publishes a `run.completed` that nobody receives, and the thread
+ * spins forever. The run's own output is the same payload that publish carries,
+ * so we read it back from the run instead.
+ *
+ * Mounting starts the watch and unmounting stops it, so the provider only has
+ * to add and remove the thread from its pending map.
+ */
+export function RunResultWatcher({
+  eventId,
+  threadId,
+  onResult,
+  onFail,
+}: Props) {
+  // Structural sharing keeps `data` identical across unchanged polls, so the
+  // timestamp is what tells us a fresh poll landed.
+  const { data, dataUpdatedAt } = useQuery({
+    queryKey: ['insights-chat-result', eventId],
+    queryFn: () => fetchRunResult(eventId, threadId),
+    refetchInterval: POLL_INTERVAL_MS,
+    // The two moments a missed message is worth chasing straight away.
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    gcTime: 0,
+  });
+
+  const emptyTerminalPolls = useRef(0);
+
+  useEffect(() => {
+    if (!data) return;
+
+    if (data.status === 'Completed' && data.output) {
+      onResult(threadId, data.output);
+      return;
+    }
+
+    if (data.status === 'Failed' || data.status === 'Cancelled') {
+      onFail(
+        threadId,
+        'The Insights agent could not complete this request. Please try again.',
+      );
+      return;
+    }
+
+    if (data.status === 'Completed') {
+      emptyTerminalPolls.current += 1;
+      if (emptyTerminalPolls.current >= EMPTY_TERMINAL_POLL_LIMIT) {
+        onFail(
+          threadId,
+          "This request finished but its result couldn't be read back. Please try sending it again.",
+        );
+      }
+    }
+
+    // Still Running: nothing to report, and no attempt cap — the answer is
+    // still coming.
+  }, [data, dataUpdatedAt, threadId, onResult, onFail]);
+
+  return null;
+}

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/chatReducer.test.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/chatReducer.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assistantMessage,
+  chatReducer,
+  initialChatState,
+  type ChatState,
+} from './chatReducer';
+import type { Message } from './types';
+
+const THREAD = 'thread_1';
+
+const userMessage: Message = {
+  id: 'msg_1',
+  role: 'user',
+  threadId: THREAD,
+  parts: [{ type: 'text', content: 'how many runs failed?' }],
+};
+
+function afterSend(): ChatState {
+  return chatReducer(initialChatState, {
+    type: 'send',
+    threadId: THREAD,
+    message: userMessage,
+  });
+}
+
+const answer = () =>
+  assistantMessage(THREAD, [{ type: 'text', content: '12 runs' }]);
+
+describe('chatReducer', () => {
+  it('marks the thread pending as soon as the message is sent', () => {
+    const state = afterSend();
+
+    expect(state.pendingByThread).toEqual({ [THREAD]: '' });
+    expect(state.messagesByThread[THREAD]).toEqual([userMessage]);
+  });
+
+  it('records the event id so the result can be recovered', () => {
+    const state = chatReducer(afterSend(), {
+      type: 'sent',
+      threadId: THREAD,
+      eventId: 'evt_1',
+    });
+
+    expect(state.pendingByThread).toEqual({ [THREAD]: 'evt_1' });
+  });
+
+  it('ignores the event id once the run has already answered', () => {
+    const answered = chatReducer(afterSend(), {
+      type: 'result',
+      threadId: THREAD,
+      message: answer(),
+    });
+
+    const state = chatReducer(answered, {
+      type: 'sent',
+      threadId: THREAD,
+      eventId: 'evt_1',
+    });
+
+    expect(state).toBe(answered);
+    expect(state.pendingByThread).toEqual({});
+  });
+
+  it('applies the first result and clears the thread', () => {
+    const state = chatReducer(afterSend(), {
+      type: 'result',
+      threadId: THREAD,
+      message: answer(),
+    });
+
+    expect(state.messagesByThread[THREAD]).toHaveLength(2);
+    expect(state.pendingByThread).toEqual({});
+  });
+
+  it('drops a second result for the same run', () => {
+    // Realtime and the recovery poll both deliver; only one may land.
+    const first = chatReducer(afterSend(), {
+      type: 'result',
+      threadId: THREAD,
+      message: answer(),
+    });
+
+    const second = chatReducer(first, {
+      type: 'result',
+      threadId: THREAD,
+      message: answer(),
+    });
+
+    expect(second).toBe(first);
+    expect(second.messagesByThread[THREAD]).toHaveLength(2);
+  });
+
+  it('drops a result for a thread the user cleared', () => {
+    const cleared = chatReducer(afterSend(), {
+      type: 'clearThread',
+      threadId: THREAD,
+    });
+
+    const state = chatReducer(cleared, {
+      type: 'result',
+      threadId: THREAD,
+      message: answer(),
+    });
+
+    expect(state.messagesByThread[THREAD]).toBeUndefined();
+    expect(state.pendingByThread).toEqual({});
+  });
+
+  it('stops the spinner but keeps the thread when a result has no parts', () => {
+    const state = chatReducer(afterSend(), {
+      type: 'result',
+      threadId: THREAD,
+      message: null,
+    });
+
+    expect(state.messagesByThread[THREAD]).toEqual([userMessage]);
+    expect(state.pendingByThread).toEqual({});
+  });
+
+  it('rolls back the optimistic user message when the send fails', () => {
+    const state = chatReducer(afterSend(), {
+      type: 'sendFailed',
+      threadId: THREAD,
+      messageId: userMessage.id,
+      message: assistantMessage(THREAD, [
+        { type: 'text', content: 'Error: nope' },
+      ]),
+    });
+
+    expect(state.messagesByThread[THREAD]).toHaveLength(1);
+    expect(state.messagesByThread[THREAD]?.[0]?.role).toBe('assistant');
+    expect(state.pendingByThread).toEqual({});
+  });
+
+  it('keeps threads independent', () => {
+    const other = chatReducer(afterSend(), {
+      type: 'send',
+      threadId: 'thread_2',
+      message: { ...userMessage, id: 'msg_2', threadId: 'thread_2' },
+    });
+
+    const state = chatReducer(other, {
+      type: 'result',
+      threadId: THREAD,
+      message: answer(),
+    });
+
+    expect(state.pendingByThread).toEqual({ thread_2: '' });
+    expect(state.messagesByThread['thread_2']).toHaveLength(1);
+  });
+});

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/chatReducer.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/chatReducer.ts
@@ -1,0 +1,102 @@
+import type { Message, MessagePart } from './types';
+
+export type ChatState = {
+  messagesByThread: Record<string, Message[]>;
+  // Threads waiting on an agent run: threadId -> the id of the event that
+  // triggered it, or '' when /api/chat didn't return one. Presence is the
+  // single source of truth for the spinner, for whether the recovery poll
+  // runs, and for whether a result still has somewhere to land.
+  pendingByThread: Record<string, string>;
+};
+
+export type ChatAction =
+  | { type: 'send'; threadId: string; message: Message }
+  | { type: 'sent'; threadId: string; eventId: string }
+  | {
+      type: 'sendFailed';
+      threadId: string;
+      messageId: string;
+      message: Message;
+    }
+  | { type: 'result'; threadId: string; message: Message | null }
+  | { type: 'clearThread'; threadId: string };
+
+export const initialChatState: ChatState = {
+  messagesByThread: {},
+  pendingByThread: {},
+};
+
+export function assistantMessage(
+  threadId: string,
+  parts: MessagePart[],
+): Message {
+  return { id: crypto.randomUUID(), role: 'assistant', threadId, parts };
+}
+
+function omit<T>(map: Record<string, T>, key: string): Record<string, T> {
+  if (!(key in map)) return map;
+  const next = { ...map };
+  delete next[key];
+  return next;
+}
+
+export function chatReducer(state: ChatState, action: ChatAction): ChatState {
+  const { threadId } = action;
+  const messages = state.messagesByThread[threadId] ?? [];
+
+  switch (action.type) {
+    case 'send':
+      return {
+        messagesByThread: {
+          ...state.messagesByThread,
+          [threadId]: [...messages, action.message],
+        },
+        pendingByThread: { ...state.pendingByThread, [threadId]: '' },
+      };
+
+    case 'sent':
+      // A fast run can answer before /api/chat even returns, leaving nothing
+      // left to recover.
+      if (!(threadId in state.pendingByThread)) return state;
+      return {
+        ...state,
+        pendingByThread: {
+          ...state.pendingByThread,
+          [threadId]: action.eventId,
+        },
+      };
+
+    case 'sendFailed':
+      return {
+        messagesByThread: {
+          ...state.messagesByThread,
+          [threadId]: [
+            ...messages.filter((m) => m.id !== action.messageId),
+            action.message,
+          ],
+        },
+        pendingByThread: omit(state.pendingByThread, threadId),
+      };
+
+    case 'result':
+      // Realtime and the recovery poll carry the same result, and a cleared
+      // thread wants neither: whichever arrives first empties the pending
+      // entry and everything after it no-ops here.
+      if (!(threadId in state.pendingByThread)) return state;
+      return {
+        messagesByThread: action.message
+          ? {
+              ...state.messagesByThread,
+              [threadId]: [...messages, action.message],
+            }
+          : state.messagesByThread,
+        pendingByThread: omit(state.pendingByThread, threadId),
+      };
+
+    case 'clearThread':
+      return {
+        messagesByThread: omit(state.messagesByThread, threadId),
+        pendingByThread: omit(state.pendingByThread, threadId),
+      };
+  }
+}

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/useInsightsAgent.test.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/useInsightsAgent.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchRunResult } from './useInsightsAgent';
+
+function mockResponse(body: unknown, ok = true) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      json: async () => body,
+    }),
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchRunResult', () => {
+  it('returns the run whose output matches the thread', async () => {
+    mockResponse({
+      runs: [
+        { status: 'Completed', output: { threadId: 'other', summary: 'no' } },
+        { status: 'Completed', output: { threadId: 'mine', summary: 'yes' } },
+      ],
+    });
+
+    const result = await fetchRunResult('evt_1', 'mine');
+    expect(result?.output).toMatchObject({ summary: 'yes' });
+  });
+
+  it('falls back to the only run when no output carries a thread id', async () => {
+    mockResponse({ runs: [{ status: 'Running', output: null }] });
+
+    const result = await fetchRunResult('evt_1', 'mine');
+    expect(result?.status).toBe('Running');
+  });
+
+  it('returns null when the lookup finds nothing', async () => {
+    mockResponse({ runs: [] });
+    expect(await fetchRunResult('evt_1', 'mine')).toBeNull();
+  });
+
+  it('returns null on a non-ok response', async () => {
+    mockResponse({}, false);
+    expect(await fetchRunResult('evt_1', 'mine')).toBeNull();
+  });
+});

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/useInsightsAgent.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/useInsightsAgent.ts
@@ -48,6 +48,10 @@ export function useInsightsRealtime({
     autoCloseOnTerminal: false,
     reconnect: true,
     historyLimit: 200,
+    // Hiding the tab would otherwise tear the subscription down entirely, and
+    // realtime has no replay: anything the run publishes while we're away is
+    // lost. Agent runs routinely outlast a tab switch.
+    pauseOnHidden: false,
   });
 }
 
@@ -62,7 +66,7 @@ export async function sendChatMessage(params: {
   channelKey?: string;
   state?: Record<string, unknown>;
   history?: Array<Record<string, unknown>>;
-}): Promise<{ success: boolean; threadId?: string }> {
+}): Promise<{ success: boolean; threadId?: string; eventId?: string }> {
   const res = await fetch('/api/chat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -86,4 +90,42 @@ export async function sendChatMessage(params: {
   }
 
   return res.json();
+}
+
+export type RunResult = {
+  status: string;
+  output: Record<string, unknown> | null;
+};
+
+/**
+ * Read a chat run back from its triggering event, for when the realtime
+ * run.completed never arrived. Resolves to null when the run can't be
+ * determined, which the caller treats the same as a failure.
+ */
+export async function fetchRunResult(
+  eventId: string,
+  threadId: string,
+): Promise<RunResult | null> {
+  const res = await fetch('/api/chat-result', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ eventId }),
+  });
+  if (!res.ok) return null;
+
+  const { runs } = (await res.json()) as { runs?: RunResult[] };
+  if (!runs?.length) return null;
+
+  // One event triggers one agent run today, but match on the thread so a
+  // second run on the same event could never answer for this one.
+  return (
+    runs.find(
+      (run) =>
+        run.output &&
+        typeof run.output === 'object' &&
+        (run.output as { threadId?: unknown }).threadId === threadId,
+    ) ??
+    runs[0] ??
+    null
+  );
 }

--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -362,11 +362,14 @@ export const runInsightsAgent = inngest.createFunction(
       timestamp: Date.now(),
     });
 
+    // Mirrors the run.completed payload above: the chat UI reads this run
+    // output back when the realtime message doesn't reach the browser.
     return {
       success: true,
       threadId,
       sql: draft.sql ?? '',
       title: draft.title ?? '',
+      reasoning: draft.reasoning ?? '',
       summary,
       kind: draft.sql ? 'query' : 'answer',
       selectedEvents: draft.selectedEvents,

--- a/ui/apps/dashboard/src/lib/inngest/runLookup.test.ts
+++ b/ui/apps/dashboard/src/lib/inngest/runLookup.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchRunsForEvent } from './runLookup';
+
+const RUNS = [{ status: 'Completed', output: { summary: 'secret' } }];
+
+// Responds to /v1/events/{id} with the given owner, and to the runs path with RUNS.
+function fakeFetch(ownerUserId: string | undefined, runs = RUNS) {
+  return vi.fn(async (url: string) => {
+    const body = String(url).endsWith('/runs')
+      ? { data: runs }
+      : { data: { data: { userId: ownerUserId } } };
+    return { ok: true, json: async () => body } as Response;
+  }) as unknown as typeof fetch;
+}
+
+const args = { eventId: 'evt_1', signingKey: 'signkey' };
+
+describe('fetchRunsForEvent', () => {
+  it('returns runs to the user who triggered the event', async () => {
+    const result = await fetchRunsForEvent({
+      ...args,
+      userId: 'user_a',
+      fetchImpl: fakeFetch('user_a'),
+    });
+
+    expect(result).toEqual([{ status: 'Completed', output: RUNS[0].output }]);
+  });
+
+  it('returns nothing to a different user', async () => {
+    const fetchImpl = fakeFetch('user_a');
+    const result = await fetchRunsForEvent({
+      ...args,
+      userId: 'user_b',
+      fetchImpl,
+    });
+
+    expect(result).toEqual([]);
+    // Bailed before ever asking for the output.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns nothing when the event has no owner recorded', async () => {
+    const result = await fetchRunsForEvent({
+      ...args,
+      userId: 'user_a',
+      fetchImpl: fakeFetch(undefined),
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns nothing when the event lookup fails', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+
+    expect(
+      await fetchRunsForEvent({ ...args, userId: 'user_a', fetchImpl }),
+    ).toEqual([]);
+  });
+
+  it('returns nothing without a signing key', async () => {
+    const fetchImpl = fakeFetch('user_a');
+
+    expect(
+      await fetchRunsForEvent({
+        eventId: 'evt_1',
+        userId: 'user_a',
+        signingKey: undefined,
+        fetchImpl,
+      }),
+    ).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/ui/apps/dashboard/src/lib/inngest/runLookup.ts
+++ b/ui/apps/dashboard/src/lib/inngest/runLookup.ts
@@ -1,0 +1,82 @@
+//
+// Server-only: reads INNGEST_SIGNING_KEY. Never import this from client code.
+//
+// Reads an agent chat run back from its triggering event, for when the realtime
+// run.completed never reached the browser.
+//
+// Every tenant's Insights chats run through one shared Inngest app, so the
+// signing key scopes a lookup to that app and nothing finer. Ownership has to
+// be enforced here: /api/chat stamps userId into the event from the Clerk
+// session (never from the request body), so an event is only readable by the
+// user who triggered it.
+
+// A local dev server serves the same endpoints unauthenticated, so the signing
+// key is only required against the real API.
+const IS_DEV = Boolean(process.env.INNGEST_DEV);
+
+const INNGEST_API_BASE_URL =
+  process.env.INNGEST_API_BASE_URL ??
+  (IS_DEV ? 'http://localhost:8288' : 'https://api.inngest.com');
+
+export type EventRun = {
+  status: string;
+  output: Record<string, unknown> | null;
+};
+
+type FetchLike = typeof fetch;
+
+async function getJson(
+  path: string,
+  signingKey: string | undefined,
+  fetchImpl: FetchLike,
+): Promise<unknown | null> {
+  const res = await fetchImpl(`${INNGEST_API_BASE_URL}${path}`, {
+    headers: signingKey ? { Authorization: `Bearer ${signingKey}` } : {},
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+/**
+ * Runs for an event, but only if the authenticated user is the one who
+ * triggered it. Returns [] for "no such event", "not yours", and "lookup
+ * failed" alike, so the caller can't use this to probe for other users' events.
+ */
+export async function fetchRunsForEvent({
+  eventId,
+  userId,
+  signingKey = process.env.INNGEST_SIGNING_KEY,
+  fetchImpl = fetch,
+}: {
+  eventId: string;
+  userId: string;
+  signingKey?: string;
+  fetchImpl?: FetchLike;
+}): Promise<EventRun[]> {
+  if ((!signingKey && !IS_DEV) || !userId) return [];
+
+  const encodedId = encodeURIComponent(eventId);
+
+  try {
+    const event = (await getJson(
+      `/v1/events/${encodedId}`,
+      signingKey,
+      fetchImpl,
+    )) as { data?: { data?: { userId?: unknown } } } | null;
+
+    if (event?.data?.data?.userId !== userId) return [];
+
+    const runs = (await getJson(
+      `/v1/events/${encodedId}/runs`,
+      signingKey,
+      fetchImpl,
+    )) as { data?: { status?: string; output?: unknown }[] } | null;
+
+    return (runs?.data ?? []).map((run) => ({
+      status: run.status ?? 'Unknown',
+      output: (run.output ?? null) as Record<string, unknown> | null,
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/ui/apps/dashboard/src/routeTree.gen.ts
+++ b/ui/apps/dashboard/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as ApiInngestRouteImport } from './routes/api/inngest'
 import { Route as ApiFeedbackRouteImport } from './routes/api/feedback'
 import { Route as ApiCspReportRouteImport } from './routes/api/csp-report'
 import { Route as ApiChatValidateRouteImport } from './routes/api/chat-validate'
+import { Route as ApiChatResultRouteImport } from './routes/api/chat-result'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
 import { Route as authUserSetupRouteImport } from './routes/(auth)/user-setup'
 import { Route as authSwitchOrganizationRouteImport } from './routes/(auth)/switch-organization'
@@ -161,6 +162,11 @@ const ApiCspReportRoute = ApiCspReportRouteImport.update({
 const ApiChatValidateRoute = ApiChatValidateRouteImport.update({
   id: '/api/chat-validate',
   path: '/api/chat-validate',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiChatResultRoute = ApiChatResultRouteImport.update({
+  id: '/api/chat-result',
+  path: '/api/chat-result',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiChatRoute = ApiChatRouteImport.update({
@@ -719,6 +725,7 @@ export interface FileRoutesByFullPath {
   '/switch-organization': typeof authSwitchOrganizationRoute
   '/user-setup': typeof authUserSetupRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/chat-result': typeof ApiChatResultRoute
   '/api/chat-validate': typeof ApiChatValidateRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/feedback': typeof ApiFeedbackRoute
@@ -823,6 +830,7 @@ export interface FileRoutesByTo {
   '/switch-organization': typeof authSwitchOrganizationRoute
   '/user-setup': typeof authUserSetupRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/chat-result': typeof ApiChatResultRoute
   '/api/chat-validate': typeof ApiChatValidateRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/feedback': typeof ApiFeedbackRoute
@@ -918,6 +926,7 @@ export interface FileRoutesById {
   '/(auth)/switch-organization': typeof authSwitchOrganizationRoute
   '/(auth)/user-setup': typeof authUserSetupRoute
   '/api/chat': typeof ApiChatRoute
+  '/api/chat-result': typeof ApiChatResultRoute
   '/api/chat-validate': typeof ApiChatValidateRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/feedback': typeof ApiFeedbackRoute
@@ -1025,6 +1034,7 @@ export interface FileRouteTypes {
     | '/switch-organization'
     | '/user-setup'
     | '/api/chat'
+    | '/api/chat-result'
     | '/api/chat-validate'
     | '/api/csp-report'
     | '/api/feedback'
@@ -1129,6 +1139,7 @@ export interface FileRouteTypes {
     | '/switch-organization'
     | '/user-setup'
     | '/api/chat'
+    | '/api/chat-result'
     | '/api/chat-validate'
     | '/api/csp-report'
     | '/api/feedback'
@@ -1223,6 +1234,7 @@ export interface FileRouteTypes {
     | '/(auth)/switch-organization'
     | '/(auth)/user-setup'
     | '/api/chat'
+    | '/api/chat-result'
     | '/api/chat-validate'
     | '/api/csp-report'
     | '/api/feedback'
@@ -1327,6 +1339,7 @@ export interface RootRouteChildren {
   authSwitchOrganizationRoute: typeof authSwitchOrganizationRoute
   authUserSetupRoute: typeof authUserSetupRoute
   ApiChatRoute: typeof ApiChatRoute
+  ApiChatResultRoute: typeof ApiChatResultRoute
   ApiChatValidateRoute: typeof ApiChatValidateRoute
   ApiCspReportRoute: typeof ApiCspReportRoute
   ApiFeedbackRoute: typeof ApiFeedbackRoute
@@ -1412,6 +1425,13 @@ declare module '@tanstack/react-router' {
       path: '/api/chat-validate'
       fullPath: '/api/chat-validate'
       preLoaderRoute: typeof ApiChatValidateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/chat-result': {
+      id: '/api/chat-result'
+      path: '/api/chat-result'
+      fullPath: '/api/chat-result'
+      preLoaderRoute: typeof ApiChatResultRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/chat': {
@@ -2490,6 +2510,7 @@ const rootRouteChildren: RootRouteChildren = {
   authSwitchOrganizationRoute: authSwitchOrganizationRoute,
   authUserSetupRoute: authUserSetupRoute,
   ApiChatRoute: ApiChatRoute,
+  ApiChatResultRoute: ApiChatResultRoute,
   ApiChatValidateRoute: ApiChatValidateRoute,
   ApiCspReportRoute: ApiCspReportRoute,
   ApiFeedbackRoute: ApiFeedbackRoute,

--- a/ui/apps/dashboard/src/routes/api/chat-result.ts
+++ b/ui/apps/dashboard/src/routes/api/chat-result.ts
@@ -1,0 +1,56 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { auth } from '@clerk/tanstack-react-start/server';
+import { z } from 'zod/v3';
+
+import { fetchRunsForEvent } from '@/lib/inngest/runLookup';
+
+//
+// Recovery path for the agent chat. Realtime has no replay: if the browser is
+// disconnected when the run publishes run.completed, that message is gone for
+// good and the UI would spin forever. The run's own output is the same payload
+// the publish carries, so the chat UI polls here with the event id it got back
+// from /api/chat.
+//
+// The lookup is pinned to the caller's Clerk session, the same way
+// chat-validate pins its write, because one shared Inngest app serves every
+// tenant's chats.
+const requestSchema = z.object({
+  eventId: z.string().min(1).max(64),
+});
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export const Route = createFileRoute('/api/chat-result')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const { userId } = await auth();
+        if (!userId) return json({ error: 'Please sign in' }, 401);
+
+        const body: unknown = await request.json().catch(() => null);
+        const parsed = requestSchema.safeParse(body);
+        if (!parsed.success) {
+          return json(
+            { error: parsed.error.errors[0]?.message ?? 'Invalid request' },
+            400,
+          );
+        }
+
+        // userId comes from the Clerk session, never the request body. An
+        // unowned or unknown event returns an empty list either way, so this
+        // can't be used to probe for other users' events.
+        const runs = await fetchRunsForEvent({
+          eventId: parsed.data.eventId,
+          userId,
+        });
+
+        return json({ runs });
+      },
+    },
+  },
+});

--- a/ui/apps/dashboard/src/routes/api/chat.ts
+++ b/ui/apps/dashboard/src/routes/api/chat.ts
@@ -89,7 +89,7 @@ export const Route = createFileRoute('/api/chat')({
 
           //
           // Send event to Inngest to trigger the agent chat
-          await inngest.send({
+          const { ids } = await inngest.send({
             name: 'insights-agent/chat.requested',
             data: {
               threadId: threadId ?? undefined,
@@ -110,6 +110,9 @@ export const Route = createFileRoute('/api/chat')({
             JSON.stringify({
               success: true,
               threadId: threadId,
+              // Lets the chat UI recover the result via /api/chat-result if the
+              // realtime run.completed never reaches the browser.
+              eventId: ids[0],
             }),
             {
               status: 200,


### PR DESCRIPTION
## Description

Replaces #4691 with a smaller version of the same fix. Same two problems, same
recovery mechanism, but the client-side bookkeeping collapses instead of growing.

Realtime has no replay ([broadcaster.md](https://github.com/inngest/inngest/blob/main/pkg/execution/realtime/docs/broadcaster.md#L62): *"If no subscriber is connected when a message is
published, it's lost"*), so a run that finishes while the tab is hidden or the
socket is down publishes a `run.completed` nobody receives and the chat spins
forever.

- `pauseOnHidden: false` on the subscription. It defaults to true and tears the
  whole subscription down on a tab switch, which these runs routinely outlast.
- The chat can read the result back from the run itself. `/api/chat` returns the
  event id, and a per-run poll hits a new `/api/chat-result` until the run
  reports a result. The run output already mirrors the `run.completed` payload,
  so nothing new is stored.

### What's different from #4691

That PR added a watchdog: two ref maps, a self-rescheduling `setTimeout` chain,
a reconnect hook, an idle threshold, a retry interval, and an attempt cap. This
one has no timers. A run is watched by a `RunResultWatcher` component — mounting
starts the watch, unmounting stops it — and React Query supplies the interval
plus the refetch-on-focus and refetch-on-reconnect that the watchdog was
hand-rolling. Those are also the only two moments recovery actually matters,
and they're the moments a hidden tab's `setTimeout` is least reliable.

The chat had three overlapping notions of "this thread is waiting":
`threadFlags`, the `run.started` handler, and the send path. They collapse into
one `pendingByThread` map behind a reducer. Presence in that map drives the
spinner, whether the poll runs, and whether an arriving result still has
somewhere to land — so realtime and the poll can both deliver and only the first
one lands. The reducer's stable `dispatch` also keeps the realtime effect from
reprocessing its message delta, which unstable callbacks would have caused.

Three things that fall out of this:

- **No false failure.** #4691 gave up after ~3.4 minutes and called the run
  lost even while the lookup was still reporting `Running`, then dropped the
  real answer when it arrived. Here a `Running` run is simply still running.
- **The spinner starts at send**, not on `run.started`. Previously a run whose
  realtime never connected showed no spinner at all and left the composer
  enabled.
- **Completed-with-no-output is terminal.** Found while testing: the poll can
  see `Completed` with nothing to render, which would otherwise poll forever.
  It now ends the thread after a few polls, since status and output are read
  from different stores and can briefly disagree.

`runLookup` also falls back to a local dev server when `INNGEST_DEV` is set;
without that the recovery path is inert in local dev and can't be exercised.

## Testing

Verified against a local dev server + the local stack, signed in through the
dashboard, driving the real Insights chat:

1. **Happy path** — agent answers over realtime, SQL auto-applies and runs,
   spinner clears. The poll ran alongside and correctly did *not* interfere.
2. **Recovery path** — `/api/realtime/token` blocked so realtime can never
   connect. The answer still arrives, via `/api/chat` → `/api/chat-result` →
   `runLookup` → the watcher, and the spinner clears.
3. **Ownership** — with the event owned by a different user, the lookup bails
   after the event fetch (never requests the runs), nothing renders, and the
   thread stays waiting rather than falsely resolving.

Case 2's upstream Inngest API was stubbed, because a dev server does not
populate run `output` at all (confirmed with a trivial function). The cloud
does: `GetEventRuns` sets `IncludeOutput` and unwraps the `{"data": T}`
envelope. Worth a second pair of eyes on that assumption since it's the one
part not exercised end-to-end.

Plus 18 unit tests: the reducer's dedupe/clear gates, `fetchRunResult`, and
`runLookup`'s ownership branches. `pnpm test` has 2 pre-existing failures on
`main` (`APIKeys/errorMessage.test.ts`, `lib/experiments/score.test.ts`),
unrelated and untouched.

## Release note

None.

## Migration note

None.
