### PR TITLE
chore(event types): Fix archive event type copy

### DIFF
--- a/ui/apps/dashboard/src/components/Events/ArchiveEventModal.tsx
+++ b/ui/apps/dashboard/src/components/Events/ArchiveEventModal.tsx
@@ -49,11 +49,11 @@ export default function ArchiveEventModal({
       isOpen={isOpen}
       onClose={onClose}
       onSubmit={handleSubmit}
-      title="Archive Event"
+      title="Archive Event Type"
     >
       <p className="px-6 pt-4">
-        Are you sure you want to archive this event? This action cannot be
-        undone.
+        Archive this event type? It will be hidden from the Active events list.
+        Sending another event with this name will unarchive it.
       </p>
 
       {error && (


### PR DESCRIPTION
## Description

It was inaccurate that archiving events cannot be undone, also it was unclear what happened if another instance of this event was sent.

<img width="604" height="247" alt="image" src="https://github.com/user-attachments/assets/10fa13ea-3469-4b7f-a7ac-c07e3f822c67" />


This is corroborated by another existing part of the UI
<img width="380" height="165" alt="image" src="https://github.com/user-attachments/assets/58d447fa-86b9-4ada-9f6d-ce83835a2eae" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
