### PR TITLE
internal(defers): store defer meta in its own hash

### DIFF
--- a/pkg/execution/state/redis_state/defer_test.go
+++ b/pkg/execution/state/redis_state/defer_test.go
@@ -118,6 +118,54 @@ func TestSaveDefer(t *testing.T) {
 		require.JSONEq(t, string(d.Meta), string(metas[d.HashedID].Meta))
 	})
 
+	t.Run("control meta is stored verbatim", func(t *testing.T) {
+		r := require.New(t)
+		v2svc, id := newDeferTestRunService(t)
+
+		// Key order and number formatting must come back exactly as sent, the
+		// same guarantee Input gets from its own hash.
+		meta := `{"propagated_sessions":{"id":1234567890123456789,"empty":{},"tenant":"acme"}}`
+		d := statev2.Defer{
+			FnSlug:         "onDefer-score",
+			HashedID:       "hash-step-1",
+			ScheduleStatus: enums.DeferStatusAfterRun,
+			Meta:           json.RawMessage(meta),
+		}
+		r.NoError(v2svc.SaveDefer(ctx, id, d))
+
+		defers, err := v2svc.LoadDefers(ctx, id)
+		r.NoError(err)
+		r.Equal(meta, string(defers[d.HashedID].Meta))
+	})
+
+	t.Run("aggregate-cap rejection stores no control meta", func(t *testing.T) {
+		r := require.New(t)
+		v2svc, id := newDeferTestRunService(t)
+
+		big := statev2.Defer{
+			FnSlug:         "onDefer-score",
+			HashedID:       "hash-first",
+			ScheduleStatus: enums.DeferStatusAfterRun,
+			Input:          json.RawMessage(`{"msg": "` + strings.Repeat("a", consts.MaxDeferInputAggregateSize-64) + `"}`),
+		}
+		r.NoError(v2svc.SaveDefer(ctx, id, big))
+
+		// Overflows the aggregate input budget, so this becomes a Rejected
+		// sentinel. A rejected defer is never scheduled, so its Meta is dead
+		// weight and is not persisted.
+		overflow := big
+		overflow.HashedID = "hash-second"
+		overflow.Meta = json.RawMessage(`{"propagated_sessions":{"tenant":"acme"}}`)
+		r.ErrorIs(v2svc.SaveDefer(ctx, id, overflow), statev2.ErrDeferInputAggregateExceeded)
+
+		defers, err := v2svc.LoadDefers(ctx, id)
+		r.NoError(err)
+		got := defers["hash-second"]
+		r.Equal(enums.DeferStatusRejected, got.ScheduleStatus)
+		r.Empty(got.Input)
+		r.Empty(got.Meta)
+	})
+
 	t.Run("idempotent", func(t *testing.T) {
 		v2svc, id := newDeferTestRunService(t)
 
@@ -408,6 +456,55 @@ func TestSetDeferStatus(t *testing.T) {
 				r.Equal(d.HashedID, got.HashedID)
 				r.Equal(enums.DeferStatusAborted, got.ScheduleStatus)
 				r.Empty(got.Input)
+			})
+		}
+	})
+
+	t.Run("control meta survives abort byte-for-byte", func(t *testing.T) {
+		// Meta is stored in defers-control-meta precisely so that the cjson
+		// decode/re-encode in this script cannot touch it. Assert exact bytes,
+		// not JSONEq: a re-encode that preserved semantics but reordered keys
+		// or reformatted numbers would still be a regression.
+		cases := []struct {
+			name string
+			meta string
+		}{
+			{"empty object", `{}`},
+			{"nested empty object", `{"propagated_sessions":{}}`},
+			// 2^53 + 1 — the first integer a float64 cannot hold exactly.
+			// cjson's %.14g encoding mangles it, and any session ID beyond
+			// 14 significant digits, on the way back out.
+			{"integer above 2^53", `{"propagated_sessions":{"external_id":9007199254740993}}`},
+			{"19-digit session id", `{"propagated_sessions":{"id":1234567890123456789}}`},
+			{"float", `{"propagated_sessions":{"score":0.30000000000000004}}`},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				r := require.New(t)
+				v2svc, id := newDeferTestRunService(t)
+
+				d := statev2.Defer{
+					FnSlug:         "onDefer-score",
+					HashedID:       "hash-step-1",
+					ScheduleStatus: enums.DeferStatusAfterRun,
+					Input:          json.RawMessage(`{"user_id":"u_123"}`),
+					Meta:           json.RawMessage(tc.meta),
+				}
+				r.NoError(v2svc.SaveDefer(ctx, id, d))
+				r.NoError(v2svc.SetDeferStatus(ctx, id, d.HashedID, enums.DeferStatusAborted))
+
+				defers, err := v2svc.LoadDefers(ctx, id)
+				r.NoError(err)
+				got := defers[d.HashedID]
+				r.Equal(enums.DeferStatusAborted, got.ScheduleStatus)
+				r.Empty(got.Input, "abort releases the input budget")
+				r.Equal(tc.meta, string(got.Meta))
+
+				// The metadata-only view is what finalize reads.
+				metas, err := v2svc.LoadDefersMeta(ctx, id)
+				r.NoError(err)
+				r.Equal(tc.meta, string(metas[d.HashedID].Meta))
 			})
 		}
 	})

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -45,6 +45,13 @@ type RunStateKeyGenerator interface {
 	// DefersInput returns the key used to store each defer's arbitrary input
 	// data. This does not include defer metadata, which is stored in DefersMeta
 	DefersInput(ctx context.Context, isSharded bool, fnID uuid.UUID, runID ulid.ULID) string
+
+	// DefersControlMeta returns the key used to store each defer's opaque
+	// control metadata (e.g. SDK-stamped session layers). Like DefersInput, the
+	// values are written verbatim and never decoded by Lua, so they are immune
+	// to cjson's number-precision and empty-object mangling. DefersMeta holds
+	// the fields Lua does read and rewrite.
+	DefersControlMeta(ctx context.Context, isSharded bool, fnID uuid.UUID, runID ulid.ULID) string
 }
 
 type runStateKeyGenerator struct {
@@ -87,6 +94,10 @@ func (s runStateKeyGenerator) DefersMeta(ctx context.Context, isSharded bool, fn
 
 func (s runStateKeyGenerator) DefersInput(ctx context.Context, isSharded bool, fnID uuid.UUID, runID ulid.ULID) string {
 	return fmt.Sprintf("{%s}:defers-input:%s:%s", s.Prefix(ctx, s.stateDefaultKey, isSharded, runID), fnID, runID)
+}
+
+func (s runStateKeyGenerator) DefersControlMeta(ctx context.Context, isSharded bool, fnID uuid.UUID, runID ulid.ULID) string {
+	return fmt.Sprintf("{%s}:defers-control-meta:%s:%s", s.Prefix(ctx, s.stateDefaultKey, isSharded, runID), fnID, runID)
 }
 
 func (s runStateKeyGenerator) Stack(ctx context.Context, isSharded bool, runID ulid.ULID) string {

--- a/pkg/execution/state/redis_state/lua/saveDefer.lua
+++ b/pkg/execution/state/redis_state/lua/saveDefer.lua
@@ -6,18 +6,20 @@ is a no-op, so SDK retransmits are idempotent regardless of payload.
 
 New defers past the per-run count cap are rejected. Writes that would exceed the
 aggregate-input cap are converted into a Rejected sentinel (status=Rejected, no
-input, no aggregate increment).
+input, no control meta, no aggregate increment).
 
 KEYS[1] - defers meta hash key
 KEYS[2] - defers input hash key
 KEYS[3] - run metadata hash key
+KEYS[4] - defers control meta hash key
 ARGV[1] - hashedID
-ARGV[2] - meta JSON ({FnSlug, HashedID, ScheduleStatus, Meta}), where Meta is
-          an opaque control-metadata blob (e.g. session layers). Meta is not
-          counted toward the aggregate-input cap below.
+ARGV[2] - meta JSON ({FnSlug, HashedID, ScheduleStatus} only)
 ARGV[3] - raw Input bytes (HSET verbatim, never decoded by Lua). Empty for rejected defers.
 ARGV[4] - integer max defers per run
 ARGV[5] - integer max defer input aggregate size (bytes)
+ARGV[6] - raw control Meta bytes (HSET verbatim, never decoded by Lua). Empty
+          when the defer carries no control metadata. Not counted toward the
+          aggregate-input cap above; capped per-defer at op receipt instead.
 
 Output:
    1: written
@@ -29,14 +31,16 @@ Output:
 -- Must match enums.DeferStatusRejected in pkg/enums/defer_status.go.
 local DEFER_STATUS_REJECTED = 4
 
-local metaKey       = KEYS[1]
-local inputKey      = KEYS[2]
-local metadataKey   = KEYS[3]
-local hashedID      = ARGV[1]
-local metaPayload   = ARGV[2]
-local inputPayload  = ARGV[3]
-local maxDefers     = tonumber(ARGV[4])
-local maxAggInput   = tonumber(ARGV[5])
+local metaKey        = KEYS[1]
+local inputKey       = KEYS[2]
+local metadataKey    = KEYS[3]
+local controlMetaKey = KEYS[4]
+local hashedID       = ARGV[1]
+local metaPayload    = ARGV[2]
+local inputPayload   = ARGV[3]
+local maxDefers      = tonumber(ARGV[4])
+local maxAggInput    = tonumber(ARGV[5])
+local controlPayload = ARGV[6]
 
 if redis.call("HEXISTS", metaKey, hashedID) == 1 then
     return 0
@@ -63,5 +67,8 @@ redis.call("HSET", metaKey, hashedID, metaPayload)
 if newInputLen > 0 then
     redis.call("HSET", inputKey, hashedID, inputPayload)
     redis.call("HINCRBY", metadataKey, "defer_input_size", newInputLen)
+end
+if #controlPayload > 0 then
+    redis.call("HSET", controlMetaKey, hashedID, controlPayload)
 end
 return 1

--- a/pkg/execution/state/redis_state/lua/setDeferStatus.lua
+++ b/pkg/execution/state/redis_state/lua/setDeferStatus.lua
@@ -5,6 +5,10 @@ The Aborted transition also deletes the Input and decrements the aggregate
 counter, ensuring we don't use the size budget for useless data. The meta entry
 stays so saveDefer.lua's terminal-sticky check still dedupes retransmits.
 
+Control meta (defers-control-meta) is deliberately left alone: it holds no
+aggregate budget to release, and it must never pass through cjson. Deleting the
+run drops that hash along with the rest of the run state.
+
 KEYS[1] - defers meta hash key
 KEYS[2] - defers input hash key
 KEYS[3] - run metadata hash key

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -549,9 +549,14 @@ func (m shardedMgr) Metadata(ctx context.Context, accountId uuid.UUID, runID uli
 }
 
 // deferMeta is the cjson-safe subset of statev2.Defer stored as the value of
-// each field in the defers-meta hash. Input lives in a separate defers-input
-// hash and is never decoded by Lua, sidestepping cjson's empty-object → array
-// and >2^53 integer precision bugs.
+// each field in the defers-meta hash. Values here are decoded and re-encoded by
+// Lua on every status transition (setDeferStatus.lua, and saveDefer.lua's
+// aggregate-cap Rejected path), so they are subject to cjson's empty-object →
+// array and >2^53 integer precision bugs.
+//
+// The two user-controlled blobs are therefore stored outside this struct, in
+// hashes Lua only ever writes verbatim or deletes wholesale: Input in
+// defers-input, and Meta in defers-control-meta.
 //
 // DO NOT add fields here without first verifying they are cjson-safe. Safe
 // field types are strings and small ints (status enums, bounded counts).
@@ -564,21 +569,10 @@ type deferMeta struct {
 	// this field as a number via cjson. Conversion to the typed enum happens
 	// at the LoadDefers/SaveDefer boundary.
 	ScheduleStatus int
-
-	// Meta is an opaque JSON blob (SDK-stamped session layers) that must
-	// survive to the parent run's finalize.
-	//
-	// It is exempt from the cjson-safe rule above: a schedulable (AfterRun)
-	// defer's meta is only ever written verbatim by saveDefer.lua (HSET, no
-	// cjson), and buildDeferEvents reads only AfterRun defers. cjson round-trips
-	// the blob solely on terminal transitions (setDeferStatus.lua Aborted,
-	// saveDefer.lua aggregate-cap Rejected), whose Meta is never read. omitempty
-	// keeps the stored payload byte-identical for defers without sessions.
-	Meta json.RawMessage `json:",omitempty"`
 }
 
 // LoadDefersMeta returns each defer's metadata without loading Input. Use this
-// from any path that only needs FnSlug / HashedID / ScheduleStatus
+// from any path that only needs FnSlug / HashedID / ScheduleStatus / Meta
 func (m shardedMgr) LoadDefersMeta(
 	ctx context.Context,
 	accountId uuid.UUID,
@@ -634,18 +628,36 @@ func (m shardedMgr) LoadDefersMeta(
 		hashedIDs = hashedIDs[:consts.MaxDefersPerRun]
 	}
 
+	// Control metadata lives in its own hash so Lua never runs it through
+	// cjson. Skipped when the run has no defers at all, keeping the no-defer
+	// path a single round trip.
+	control := map[string]string{}
+	if len(hashedIDs) > 0 {
+		control, err = r.Do(ctx, func(client rueidis.Client) rueidis.Completed {
+			return client.B().Hgetall().Key(
+				fnRunState.kg.DefersControlMeta(ctx, isSharded, fnID, runID),
+			).Build()
+		}).AsStrMap()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	metas := make(map[string]statev2.DeferMeta, len(hashedIDs))
 	for _, hashedID := range hashedIDs {
 		var meta deferMeta
 		if err := json.Unmarshal([]byte(rmap[hashedID]), &meta); err != nil {
 			return nil, err
 		}
-		metas[hashedID] = statev2.DeferMeta{
+		dm := statev2.DeferMeta{
 			FnSlug:         meta.FnSlug,
 			HashedID:       meta.HashedID,
 			ScheduleStatus: enums.DeferStatus(meta.ScheduleStatus),
-			Meta:           meta.Meta,
 		}
+		if raw, ok := control[hashedID]; ok && len(raw) > 0 {
+			dm.Meta = json.RawMessage(raw)
+		}
+		metas[hashedID] = dm
 	}
 	return metas, nil
 }
@@ -951,7 +963,6 @@ func (m shardedMgr) SaveDefer(ctx context.Context, accountId uuid.UUID, fnID uui
 		FnSlug:         d.FnSlug,
 		HashedID:       d.HashedID,
 		ScheduleStatus: int(d.ScheduleStatus),
-		Meta:           d.Meta,
 	})
 	if err != nil {
 		return err
@@ -963,6 +974,7 @@ func (m shardedMgr) SaveDefer(ctx context.Context, accountId uuid.UUID, fnID uui
 		string(d.Input),
 		consts.MaxDefersPerRun,
 		consts.MaxDeferInputAggregateSize,
+		string(d.Meta),
 	})
 	if err != nil {
 		return err
@@ -975,6 +987,7 @@ func (m shardedMgr) SaveDefer(ctx context.Context, accountId uuid.UUID, fnID uui
 			fnRunState.kg.DefersMeta(ctx, isSharded, fnID, runID),
 			fnRunState.kg.DefersInput(ctx, isSharded, fnID, runID),
 			fnRunState.kg.RunMetadata(ctx, isSharded, runID),
+			fnRunState.kg.DefersControlMeta(ctx, isSharded, fnID, runID),
 		},
 		args,
 	).AsInt64()
@@ -1183,6 +1196,7 @@ func (m shardedMgr) delete(ctx context.Context, callCtx context.Context, i state
 		fnRunState.kg.Pending(ctx, isSharded, i),
 		fnRunState.kg.DefersMeta(ctx, isSharded, i.WorkflowID, i.RunID),
 		fnRunState.kg.DefersInput(ctx, isSharded, i.WorkflowID, i.RunID),
+		fnRunState.kg.DefersControlMeta(ctx, isSharded, i.WorkflowID, i.RunID),
 	}
 
 	result := r.Do(callCtx, func(client rueidis.Client) rueidis.Completed {

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -232,6 +232,7 @@ func (v v2) Migrate(ctx context.Context, s state.MigrateState) error {
 	pendingKey := fnRunState.kg.Pending(ctx, isSharded, v1id)
 	defersMetaKey := fnRunState.kg.DefersMeta(ctx, isSharded, id.FunctionID, id.RunID)
 	defersInputKey := fnRunState.kg.DefersInput(ctx, isSharded, id.FunctionID, id.RunID)
+	defersControlMetaKey := fnRunState.kg.DefersControlMeta(ctx, isSharded, id.FunctionID, id.RunID)
 
 	eventsBlob, err := json.Marshal(s.Events)
 	if err != nil {
@@ -299,6 +300,8 @@ func (v v2) Migrate(ctx context.Context, s state.MigrateState) error {
 		var metaValues []string
 		var inputHashedIDs []string
 		var inputValues []string
+		var controlHashedIDs []string
+		var controlValues []string
 		for hashedID, d := range s.Defers {
 			metaJSON, err := json.Marshal(deferMeta{
 				FnSlug:         d.FnSlug,
@@ -313,6 +316,10 @@ func (v v2) Migrate(ctx context.Context, s state.MigrateState) error {
 			if len(d.Input) > 0 {
 				inputHashedIDs = append(inputHashedIDs, hashedID)
 				inputValues = append(inputValues, string(d.Input))
+			}
+			if len(d.Meta) > 0 {
+				controlHashedIDs = append(controlHashedIDs, hashedID)
+				controlValues = append(controlValues, string(d.Meta))
 			}
 		}
 		if err := client.Do(ctx, func(c rueidis.Client) rueidis.Completed {
@@ -333,6 +340,17 @@ func (v v2) Migrate(ctx context.Context, s state.MigrateState) error {
 				return partial.Build()
 			}).Error(); err != nil {
 				return fmt.Errorf("redis_state: migrate defers input: %w", err)
+			}
+		}
+		if len(controlHashedIDs) > 0 {
+			if err := client.Do(ctx, func(c rueidis.Client) rueidis.Completed {
+				partial := c.B().Hset().Key(defersControlMetaKey).FieldValue()
+				for i, h := range controlHashedIDs {
+					partial = partial.FieldValue(h, controlValues[i])
+				}
+				return partial.Build()
+			}).Error(); err != nil {
+				return fmt.Errorf("redis_state: migrate defers control meta: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

- Previously, we added the events meta into the general meta field in Redis. However this exposed it to lossy cjson serialization
- We split it into a separate field in the Redis hash. Unfortunately, defer-meta is taken, so instead we use defer-control-meta as our key. This separate field doesn't need that serialization, and thus stays pristine

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
- Add in support for propagating sessions into child runs, building on top of previous PRs

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
