### PR TITLE
ci(e2e): Run more tests on Depot

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,7 +119,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        # Benchmark: Depot 2 vCPU. Compare against the 4 vCPU variant before
+        # settling on a size.
+        os: [depot-ubuntu-22.04]
         experimentalKeyQueues: [false, true]
         database: [sqlite, postgres]
         parallelism: [5]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,9 +119,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Depot 2 vCPU: these suites are latency-bound, not CPU-bound, so 4 vCPU
-        # measured within 3% of 2 vCPU (identical medians) for double the cost.
-        # The win here is queue time, not cores.
         os: [depot-ubuntu-22.04]
         experimentalKeyQueues: [false, true]
         database: [sqlite, postgres]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [depot-ubuntu-22.04]
         experimentalKeyQueues: [false, true]
     runs-on: ${{ matrix.os }}
     steps:
@@ -119,8 +119,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Benchmark: Depot 2 vCPU. Compare against the 4 vCPU variant before
-        # settling on a size.
+        # Depot 2 vCPU: these suites are latency-bound, not CPU-bound, so 4 vCPU
+        # measured within 3% of 2 vCPU (identical medians) for double the cost.
+        # The win here is queue time, not cores.
         os: [depot-ubuntu-22.04]
         experimentalKeyQueues: [false, true]
         database: [sqlite, postgres]
@@ -222,7 +223,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [depot-ubuntu-22.04]
         experimentalKeyQueues: [false, true]
         database: [sqlite, postgres]
         splitBatchPartition: [false, true]
@@ -321,7 +322,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [depot-ubuntu-22.04]
         experimentalKeyQueues: [false, true]
         database: [sqlite, postgres]
     runs-on: ${{ matrix.os }}
@@ -418,7 +419,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [depot-ubuntu-22.04]
         experimentalKeyQueues: [false, true]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Description

- Sometimes I wait for my PRs to pass their tests, but my tests get stuck queued. They aren't running, but rather waiting for a GitHub Action Runner to open up.
- Queueing time is p50 5m and p90 18m
- I'd like to not wait for my test to run. Let's switch to depot, which we already use and has ~3s of queueing. This gets the additional benefit of Depot for build caching.
- This will cost us ~$400/month. However, we are moving our CI in the near future, so this is a fleeting cost
- I ran a quick n=2 test to compare 4 vs 2 cpu, and the 4 cpu gains seem to be ~< 10%, so using 2 cpu for now

## Release note

None.

## Migration note

None.
