### PR TITLE
internal(metrics): tag session resolutions that null inherited sessions

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -260,7 +260,7 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				evt.User = map[string]any{}
 			}
 
-			// Merge propagated sessionsMetrics into the manual layer before validation.
+			// Merge propagated sessions into the manual layer before validation.
 			// The merge reports the pre-merge state of both layers for adoption
 			// metrics.
 			sessionsMetrics := evt.Meta.ResolveSessions()

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -260,12 +260,18 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				evt.User = map[string]any{}
 			}
 
-			// Merge propagated sessions into the manual layer before validation,
-			// recording which layers were present for adoption metrics (read
-			// before the merge nils the propagated layer).
-			manualSessions, propagatedSessions := len(evt.Meta.Sessions) > 0, len(evt.Meta.PropagatedSessions) > 0
-			evt.Meta.ResolveSessions()
-			metrics.IncrEventSessionsResolvedCounter(ctx, "ingest", manualSessions, propagatedSessions, metrics.CounterOpt{PkgName: metricsPkgName})
+			// Merge propagated sessionsMetrics into the manual layer before validation.
+			// The merge reports the pre-merge state of both layers for adoption
+			// metrics.
+			sessionsMetrics := evt.Meta.ResolveSessions()
+			metrics.IncrEventSessionsResolvedCounter(
+				ctx,
+				"ingest",
+				sessionsMetrics.Manual,
+				sessionsMetrics.Propagated,
+				sessionsMetrics.Nulling,
+				metrics.CounterOpt{PkgName: metricsPkgName},
+			)
 
 			if err := evt.Validate(ctx); err != nil {
 				return err
@@ -352,11 +358,17 @@ func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
 	}
 	evt := event.NewInvocationEvent(newInvOpts)
 
-	// Merge the two session layers before the event is handled, recording which
-	// layers were present for adoption metrics (read before the merge).
-	manualSessions, propagatedSessions := len(evt.Event.Meta.Sessions) > 0, len(evt.Event.Meta.PropagatedSessions) > 0
-	evt.Event.Meta.ResolveSessions()
-	metrics.IncrEventSessionsResolvedCounter(r.Context(), "invoke_http", manualSessions, propagatedSessions, metrics.CounterOpt{PkgName: metricsPkgName})
+	// Merge the two session layers before the event is handled. The merge
+	// reports the pre-merge state of both layers for adoption metrics.
+	sessionsMetrics := evt.Event.Meta.ResolveSessions()
+	metrics.IncrEventSessionsResolvedCounter(
+		r.Context(),
+		"invoke_http",
+		sessionsMetrics.Manual,
+		sessionsMetrics.Propagated,
+		sessionsMetrics.Nulling,
+		metrics.CounterOpt{PkgName: metricsPkgName},
+	)
 
 	// Validate after the merge
 	if err := evt.Event.Validate(r.Context()); err != nil {

--- a/pkg/event/sessions.go
+++ b/pkg/event/sessions.go
@@ -146,7 +146,7 @@ type SessionsMetrics struct {
 // lexicographic key order (matching run-level session truncation) for
 // deterministic output. PropagatedSessions is cleared so it never persists.
 //
-// The returned SessionsResolutionMetric snapshots the pre-merge state for adoption
+// The returned SessionsMetrics snapshots the pre-merge state for adoption
 // metrics; it is safe to ignore.
 //
 // Called at API ingest before Event.Validate: each layer may independently be

--- a/pkg/event/sessions.go
+++ b/pkg/event/sessions.go
@@ -121,6 +121,24 @@ func parseManualSessions(raw json.RawMessage) (sessions Sessions, tombstones []s
 	return sessions, tombstones, false, nil
 }
 
+// SessionsMetrics summarizes the pre-merge state of the two session layers,
+// for adoption metrics. ResolveSessions returns it because the state it
+// describes — in particular the null tombstones, which live in unexported
+// fields — is consumed by the merge and unreadable to callers afterwards.
+type SessionsMetrics struct {
+	// Manual is true when the user set at least one concrete session key.
+	Manual bool
+
+	// Propagated is true when the event carried an inherited session layer.
+	Propagated bool
+
+	// Nulling is true when the manual layer used a JSON null to suppress
+	// inherited sessions: either the whole `sessions` field (clear all) or at
+	// least one per-key tombstone. It is independent of Manual — an event may
+	// both set keys and null others.
+	Nulling bool
+}
+
 // ResolveSessions folds the propagated (inherited) session layer into the
 // manual layer, producing the single Sessions map carried downstream. Manual
 // keys always win and are never evicted; remaining slots up to
@@ -128,8 +146,8 @@ func parseManualSessions(raw json.RawMessage) (sessions Sessions, tombstones []s
 // lexicographic key order (matching run-level session truncation) for
 // deterministic output. PropagatedSessions is cleared so it never persists.
 //
-// Callers that want adoption metrics read len(Sessions)/len(PropagatedSessions)
-// before calling this (the propagated layer is nil afterwards).
+// The returned SessionsResolutionMetric snapshots the pre-merge state for adoption
+// metrics; it is safe to ignore.
 //
 // Called at API ingest before Event.Validate: each layer may independently be
 // up to MaxEventSessions, so the pre-merge union can exceed the cap —
@@ -140,7 +158,13 @@ func parseManualSessions(raw json.RawMessage) (sessions Sessions, tombstones []s
 // are always consumed here: a whole-field-null manual layer clears every
 // inherited session, and per-key nulls cut the matching inherited keys.
 // Tombstones never survive into Sessions and so never count against the cap.
-func (m *EventMeta) ResolveSessions() {
+func (m *EventMeta) ResolveSessions() SessionsMetrics {
+	res := SessionsMetrics{
+		Manual:     len(m.Sessions) > 0,
+		Propagated: len(m.PropagatedSessions) > 0,
+		Nulling:    m.clearPropagated || len(m.sessionTombstones) > 0,
+	}
+
 	// Apply the manual layer's tombstones to the inherited candidates before
 	// merging. Whole-field null wins over individual tombstones (there is nothing
 	// left to cut once everything is cleared).
@@ -161,11 +185,12 @@ func (m *EventMeta) ResolveSessions() {
 		if len(m.Sessions) == 0 {
 			m.Sessions = nil
 		}
-		return
+		return res
 	}
 
 	m.Sessions = mergeSessions(m.PropagatedSessions, m.Sessions)
 	m.PropagatedSessions = nil
+	return res
 }
 
 // mergeSessions folds the propagated (inherited) session candidates into the

--- a/pkg/event/sessions_test.go
+++ b/pkg/event/sessions_test.go
@@ -210,6 +210,79 @@ func TestResolveSessionsTombstones(t *testing.T) {
 	}
 }
 
+// TestResolveSessionsResolution pins the SessionsResolution summary that drives
+// the adoption metric's tags. It starts from wire JSON because Nulling is
+// derived from the null tombstones, which only exist after unmarshalling.
+//
+// Manual and Nulling are deliberately independent: an event may set keys, null
+// keys, both, or neither. "Any manual interaction" is Manual || Nulling, and
+// clear-and-set within one event is Manual && Nulling.
+func TestResolveSessionsResolution(t *testing.T) {
+	cases := []struct {
+		name string
+		// meta is the raw JSON of an event's `meta` object.
+		meta string
+		want SessionsMetrics
+	}{
+		{
+			name: "absent meta is the empty denominator case",
+			meta: `{}`,
+			want: SessionsMetrics{},
+		},
+		{
+			name: "empty manual object is not an interaction (RFC 7386 empty patch)",
+			meta: `{"sessions":{}}`,
+			want: SessionsMetrics{},
+		},
+		{
+			name: "manual keys only",
+			meta: `{"sessions":{"conv_id":"123"}}`,
+			want: SessionsMetrics{Manual: true},
+		},
+		{
+			name: "propagated only",
+			meta: `{"propagated_sessions":{"conv_id":"123"}}`,
+			want: SessionsMetrics{Propagated: true},
+		},
+		{
+			name: "both layers present",
+			meta: `{"sessions":{"a":"1"},"propagated_sessions":{"b":"2"}}`,
+			want: SessionsMetrics{Manual: true, Propagated: true},
+		},
+		{
+			name: "per-key tombstone is nulling, not manual",
+			meta: `{"sessions":{"conv_id":null},"propagated_sessions":{"conv_id":"123"}}`,
+			want: SessionsMetrics{Nulling: true, Propagated: true},
+		},
+		{
+			name: "whole-field null is nulling, not manual",
+			meta: `{"sessions":null,"propagated_sessions":{"a":"1"}}`,
+			want: SessionsMetrics{Nulling: true, Propagated: true},
+		},
+		{
+			name: "clear-and-set in one event is both manual and nulling",
+			meta: `{"sessions":{"conv_id":null,"new_id":"456"},"propagated_sessions":{"conv_id":"123"}}`,
+			want: SessionsMetrics{Manual: true, Nulling: true, Propagated: true},
+		},
+		{
+			name: "nulling with nothing inherited still counts as an interaction",
+			meta: `{"sessions":{"ghost":null}}`,
+			want: SessionsMetrics{Nulling: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+
+			var m EventMeta
+			r.NoError(json.Unmarshal([]byte(tc.meta), &m))
+
+			r.Equal(tc.want, m.ResolveSessions())
+		})
+	}
+}
+
 // TestParseManualSessionsRejectsBool ensures non-string/number/null manual
 // values are rejected, mirroring the propagated-layer decoding.
 func TestParseManualSessionsRejectsBool(t *testing.T) {

--- a/pkg/event/sessions_test.go
+++ b/pkg/event/sessions_test.go
@@ -210,7 +210,7 @@ func TestResolveSessionsTombstones(t *testing.T) {
 	}
 }
 
-// TestResolveSessionsResolution pins the SessionsResolution summary that drives
+// TestResolveSessionsResolution pins the SessionsMetrics summary that drives
 // the adoption metric's tags. It starts from wire JSON because Nulling is
 // derived from the null tombstones, which only exist after unmarshalling.
 //

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -5216,11 +5216,17 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 	})
 
 	// Merge the invocation payload's two session layers before the event is
-	// published, recording which layers were present for adoption metrics (read
-	// before the merge nils the propagated layer).
-	manualSessions, propagatedSessions := len(evt.Event.Meta.Sessions) > 0, len(evt.Event.Meta.PropagatedSessions) > 0
-	evt.Event.Meta.ResolveSessions()
-	metrics.IncrEventSessionsResolvedCounter(ctx, "invoke_executor", manualSessions, propagatedSessions, metrics.CounterOpt{PkgName: pkgName})
+	// published. The merge reports the pre-merge state of both layers for
+	// adoption metrics.
+	sessionsMetrics := evt.Event.Meta.ResolveSessions()
+	metrics.IncrEventSessionsResolvedCounter(
+		ctx,
+		"invoke_executor",
+		sessionsMetrics.Manual,
+		sessionsMetrics.Propagated,
+		sessionsMetrics.Nulling,
+		metrics.CounterOpt{PkgName: pkgName},
+	)
 
 	// Validate the sessions after the merge
 	if err := evt.Event.Meta.Sessions.Validate(); err != nil {

--- a/pkg/execution/state/opcode_test.go
+++ b/pkg/execution/state/opcode_test.go
@@ -274,3 +274,50 @@ func TestDeferAddOpts_Validate(t *testing.T) {
 		require.NoError(t, opts.Validate())
 	})
 }
+
+// TestInvokeFunctionOptsPreservesSessionNulls pins that RFC 7386 null
+// tombstones on the invoke payload survive decoding into InvokeFunctionOpts.
+//
+// GeneratorOpcode.Opts is `any`, so UnmarshalAny round-trips through a generic
+// map where a JSON null stays nil and re-marshals as null, reaching
+// EventMeta.UnmarshalJSON intact. A typed intermediate would silently drop the
+// tombstones — EventMeta holds them in unexported fields and has no
+// MarshalJSON — which would both break clearing and understate the executor's
+// session adoption metric.
+func TestInvokeFunctionOptsPreservesSessionNulls(t *testing.T) {
+	cases := []struct {
+		name        string
+		sessions    string
+		wantNulling bool
+	}{
+		{name: "per-key tombstone", sessions: `{"conv_id":null}`, wantNulling: true},
+		{name: "whole-field null", sessions: `null`, wantNulling: true},
+		{name: "concrete keys only", sessions: `{"conv_id":"123"}`, wantNulling: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+
+			// Decode the SDK's opcode the way the executor does: into the
+			// generic `Opts any` field, then through InvokeFunctionOpts.
+			raw := `{"op":"InvokeFunction","id":"1","opts":{"function_id":"fn",` +
+				`"payload":{"name":"evt","meta":{"sessions":` + tc.sessions +
+				`,"propagated_sessions":{"conv_id":"inherited"}}}}}`
+			var gen GeneratorOpcode
+			r.NoError(json.Unmarshal([]byte(raw), &gen))
+
+			opts, err := gen.InvokeFunctionOpts()
+			r.NoError(err)
+			r.NotNil(opts.Payload)
+
+			res := opts.Payload.Meta.ResolveSessions()
+			r.Equal(tc.wantNulling, res.Nulling)
+			r.True(res.Propagated)
+			if tc.wantNulling {
+				r.NotContains(opts.Payload.Meta.Sessions, "conv_id",
+					"the inherited key is cut by the tombstone")
+			}
+		})
+	}
+}

--- a/pkg/telemetry/metrics/sessions.go
+++ b/pkg/telemetry/metrics/sessions.go
@@ -3,28 +3,39 @@ package metrics
 import "context"
 
 // IncrEventSessionsResolvedCounter records one session resolution (one call to
-// event.EventMeta.ResolveSessions), tagged by source and by whether each layer
-// was present. It is emitted on every resolve — including the neither-present
-// case — so the {manual=false,propagated=false} series is a self-contained
-// denominator: manual-set rate = sum(manual=true)/sum(all), propagated rate =
-// sum(propagated=true)/sum(all).
+// event.EventMeta.ResolveSessions), tagged by source and by the pre-merge state
+// of the two session layers. It is emitted on every resolve — including the
+// nothing-present case — so the {manual=false,propagated=false,nulling=false}
+// series is a self-contained denominator: manual-set rate =
+// sum(manual=true)/sum(all), propagated rate = sum(propagated=true)/sum(all).
+//
+// manual and nulling are independent: manual covers concrete keys the user set,
+// nulling covers JSON nulls used to suppress inherited sessions (whole-field or
+// per-key). Any manual interaction at all is manual=true OR nulling=true;
+// clear-and-set within one event — the signal for whether a combined operation
+// is worth having — is manual=true AND nulling=true.
+//
+// Callers pass the fields of an event.SessionsResolution. The struct itself is
+// not taken directly because pkg/event depends on this package, so the import
+// cannot run the other way.
 //
 // The server merge is the single vantage point that sees both layers for every
-// spawn primitive and SDK version. Tags are low-cardinality only (source, two
+// spawn primitive and SDK version. Tags are low-cardinality only (source, three
 // bools); per-account/per-session detail belongs in the analytics plane
 // (Insights runs.sessions), never here.
-func IncrEventSessionsResolvedCounter(ctx context.Context, source string, manual, propagated bool, opts CounterOpt) {
+func IncrEventSessionsResolvedCounter(ctx context.Context, source string, manual, propagated, nulling bool, opts CounterOpt) {
 	if opts.Tags == nil {
 		opts.Tags = map[string]any{}
 	}
 	opts.Tags["source"] = source
 	opts.Tags["manual"] = manual
 	opts.Tags["propagated"] = propagated
+	opts.Tags["nulling"] = nulling
 
 	RecordCounterMetric(ctx, 1, CounterOpt{
 		PkgName:     opts.PkgName,
 		MetricName:  "event_sessions_resolved_total",
-		Description: "Total event session resolutions, tagged by source and which layers were present",
+		Description: "Total event session resolutions, tagged by source and the pre-merge state of each session layer",
 		Tags:        opts.Tags,
 	})
 }

--- a/pkg/telemetry/metrics/sessions.go
+++ b/pkg/telemetry/metrics/sessions.go
@@ -15,7 +15,7 @@ import "context"
 // clear-and-set within one event — the signal for whether a combined operation
 // is worth having — is manual=true AND nulling=true.
 //
-// Callers pass the fields of an event.SessionsResolution. The struct itself is
+// Callers pass the fields of an event.SessionsMetrics. The struct itself is
 // not taken directly because pkg/event depends on this package, so the import
 // cannot run the other way.
 //


### PR DESCRIPTION
## Description

- Previously, we added metrics for sessions usage in https://github.com/inngest/inngest/pull/4640
- Those metrics did not track usage of nulls
- We add a new metric tag to see when nulls are used
- EXE-2142

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
