### PR TITLE
ci(e2e): benchmark Go SDK matrix on Depot 4 vCPU

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,7 +119,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        # Benchmark: Depot 4 vCPU. Compare against the 2 vCPU variant before
+        # settling on a size.
+        os: [depot-ubuntu-22.04-4]
         experimentalKeyQueues: [false, true]
         database: [sqlite, postgres]
         parallelism: [5]


### PR DESCRIPTION
## Description

- Sometimes I wait for my PRs to pass their tests, but my tests get stuck queued. They aren't running, but rather waiting for a GitHub Action Runner to open up.
- I'd like to not wait for my test to run. Let's switch to depot, which we already use. This gets the additional benefit of Depot for build caching.
- This will cost us ~$800/month. However, we have aims to run our CI with ourselves in the near future, so this isn't a permannet cost.

## Release note

None.

## Migration note

None.
