### PR TITLE
internal(event): serialize propagated sessions with snake case not camel case

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -52,7 +52,7 @@ func TestReceiveEvent_ResolvesPropagatedSessions(t *testing.T) {
 		"data": {},
 		"meta": {
 			"sessions": {"conv_id": "manual"},
-			"propagatedSessions": {"conv_id": "propagated", "org_id": "42"}
+			"propagated_sessions": {"conv_id": "propagated", "org_id": "42"}
 		}
 	}`)
 

--- a/pkg/event/sessions.go
+++ b/pkg/event/sessions.go
@@ -21,7 +21,7 @@ type EventMeta struct {
 	// emitted this event (SDK-stamped during a run). It is an un-merged layer:
 	// ResolveSessions folds it into Sessions at ingest and clears it, so it is
 	// never persisted or forwarded downstream.
-	PropagatedSessions Sessions `json:"propagatedSessions,omitempty"`
+	PropagatedSessions Sessions `json:"propagated_sessions,omitempty"`
 }
 
 func (m EventMeta) IsZero() bool {


### PR DESCRIPTION
## Description

- In #4631, we introduced fields for propagated sessions. We're switching from camel case to snake case for consistency with other fields
- No migration note, as these fields were not in use yet by SDKs and the feature is still experimental

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
