### PR TITLE
feat(telemetry): mirror spans to an external OTLP collector

### DIFF
--- a/pkg/telemetry/trace/mirror.go
+++ b/pkg/telemetry/trace/mirror.go
@@ -1,0 +1,111 @@
+package trace
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/sdk/trace"
+)
+
+// Inngest's own tracers are wired to internal sinks: `inngest dev` and `inngest
+// start` point them at the server's `/dev/traces` ingestion endpoint, which
+// persists spans for the run details UI. Repointing that exporter is not an
+// option for self-hosted users who also want their spans in an external
+// collector, because it would silently empty the UI.
+//
+// The mirror is therefore additive: when an OTLP endpoint is configured via the
+// standard OpenTelemetry environment variables, spans are exported to it *in
+// addition* to whatever sink the tracer was constructed with. Nothing changes
+// when the variables are unset.
+//
+// Configuration is delegated to the upstream OTLP exporters, which read the
+// full spec-defined variable set themselves (endpoint, headers, TLS,
+// compression, timeout). We only decide whether a mirror is wanted at all, and
+// over which protocol.
+const (
+	// envEndpoint and envSignalEndpoint gate the mirror. Either one being
+	// non-empty enables it; the signal-specific variable wins, per spec.
+	//
+	// Their path semantics differ, also per spec, and the upstream exporters
+	// implement it: the generic variable is a base URL that has "/v1/traces"
+	// appended, while the signal-specific variable is used verbatim and must
+	// therefore already carry the full path.
+	envEndpoint       = "OTEL_EXPORTER_OTLP_ENDPOINT"
+	envSignalEndpoint = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
+
+	// envProtocol and envSignalProtocol select the wire protocol. Spec values
+	// are "grpc", "http/protobuf", and "http/json"; the Go SDK has no
+	// http/json trace exporter, so it is rejected rather than silently
+	// downgraded.
+	envProtocol       = "OTEL_EXPORTER_OTLP_PROTOCOL"
+	envSignalProtocol = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+
+	protocolGRPC = "grpc"
+	protocolHTTP = "http/protobuf"
+)
+
+// mirrorEnabled reports whether an external OTLP trace endpoint is configured.
+func mirrorEnabled() bool {
+	return mirrorEndpoint() != ""
+}
+
+func mirrorEndpoint() string {
+	if v := strings.TrimSpace(os.Getenv(envSignalEndpoint)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv(envEndpoint))
+}
+
+func mirrorProtocol() string {
+	if v := strings.TrimSpace(os.Getenv(envSignalProtocol)); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv(envProtocol)); v != "" {
+		return v
+	}
+	// Spec default.
+	return protocolHTTP
+}
+
+// newMirrorSpanProcessor builds a batch span processor that ships spans to the
+// externally configured OTLP endpoint. It returns a nil processor when no
+// endpoint is configured, which callers MUST treat as "no mirror wanted"
+// rather than an error.
+func newMirrorSpanProcessor(ctx context.Context) (trace.SpanProcessor, error) {
+	if !mirrorEnabled() {
+		return nil, nil
+	}
+
+	var (
+		exp *otlptrace.Exporter
+		err error
+	)
+
+	switch proto := mirrorProtocol(); proto {
+	case protocolGRPC:
+		// No WithEndpoint/WithInsecure here on purpose: the exporter reads
+		// OTEL_EXPORTER_OTLP_[TRACES_]ENDPOINT itself and derives TLS from the
+		// scheme, so `http://` collectors work without a separate insecure
+		// flag.
+		exp, err = otlptracegrpc.New(ctx)
+	case protocolHTTP:
+		exp, err = otlptracehttp.New(ctx)
+	default:
+		return nil, fmt.Errorf(
+			"unsupported OTLP trace protocol %q: use %q or %q",
+			proto, protocolHTTP, protocolGRPC,
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error creating mirrored OTLP trace exporter: %w", err)
+	}
+
+	// Registered on the provider, so provider ForceFlush/Shutdown already
+	// drains and closes this processor and its exporter.
+	return trace.NewBatchSpanProcessor(exp), nil
+}

--- a/pkg/telemetry/trace/mirror.go
+++ b/pkg/telemetry/trace/mirror.go
@@ -12,36 +12,21 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
-// Inngest's own tracers are wired to internal sinks: `inngest dev` and `inngest
-// start` point them at the server's `/dev/traces` ingestion endpoint, which
-// persists spans for the run details UI. Repointing that exporter is not an
-// option for self-hosted users who also want their spans in an external
-// collector, because it would silently empty the UI.
+// `inngest dev` and `inngest start` point their tracers at the server's own
+// `/dev/traces` endpoint, which persists spans for the run details UI, so
+// repointing that exporter would silently empty the UI. The mirror is
+// additive instead: spans go to an external OTLP collector as well as the
+// tracer's own sink, and only when one of these is set.
 //
-// The mirror is therefore additive: when an OTLP endpoint is configured via the
-// standard OpenTelemetry environment variables, spans are exported to it *in
-// addition* to whatever sink the tracer was constructed with. Nothing changes
-// when the variables are unset.
-//
-// Configuration is delegated to the upstream OTLP exporters, which read the
-// full spec-defined variable set themselves (endpoint, headers, TLS,
-// compression, timeout). We only decide whether a mirror is wanted at all, and
-// over which protocol.
+// Endpoint, headers, TLS, compression and timeout are all read by the
+// upstream exporters themselves; we only pick whether and over what.
 const (
-	// envEndpoint and envSignalEndpoint gate the mirror. Either one being
-	// non-empty enables it; the signal-specific variable wins, per spec.
-	//
-	// Their path semantics differ, also per spec, and the upstream exporters
-	// implement it: the generic variable is a base URL that has "/v1/traces"
-	// appended, while the signal-specific variable is used verbatim and must
-	// therefore already carry the full path.
+	// Path semantics differ, per spec: the generic endpoint is a base URL
+	// with "/v1/traces" appended, the signal-specific one is used verbatim
+	// and must already carry the path. The signal-specific one wins.
 	envEndpoint       = "OTEL_EXPORTER_OTLP_ENDPOINT"
 	envSignalEndpoint = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"
 
-	// envProtocol and envSignalProtocol select the wire protocol. Spec values
-	// are "grpc", "http/protobuf", and "http/json"; the Go SDK has no
-	// http/json trace exporter, so it is rejected rather than silently
-	// downgraded.
 	envProtocol       = "OTEL_EXPORTER_OTLP_PROTOCOL"
 	envSignalProtocol = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
 
@@ -49,7 +34,6 @@ const (
 	protocolHTTP = "http/protobuf"
 )
 
-// mirrorEnabled reports whether an external OTLP trace endpoint is configured.
 func mirrorEnabled() bool {
 	return mirrorEndpoint() != ""
 }
@@ -72,10 +56,8 @@ func mirrorProtocol() string {
 	return protocolHTTP
 }
 
-// newMirrorSpanProcessor builds a batch span processor that ships spans to the
-// externally configured OTLP endpoint. It returns a nil processor when no
-// endpoint is configured, which callers MUST treat as "no mirror wanted"
-// rather than an error.
+// newMirrorSpanProcessor returns a nil processor, and no error, when no
+// external endpoint is configured.
 func newMirrorSpanProcessor(ctx context.Context) (trace.SpanProcessor, error) {
 	if !mirrorEnabled() {
 		return nil, nil
@@ -88,10 +70,9 @@ func newMirrorSpanProcessor(ctx context.Context) (trace.SpanProcessor, error) {
 
 	switch proto := mirrorProtocol(); proto {
 	case protocolGRPC:
-		// No WithEndpoint/WithInsecure here on purpose: the exporter reads
-		// OTEL_EXPORTER_OTLP_[TRACES_]ENDPOINT itself and derives TLS from the
-		// scheme, so `http://` collectors work without a separate insecure
-		// flag.
+		// Endpoint deliberately left to the exporter: it reads the env vars
+		// itself and derives TLS from the scheme, so http:// needs no
+		// separate insecure flag.
 		exp, err = otlptracegrpc.New(ctx)
 	case protocolHTTP:
 		exp, err = otlptracehttp.New(ctx)
@@ -105,7 +86,5 @@ func newMirrorSpanProcessor(ctx context.Context) (trace.SpanProcessor, error) {
 		return nil, fmt.Errorf("error creating mirrored OTLP trace exporter: %w", err)
 	}
 
-	// Registered on the provider, so provider ForceFlush/Shutdown already
-	// drains and closes this processor and its exporter.
 	return trace.NewBatchSpanProcessor(exp), nil
 }

--- a/pkg/telemetry/trace/mirror_test.go
+++ b/pkg/telemetry/trace/mirror_test.go
@@ -401,6 +401,53 @@ func TestTracerExportWithoutMirror(t *testing.T) {
 	require.Equal(t, map[string]string{"unmirrored-export": "test"}, sink.spans(t))
 }
 
+// TestTracerExportMirrorsWithoutSink covers the noop tracer that
+// UserTracer/SystemTracer fall back to when nothing configured them: it has no
+// processor, so the mirror must not depend on one to receive Export's spans.
+func TestTracerExportMirrorsWithoutSink(t *testing.T) {
+	ctx := context.Background()
+
+	clearOTLPEnv(t)
+
+	collector := newTraceSink(t)
+
+	// Per-signal endpoints are used verbatim, so spell out the full path.
+	t.Setenv(envSignalEndpoint, collector.URL+"/v1/traces")
+
+	tr, err := newTracer(ctx, TracerOpts{
+		Type:        TracerTypeNoop,
+		ServiceName: "test",
+	})
+	require.NoError(t, err)
+	t.Cleanup(tr.Shutdown(ctx))
+
+	concrete, ok := tr.(*tracer)
+	require.True(t, ok)
+	// Should the noop provider ever gain a processor, this test stops covering
+	// the bug it was written for and needs updating rather than deleting.
+	require.Nil(t, concrete.processor, "the noop sink must not have a processor")
+	require.NotNil(t, concrete.mirror, "a configured mirror must be attached to the tracer")
+
+	require.NoError(t, tr.Export(exportedSpan("noop-sink-export")))
+	require.NoError(t, tr.Provider().ForceFlush(ctx))
+
+	require.Equal(t, map[string]string{"noop-sink-export": "test"}, collector.spans(t))
+}
+
+// TestTracerExportWithoutSinkOrMirror pins the other end of the same guard:
+// nowhere to send a span is not an error, and must not panic.
+func TestTracerExportWithoutSinkOrMirror(t *testing.T) {
+	ctx := context.Background()
+
+	clearOTLPEnv(t)
+
+	tr, err := newTracer(ctx, TracerOpts{Type: TracerTypeNoop, ServiceName: "test"})
+	require.NoError(t, err)
+	t.Cleanup(tr.Shutdown(ctx))
+
+	require.NoError(t, tr.Export(exportedSpan("dropped-export")))
+}
+
 // TestNewTracerDegradesOnUnsupportedMirrorProtocol guards against a telemetry
 // typo taking the server down: an error here propagates out of every component
 // that traces and prevents startup, for a signal nothing depends on.

--- a/pkg/telemetry/trace/mirror_test.go
+++ b/pkg/telemetry/trace/mirror_test.go
@@ -8,10 +8,15 @@ import (
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // clearOTLPEnv makes the OTLP environment hermetic. Both mirror.go and the
@@ -352,6 +357,129 @@ func TestNewTracerWithoutMirrorEnv(t *testing.T) {
 	require.Equal(t, map[string]string{"unmirrored-span": "test"}, sink.spans(t))
 }
 
+// TestTracerExportFansOutToSinkAndMirror covers the path that carries the
+// entire legacy run and step span tree: pkg/run builds its own ReadOnlySpans
+// and ends them through Export (see run.Span.End), which writes straight to the
+// span processors and never touches the provider's tracer. Until Export learned
+// about the mirror, exactly the spans an external backend is wanted for were
+// the ones it never saw, while spans created through the otel API arrived
+// normally - a gap no provider-level test can catch.
+func TestTracerExportFansOutToSinkAndMirror(t *testing.T) {
+	ctx := context.Background()
+
+	clearOTLPEnv(t)
+
+	sink := newTraceSink(t)
+	collector := newTraceSink(t)
+
+	// Per-signal endpoints are used verbatim by the upstream exporter, so the
+	// full path an operator would configure is spelled out here.
+	t.Setenv(envSignalEndpoint, collector.URL+"/v1/traces")
+
+	tracer, err := newTracer(ctx, TracerOpts{
+		Type:          TracerTypeOTLPHTTP,
+		TraceEndpoint: sink.Listener.Addr().String(),
+		TraceURLPath:  "/dev/traces",
+		ServiceName:   "test",
+	})
+	require.NoError(t, err)
+	t.Cleanup(tracer.Shutdown(ctx))
+
+	require.NoError(t, tracer.Export(exportedSpan("exported-span")))
+
+	// Export enqueues on the processors directly, but both of them are batch
+	// processors registered on the provider, so the provider's ForceFlush
+	// drains them however the span was queued. Shutdown would drain them too
+	// (it calls the same ForceFlush) but it also closes the tracer, so
+	// ForceFlush is used here to keep the assertions on a live one.
+	require.NoError(t, tracer.Provider().ForceFlush(ctx))
+
+	// Because Export bypasses the provider, the resource that reaches a
+	// collector is the span's own rather than the tracer's. Pinning it on both
+	// copies proves the mirror ships the span it was handed instead of a
+	// re-attributed one, which is what external backends group by.
+	expected := map[string]string{"exported-span": "test"}
+	require.Equal(t, expected, sink.spans(t), "internal sink did not receive the exported span")
+	require.Equal(t, expected, collector.spans(t), "external collector did not receive the exported span")
+
+	// Fanning out must not move the internal sink: the dev server only ingests
+	// traces on the configured path.
+	for _, req := range sink.received() {
+		require.Equal(t, "/dev/traces", req.path)
+	}
+}
+
+// TestTracerExportWithoutMirror is the other half of that contract. With no
+// external endpoint configured there is no mirror to fan out to, and Export
+// must still deliver to the internal sink rather than dereferencing a nil
+// processor or bailing out before the sink is written.
+func TestTracerExportWithoutMirror(t *testing.T) {
+	ctx := context.Background()
+
+	clearOTLPEnv(t)
+
+	sink := newTraceSink(t)
+
+	tr, err := newTracer(ctx, TracerOpts{
+		Type:          TracerTypeOTLPHTTP,
+		TraceEndpoint: sink.Listener.Addr().String(),
+		TraceURLPath:  "/dev/traces",
+		ServiceName:   "test",
+	})
+	require.NoError(t, err)
+	t.Cleanup(tr.Shutdown(ctx))
+
+	concrete, ok := tr.(*tracer)
+	require.True(t, ok)
+	require.Nil(t, concrete.mirror, "an unconfigured process must not attach a mirror to the tracer")
+
+	require.NoError(t, tr.Export(exportedSpan("unmirrored-export")))
+	require.NoError(t, tr.Provider().ForceFlush(ctx))
+
+	require.Equal(t, map[string]string{"unmirrored-export": "test"}, sink.spans(t))
+}
+
+// TestNewTracerDegradesOnUnsupportedMirrorProtocol is the regression guard for
+// a telemetry typo taking the server down with it. http/json is a real OTLP
+// spec value with no Go trace exporter, so the constructor rejects it (see
+// TestNewMirrorSpanProcessorRejectsUnsupportedProtocol); newTracer has to log
+// that and hand back a working tracer regardless, because a returned error here
+// propagates out of every server component that traces and prevents startup -
+// for a signal the platform does not depend on.
+func TestNewTracerDegradesOnUnsupportedMirrorProtocol(t *testing.T) {
+	ctx := context.Background()
+
+	clearOTLPEnv(t)
+
+	sink := newTraceSink(t)
+
+	// Nothing needs to listen on the mirror endpoint: the protocol is rejected
+	// before an exporter is built, let alone connected. It only has to be
+	// non-empty, since that is what asks for a mirror at all.
+	t.Setenv(envSignalEndpoint, "http://127.0.0.1:4318/v1/traces")
+	t.Setenv(envSignalProtocol, "http/json")
+
+	tr, err := newTracer(ctx, TracerOpts{
+		Type:          TracerTypeOTLPHTTP,
+		TraceEndpoint: sink.Listener.Addr().String(),
+		TraceURLPath:  "/dev/traces",
+		ServiceName:   "test",
+	})
+	require.NoError(t, err, "a mirror misconfiguration must not stop the server from booting")
+	require.NotNil(t, tr)
+	t.Cleanup(tr.Shutdown(ctx))
+
+	concrete, ok := tr.(*tracer)
+	require.True(t, ok)
+	require.Nil(t, concrete.mirror, "a rejected mirror must not be attached to the tracer")
+
+	// Degraded, not dead: the sink the platform itself depends on still works.
+	require.NoError(t, tr.Export(exportedSpan("degraded-export")))
+	require.NoError(t, tr.Provider().ForceFlush(ctx))
+
+	require.Equal(t, map[string]string{"degraded-export": "test"}, sink.spans(t))
+}
+
 // traceSink is an in-process stand-in for an OTLP/HTTP collector. It accepts
 // any path and records every request so tests can assert which sinks a span
 // actually reached.
@@ -435,4 +563,30 @@ func (s *traceSink) spans(t *testing.T) map[string]string {
 	}
 
 	return out
+}
+
+// exportedSpan stands in for the spans pkg/run hands to Export: ReadOnlySpans
+// assembled by hand that never pass through a tracer provider, which is the
+// whole reason Export exists. A real run.Span cannot be used here because
+// pkg/run imports this package, so the upstream stub plays its part. The
+// timestamps and IDs are fixed so the encoded payload is identical on every
+// run, and the resource carries service.name because Export bypasses the
+// provider that would otherwise supply one.
+func exportedSpan(name string) trace.ReadOnlySpan {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return tracetest.SpanStub{
+		Name: name,
+		SpanContext: oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+			TraceID:    oteltrace.TraceID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10},
+			SpanID:     oteltrace.SpanID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8},
+			TraceFlags: oteltrace.FlagsSampled,
+		}),
+		StartTime: start,
+		EndTime:   start.Add(time.Millisecond),
+		Resource: resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceNameKey.String("test"),
+		),
+	}.Snapshot()
 }

--- a/pkg/telemetry/trace/mirror_test.go
+++ b/pkg/telemetry/trace/mirror_test.go
@@ -1,0 +1,438 @@
+package trace
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
+)
+
+// clearOTLPEnv makes the OTLP environment hermetic. Both mirror.go and the
+// upstream exporters read process env directly, so a developer's own OTEL_*
+// values would otherwise decide the outcome of these tests. t.Setenv restores
+// the previous state on cleanup, and an empty value is indistinguishable from
+// unset to os.Getenv, which is all any of this code uses.
+//
+// The compression and insecure variables are cleared too: they are read by the
+// mirror exporter (which is deliberately configured entirely from env) and
+// would gzip the body or force TLS, breaking the end-to-end test for reasons
+// that have nothing to do with the mirror.
+func clearOTLPEnv(t *testing.T) {
+	t.Helper()
+
+	for _, k := range []string{
+		envEndpoint,
+		envSignalEndpoint,
+		envProtocol,
+		envSignalProtocol,
+		"OTEL_EXPORTER_OTLP_COMPRESSION",
+		"OTEL_EXPORTER_OTLP_TRACES_COMPRESSION",
+		"OTEL_EXPORTER_OTLP_INSECURE",
+		"OTEL_EXPORTER_OTLP_TRACES_INSECURE",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestMirrorEndpointResolution(t *testing.T) {
+	const (
+		generic = "http://generic-collector:4318"
+		signal  = "http://signal-collector:4318"
+	)
+
+	tests := []struct {
+		name        string
+		env         map[string]string
+		expected    string
+		wantEnabled bool
+	}{
+		{
+			name:        "no endpoint leaves the mirror disabled",
+			env:         map[string]string{},
+			expected:    "",
+			wantEnabled: false,
+		},
+		{
+			name:        "generic endpoint enables the mirror",
+			env:         map[string]string{envEndpoint: generic},
+			expected:    generic,
+			wantEnabled: true,
+		},
+		{
+			name:        "signal endpoint enables the mirror",
+			env:         map[string]string{envSignalEndpoint: signal},
+			expected:    signal,
+			wantEnabled: true,
+		},
+		{
+			name: "signal endpoint wins over generic",
+			env: map[string]string{
+				envEndpoint:       generic,
+				envSignalEndpoint: signal,
+			},
+			expected:    signal,
+			wantEnabled: true,
+		},
+		{
+			name: "whitespace-only signal endpoint falls back to generic",
+			env: map[string]string{
+				envEndpoint:       generic,
+				envSignalEndpoint: "   ",
+			},
+			expected:    generic,
+			wantEnabled: true,
+		},
+		{
+			name: "whitespace-only endpoints leave the mirror disabled",
+			env: map[string]string{
+				envEndpoint:       " \t\n ",
+				envSignalEndpoint: "  ",
+			},
+			expected:    "",
+			wantEnabled: false,
+		},
+		{
+			name:        "surrounding whitespace is trimmed off the endpoint",
+			env:         map[string]string{envSignalEndpoint: "  " + signal + "\n"},
+			expected:    signal,
+			wantEnabled: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearOTLPEnv(t)
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
+
+			require.Equal(t, test.expected, mirrorEndpoint())
+			require.Equal(t, test.wantEnabled, mirrorEnabled())
+		})
+	}
+}
+
+func TestMirrorProtocolResolution(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      map[string]string
+		expected string
+	}{
+		{
+			// The OTLP spec mandates http/protobuf when nothing is set;
+			// picking anything else silently changes the wire format every
+			// self-hosted collector has to accept.
+			name:     "unset protocol resolves to the spec-mandated protocol",
+			env:      map[string]string{},
+			expected: protocolHTTP,
+		},
+		{
+			name:     "generic protocol is honoured",
+			env:      map[string]string{envProtocol: protocolGRPC},
+			expected: protocolGRPC,
+		},
+		{
+			name:     "signal protocol is honoured",
+			env:      map[string]string{envSignalProtocol: protocolGRPC},
+			expected: protocolGRPC,
+		},
+		{
+			name: "signal protocol wins over generic",
+			env: map[string]string{
+				envProtocol:       protocolHTTP,
+				envSignalProtocol: protocolGRPC,
+			},
+			expected: protocolGRPC,
+		},
+		{
+			name: "whitespace-only signal protocol falls back to generic",
+			env: map[string]string{
+				envProtocol:       protocolGRPC,
+				envSignalProtocol: "   ",
+			},
+			expected: protocolGRPC,
+		},
+		{
+			name: "whitespace-only protocols fall back to the spec protocol",
+			env: map[string]string{
+				envProtocol:       "  ",
+				envSignalProtocol: " \t ",
+			},
+			expected: protocolHTTP,
+		},
+		{
+			name:     "surrounding whitespace is trimmed off the protocol",
+			env:      map[string]string{envSignalProtocol: " " + protocolGRPC + "\n"},
+			expected: protocolGRPC,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearOTLPEnv(t)
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
+
+			require.Equal(t, test.expected, mirrorProtocol())
+		})
+	}
+}
+
+// TestNewMirrorSpanProcessorWithoutEndpoint pins the invariant the whole
+// feature rests on: unless an endpoint is configured there is no mirror, and
+// that is not an error condition. A processor here would attach an extra
+// exporter to every tracer in the process.
+func TestNewMirrorSpanProcessorWithoutEndpoint(t *testing.T) {
+	clearOTLPEnv(t)
+
+	// A protocol on its own must not be enough to turn the mirror on.
+	t.Setenv(envSignalProtocol, protocolGRPC)
+
+	sp, err := newMirrorSpanProcessor(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, sp)
+}
+
+func TestNewMirrorSpanProcessorSupportedProtocols(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+	}{
+		{name: "grpc", protocol: protocolGRPC},
+		{name: "http/protobuf", protocol: protocolHTTP},
+		{name: "unset protocol still yields a usable mirror", protocol: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			clearOTLPEnv(t)
+			t.Setenv(envSignalEndpoint, "http://127.0.0.1:4318")
+			if test.protocol != "" {
+				t.Setenv(envSignalProtocol, test.protocol)
+			}
+
+			sp, err := newMirrorSpanProcessor(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, sp)
+			require.NoError(t, sp.Shutdown(ctx))
+		})
+	}
+}
+
+// TestNewMirrorSpanProcessorRejectsUnsupportedProtocol guards against a silent
+// downgrade: an operator who asks for a protocol we cannot speak must be told,
+// not quietly given a different wire format.
+func TestNewMirrorSpanProcessorRejectsUnsupportedProtocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+	}{
+		{
+			// A real OTLP spec value that the Go SDK has no trace exporter
+			// for, so it is the likeliest thing an operator copies in.
+			name:     "http/json has no Go trace exporter",
+			protocol: "http/json",
+		},
+		{
+			name:     "unknown protocol",
+			protocol: "thrift",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clearOTLPEnv(t)
+			t.Setenv(envSignalEndpoint, "http://127.0.0.1:4318")
+			t.Setenv(envSignalProtocol, test.protocol)
+
+			sp, err := newMirrorSpanProcessor(context.Background())
+			require.Nil(t, sp)
+			require.Error(t, err)
+
+			// The message has to name the rejected value and both usable
+			// alternatives, otherwise it is not actionable.
+			require.ErrorContains(t, err, test.protocol)
+			require.ErrorContains(t, err, protocolHTTP)
+			require.ErrorContains(t, err, protocolGRPC)
+		})
+	}
+}
+
+// TestNewTracerExportsToSinkAndMirror is the contract that justifies the
+// feature: with an external OTLP endpoint configured, a single span lands in
+// *both* the tracer's own sink (for `inngest dev`, the server's /dev/traces
+// ingestion endpoint that feeds the run details UI) and the external
+// collector. Losing either half is a shipping bug.
+func TestNewTracerExportsToSinkAndMirror(t *testing.T) {
+	ctx := context.Background()
+
+	clearOTLPEnv(t)
+
+	sink := newTraceSink(t)
+	collector := newTraceSink(t)
+
+	// The mirror exporter reads this itself; the http:// scheme is what makes
+	// it plaintext, so no TLS setup is needed. Note the Go SDK uses a
+	// per-signal endpoint URL as-is (a URL with no path is served at "/"),
+	// unlike the generic variable which gets /v1/traces appended - which is
+	// why the sink records whatever path it is hit on rather than asserting a
+	// path the upstream exporter owns.
+	t.Setenv(envSignalEndpoint, collector.URL)
+
+	tracer, err := newTracer(ctx, TracerOpts{
+		Type:          TracerTypeOTLPHTTP,
+		TraceEndpoint: sink.Listener.Addr().String(),
+		TraceURLPath:  "/dev/traces",
+		ServiceName:   "test",
+	})
+	require.NoError(t, err)
+	t.Cleanup(tracer.Shutdown(ctx))
+
+	_, span := tracer.Provider().Tracer("test").Start(ctx, "mirrored-span")
+	span.End()
+
+	// ForceFlush drains every processor registered on the provider, and each
+	// OTLP HTTP export blocks until its collector responds, so both sinks have
+	// been hit by the time this returns. No polling required.
+	require.NoError(t, tracer.Provider().ForceFlush(ctx))
+
+	// service.name comes from the provider's resource. Asserting it on the
+	// mirrored copy proves the mirror rides the same provider rather than
+	// standing up an unattributed one of its own, which is what external
+	// collectors key off.
+	expected := map[string]string{"mirrored-span": "test"}
+	require.Equal(t, expected, sink.spans(t), "internal sink did not receive the span")
+	require.Equal(t, expected, collector.spans(t), "external collector did not receive the mirrored span")
+
+	// The mirror must not repoint the internal sink: the dev server only
+	// ingests traces on the configured path.
+	for _, req := range sink.received() {
+		require.Equal(t, "/dev/traces", req.path)
+	}
+}
+
+// TestNewTracerWithoutMirrorEnv is the inverse regression: with the OTLP
+// variables unset there is no mirror at all and the tracer behaves exactly as
+// it did before the feature landed.
+func TestNewTracerWithoutMirrorEnv(t *testing.T) {
+	ctx := context.Background()
+
+	clearOTLPEnv(t)
+
+	mirror, err := newMirrorSpanProcessor(ctx)
+	require.NoError(t, err)
+	require.Nil(t, mirror, "an unconfigured process must not build a mirror")
+
+	sink := newTraceSink(t)
+
+	tracer, err := newTracer(ctx, TracerOpts{
+		Type:          TracerTypeOTLPHTTP,
+		TraceEndpoint: sink.Listener.Addr().String(),
+		TraceURLPath:  "/dev/traces",
+		ServiceName:   "test",
+	})
+	require.NoError(t, err)
+	t.Cleanup(tracer.Shutdown(ctx))
+
+	_, span := tracer.Provider().Tracer("test").Start(ctx, "unmirrored-span")
+	span.End()
+
+	require.NoError(t, tracer.Provider().ForceFlush(ctx))
+
+	require.Equal(t, map[string]string{"unmirrored-span": "test"}, sink.spans(t))
+}
+
+// traceSink is an in-process stand-in for an OTLP/HTTP collector. It accepts
+// any path and records every request so tests can assert which sinks a span
+// actually reached.
+type traceSink struct {
+	*httptest.Server
+
+	mu       sync.Mutex
+	requests []sinkRequest
+}
+
+type sinkRequest struct {
+	method      string
+	path        string
+	contentType string
+	body        []byte
+}
+
+func newTraceSink(t *testing.T) *traceSink {
+	t.Helper()
+
+	s := &traceSink{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		s.mu.Lock()
+		s.requests = append(s.requests, sinkRequest{
+			method:      r.Method,
+			path:        r.URL.Path,
+			contentType: r.Header.Get("Content-Type"),
+			body:        body,
+		})
+		s.mu.Unlock()
+
+		// An empty 200 is a valid OTLP/HTTP success response.
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(s.Close)
+
+	return s
+}
+
+func (s *traceSink) received() []sinkRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.requests)
+}
+
+// spans decodes everything the sink was sent and returns span name ->
+// service.name of the resource that carried it.
+func (s *traceSink) spans(t *testing.T) map[string]string {
+	t.Helper()
+
+	out := map[string]string{}
+	for _, req := range s.received() {
+		require.Equal(t, http.MethodPost, req.method)
+		require.Equal(t, "application/x-protobuf", req.contentType)
+		require.NotEmpty(t, req.body)
+
+		traces, err := (&ptrace.ProtoUnmarshaler{}).UnmarshalTraces(req.body)
+		require.NoError(t, err, "sink was sent a body that is not OTLP protobuf")
+
+		for i := range traces.ResourceSpans().Len() {
+			rs := traces.ResourceSpans().At(i)
+
+			var svc string
+			if v, ok := rs.Resource().Attributes().Get(string(semconv.ServiceNameKey)); ok {
+				svc = v.Str()
+			}
+
+			for j := range rs.ScopeSpans().Len() {
+				spans := rs.ScopeSpans().At(j).Spans()
+				for k := range spans.Len() {
+					out[spans.At(k).Name()] = svc
+				}
+			}
+		}
+	}
+
+	return out
+}

--- a/pkg/telemetry/trace/mirror_test.go
+++ b/pkg/telemetry/trace/mirror_test.go
@@ -19,16 +19,9 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
-// clearOTLPEnv makes the OTLP environment hermetic. Both mirror.go and the
-// upstream exporters read process env directly, so a developer's own OTEL_*
-// values would otherwise decide the outcome of these tests. t.Setenv restores
-// the previous state on cleanup, and an empty value is indistinguishable from
-// unset to os.Getenv, which is all any of this code uses.
-//
-// The compression and insecure variables are cleared too: they are read by the
-// mirror exporter (which is deliberately configured entirely from env) and
-// would gzip the body or force TLS, breaking the end-to-end test for reasons
-// that have nothing to do with the mirror.
+// clearOTLPEnv makes the OTLP environment hermetic: mirror.go and the upstream
+// exporters both read process env directly, and compression or insecure values
+// left in a developer's shell would break the end-to-end tests.
 func clearOTLPEnv(t *testing.T) {
 	t.Helper()
 
@@ -131,9 +124,7 @@ func TestMirrorProtocolResolution(t *testing.T) {
 		expected string
 	}{
 		{
-			// The OTLP spec mandates http/protobuf when nothing is set;
-			// picking anything else silently changes the wire format every
-			// self-hosted collector has to accept.
+			// The spec mandates http/protobuf when nothing is set.
 			name:     "unset protocol resolves to the spec-mandated protocol",
 			env:      map[string]string{},
 			expected: protocolHTTP,
@@ -192,9 +183,7 @@ func TestMirrorProtocolResolution(t *testing.T) {
 }
 
 // TestNewMirrorSpanProcessorWithoutEndpoint pins the invariant the whole
-// feature rests on: unless an endpoint is configured there is no mirror, and
-// that is not an error condition. A processor here would attach an extra
-// exporter to every tracer in the process.
+// feature rests on: no endpoint, no mirror, and that is not an error.
 func TestNewMirrorSpanProcessorWithoutEndpoint(t *testing.T) {
 	clearOTLPEnv(t)
 
@@ -234,17 +223,14 @@ func TestNewMirrorSpanProcessorSupportedProtocols(t *testing.T) {
 	}
 }
 
-// TestNewMirrorSpanProcessorRejectsUnsupportedProtocol guards against a silent
-// downgrade: an operator who asks for a protocol we cannot speak must be told,
-// not quietly given a different wire format.
+// Asking for a protocol we cannot speak must be reported, not silently served
+// over a different wire format.
 func TestNewMirrorSpanProcessorRejectsUnsupportedProtocol(t *testing.T) {
 	tests := []struct {
 		name     string
 		protocol string
 	}{
 		{
-			// A real OTLP spec value that the Go SDK has no trace exporter
-			// for, so it is the likeliest thing an operator copies in.
 			name:     "http/json has no Go trace exporter",
 			protocol: "http/json",
 		},
@@ -264,8 +250,6 @@ func TestNewMirrorSpanProcessorRejectsUnsupportedProtocol(t *testing.T) {
 			require.Nil(t, sp)
 			require.Error(t, err)
 
-			// The message has to name the rejected value and both usable
-			// alternatives, otherwise it is not actionable.
 			require.ErrorContains(t, err, test.protocol)
 			require.ErrorContains(t, err, protocolHTTP)
 			require.ErrorContains(t, err, protocolGRPC)
@@ -274,10 +258,8 @@ func TestNewMirrorSpanProcessorRejectsUnsupportedProtocol(t *testing.T) {
 }
 
 // TestNewTracerExportsToSinkAndMirror is the contract that justifies the
-// feature: with an external OTLP endpoint configured, a single span lands in
-// *both* the tracer's own sink (for `inngest dev`, the server's /dev/traces
-// ingestion endpoint that feeds the run details UI) and the external
-// collector. Losing either half is a shipping bug.
+// feature: one span reaches both the tracer's own sink (`/dev/traces`, which
+// feeds the run details UI) and the external collector.
 func TestNewTracerExportsToSinkAndMirror(t *testing.T) {
 	ctx := context.Background()
 
@@ -286,12 +268,9 @@ func TestNewTracerExportsToSinkAndMirror(t *testing.T) {
 	sink := newTraceSink(t)
 	collector := newTraceSink(t)
 
-	// The mirror exporter reads this itself; the http:// scheme is what makes
-	// it plaintext, so no TLS setup is needed. Note the Go SDK uses a
-	// per-signal endpoint URL as-is (a URL with no path is served at "/"),
-	// unlike the generic variable which gets /v1/traces appended - which is
-	// why the sink records whatever path it is hit on rather than asserting a
-	// path the upstream exporter owns.
+	// The exporter reads this itself, and http:// is what makes it plaintext.
+	// A per-signal endpoint is used as-is, so a URL with no path is served at
+	// "/" - hence the sink records paths instead of asserting one.
 	t.Setenv(envSignalEndpoint, collector.URL)
 
 	tracer, err := newTracer(ctx, TracerOpts{
@@ -306,29 +285,24 @@ func TestNewTracerExportsToSinkAndMirror(t *testing.T) {
 	_, span := tracer.Provider().Tracer("test").Start(ctx, "mirrored-span")
 	span.End()
 
-	// ForceFlush drains every processor registered on the provider, and each
-	// OTLP HTTP export blocks until its collector responds, so both sinks have
-	// been hit by the time this returns. No polling required.
+	// ForceFlush drains every processor on the provider, and each OTLP export
+	// blocks until its collector responds, so no polling is needed.
 	require.NoError(t, tracer.Provider().ForceFlush(ctx))
 
-	// service.name comes from the provider's resource. Asserting it on the
-	// mirrored copy proves the mirror rides the same provider rather than
-	// standing up an unattributed one of its own, which is what external
-	// collectors key off.
+	// Asserting service.name proves the mirror rides the tracer's own provider
+	// rather than standing up an unattributed one.
 	expected := map[string]string{"mirrored-span": "test"}
 	require.Equal(t, expected, sink.spans(t), "internal sink did not receive the span")
 	require.Equal(t, expected, collector.spans(t), "external collector did not receive the mirrored span")
 
-	// The mirror must not repoint the internal sink: the dev server only
-	// ingests traces on the configured path.
+	// The mirror must not repoint the internal sink.
 	for _, req := range sink.received() {
 		require.Equal(t, "/dev/traces", req.path)
 	}
 }
 
-// TestNewTracerWithoutMirrorEnv is the inverse regression: with the OTLP
-// variables unset there is no mirror at all and the tracer behaves exactly as
-// it did before the feature landed.
+// TestNewTracerWithoutMirrorEnv is the inverse regression: unset variables mean
+// no mirror and pre-feature behaviour.
 func TestNewTracerWithoutMirrorEnv(t *testing.T) {
 	ctx := context.Background()
 
@@ -357,13 +331,10 @@ func TestNewTracerWithoutMirrorEnv(t *testing.T) {
 	require.Equal(t, map[string]string{"unmirrored-span": "test"}, sink.spans(t))
 }
 
-// TestTracerExportFansOutToSinkAndMirror covers the path that carries the
-// entire legacy run and step span tree: pkg/run builds its own ReadOnlySpans
-// and ends them through Export (see run.Span.End), which writes straight to the
-// span processors and never touches the provider's tracer. Until Export learned
-// about the mirror, exactly the spans an external backend is wanted for were
-// the ones it never saw, while spans created through the otel API arrived
-// normally - a gap no provider-level test can catch.
+// TestTracerExportFansOutToSinkAndMirror covers the path carrying the entire
+// legacy run and step span tree: pkg/run ends its hand-built ReadOnlySpans
+// through Export, which writes to the processors and never touches the
+// provider. No provider-level test can catch a gap here.
 func TestTracerExportFansOutToSinkAndMirror(t *testing.T) {
 	ctx := context.Background()
 
@@ -372,8 +343,7 @@ func TestTracerExportFansOutToSinkAndMirror(t *testing.T) {
 	sink := newTraceSink(t)
 	collector := newTraceSink(t)
 
-	// Per-signal endpoints are used verbatim by the upstream exporter, so the
-	// full path an operator would configure is spelled out here.
+	// Per-signal endpoints are used verbatim, so spell out the full path.
 	t.Setenv(envSignalEndpoint, collector.URL+"/v1/traces")
 
 	tracer, err := newTracer(ctx, TracerOpts{
@@ -387,32 +357,24 @@ func TestTracerExportFansOutToSinkAndMirror(t *testing.T) {
 
 	require.NoError(t, tracer.Export(exportedSpan("exported-span")))
 
-	// Export enqueues on the processors directly, but both of them are batch
-	// processors registered on the provider, so the provider's ForceFlush
-	// drains them however the span was queued. Shutdown would drain them too
-	// (it calls the same ForceFlush) but it also closes the tracer, so
-	// ForceFlush is used here to keep the assertions on a live one.
+	// Both processors are registered on the provider, so its ForceFlush drains
+	// them however the span was queued. Shutdown would too, but also closes
+	// the tracer.
 	require.NoError(t, tracer.Provider().ForceFlush(ctx))
 
-	// Because Export bypasses the provider, the resource that reaches a
-	// collector is the span's own rather than the tracer's. Pinning it on both
-	// copies proves the mirror ships the span it was handed instead of a
-	// re-attributed one, which is what external backends group by.
+	// Export bypasses the provider, so the resource reaching a collector is the
+	// span's own. Pinning it proves the mirror ships the span it was handed.
 	expected := map[string]string{"exported-span": "test"}
 	require.Equal(t, expected, sink.spans(t), "internal sink did not receive the exported span")
 	require.Equal(t, expected, collector.spans(t), "external collector did not receive the exported span")
 
-	// Fanning out must not move the internal sink: the dev server only ingests
-	// traces on the configured path.
 	for _, req := range sink.received() {
 		require.Equal(t, "/dev/traces", req.path)
 	}
 }
 
-// TestTracerExportWithoutMirror is the other half of that contract. With no
-// external endpoint configured there is no mirror to fan out to, and Export
-// must still deliver to the internal sink rather than dereferencing a nil
-// processor or bailing out before the sink is written.
+// TestTracerExportWithoutMirror is the other half: with no mirror to fan out
+// to, Export must still reach the sink rather than nil-deref or bail early.
 func TestTracerExportWithoutMirror(t *testing.T) {
 	ctx := context.Background()
 
@@ -439,13 +401,9 @@ func TestTracerExportWithoutMirror(t *testing.T) {
 	require.Equal(t, map[string]string{"unmirrored-export": "test"}, sink.spans(t))
 }
 
-// TestNewTracerDegradesOnUnsupportedMirrorProtocol is the regression guard for
-// a telemetry typo taking the server down with it. http/json is a real OTLP
-// spec value with no Go trace exporter, so the constructor rejects it (see
-// TestNewMirrorSpanProcessorRejectsUnsupportedProtocol); newTracer has to log
-// that and hand back a working tracer regardless, because a returned error here
-// propagates out of every server component that traces and prevents startup -
-// for a signal the platform does not depend on.
+// TestNewTracerDegradesOnUnsupportedMirrorProtocol guards against a telemetry
+// typo taking the server down: an error here propagates out of every component
+// that traces and prevents startup, for a signal nothing depends on.
 func TestNewTracerDegradesOnUnsupportedMirrorProtocol(t *testing.T) {
 	ctx := context.Background()
 
@@ -453,9 +411,8 @@ func TestNewTracerDegradesOnUnsupportedMirrorProtocol(t *testing.T) {
 
 	sink := newTraceSink(t)
 
-	// Nothing needs to listen on the mirror endpoint: the protocol is rejected
-	// before an exporter is built, let alone connected. It only has to be
-	// non-empty, since that is what asks for a mirror at all.
+	// Nothing needs to listen: the protocol is rejected before an exporter is
+	// built. The endpoint only has to be non-empty to ask for a mirror.
 	t.Setenv(envSignalEndpoint, "http://127.0.0.1:4318/v1/traces")
 	t.Setenv(envSignalProtocol, "http/json")
 
@@ -480,9 +437,8 @@ func TestNewTracerDegradesOnUnsupportedMirrorProtocol(t *testing.T) {
 	require.Equal(t, map[string]string{"degraded-export": "test"}, sink.spans(t))
 }
 
-// traceSink is an in-process stand-in for an OTLP/HTTP collector. It accepts
-// any path and records every request so tests can assert which sinks a span
-// actually reached.
+// traceSink is an in-process stand-in for an OTLP/HTTP collector, recording
+// every request so tests can assert which sinks a span reached.
 type traceSink struct {
 	*httptest.Server
 
@@ -565,13 +521,11 @@ func (s *traceSink) spans(t *testing.T) map[string]string {
 	return out
 }
 
-// exportedSpan stands in for the spans pkg/run hands to Export: ReadOnlySpans
-// assembled by hand that never pass through a tracer provider, which is the
-// whole reason Export exists. A real run.Span cannot be used here because
-// pkg/run imports this package, so the upstream stub plays its part. The
-// timestamps and IDs are fixed so the encoded payload is identical on every
-// run, and the resource carries service.name because Export bypasses the
-// provider that would otherwise supply one.
+// exportedSpan stands in for the spans pkg/run hands to Export. A real
+// run.Span cannot be used because pkg/run imports this package. Fixed
+// timestamps and IDs keep the payload identical across runs, and the resource
+// carries service.name because Export bypasses the provider that would supply
+// one.
 func exportedSpan(name string) trace.ReadOnlySpan {
 	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 

--- a/pkg/telemetry/trace/tracer.go
+++ b/pkg/telemetry/trace/tracer.go
@@ -244,10 +244,8 @@ type tracer struct {
 	shutdown   func(context.Context)
 	processor  trace.SpanProcessor
 
-	// mirror ships spans to an external OTLP collector in addition to
-	// processor. It is registered on provider as well, so spans created
-	// through the normal otel API reach it without any help from us; the
-	// field exists for Export, which deliberately bypasses the provider.
+	// mirror is registered on provider too; the field exists for Export,
+	// which bypasses the provider.
 	mirror trace.SpanProcessor
 }
 
@@ -273,11 +271,9 @@ func (t *tracer) Export(span trace.ReadOnlySpan) error {
 
 	t.processor.OnEnd(span)
 
-	// Legacy run and step spans (pkg/run) only ever reach an exporter through
-	// here, so skipping the mirror would hide exactly the spans an external
-	// backend is wanted for. These spans can be emitted more than once as a
-	// run progresses, by design: Inngest's own ingestion dedupes them, and
-	// trace backends key on trace and span IDs, so the last write wins.
+	// Legacy run and step spans (pkg/run) only reach an exporter here, and
+	// are re-emitted as a run progresses. Ingestion dedupes them, and trace
+	// backends key on trace and span IDs, so the last write wins.
 	if t.mirror != nil {
 		t.mirror.OnEnd(span)
 	}
@@ -307,19 +303,15 @@ func TracerSetup(svc string, ttype TracerType) (func(), error) {
 }
 
 // NewTracerProvider creates a new tracer with a provider and exporter based
-// on the passed in `TraceType`.
-//
-// When an external OTLP endpoint is configured (see mirror.go), spans are
-// additionally exported there, leaving the type-specific sink untouched.
+// on the passed in `TraceType`, plus the external OTLP mirror if one is
+// configured.
 func newTracer(ctx context.Context, opts TracerOpts) (Tracer, error) {
 	t, err := newSinkTracer(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	// A misconfigured mirror degrades telemetry; it must not stop the server
-	// from booting, since the sink the platform itself depends on is already
-	// up by this point.
+	// Telemetry misconfiguration must not stop the server from booting.
 	mirror, err := newMirrorSpanProcessor(ctx)
 	if err != nil {
 		logger.StdlibLogger(ctx).Error(
@@ -330,8 +322,7 @@ func newTracer(ctx context.Context, opts TracerOpts) (Tracer, error) {
 		return t, nil
 	}
 	if mirror != nil {
-		// Provider shutdown drains registered processors, so the tracer's own
-		// shutdown func needs no changes.
+		// Provider shutdown drains registered processors.
 		t.provider.RegisterSpanProcessor(mirror)
 		t.mirror = mirror
 	}

--- a/pkg/telemetry/trace/tracer.go
+++ b/pkg/telemetry/trace/tracer.go
@@ -98,8 +98,7 @@ func (o TracerOpts) URLPath() string {
 		return o.TraceURLPath
 	}
 
-	urlpath := os.Getenv("OTEL_TRACE_COLLECTOR_URL_PATH")
-	if urlpath == "" {
+	if urlpath := os.Getenv("OTEL_TRACE_COLLECTOR_URL_PATH"); urlpath != "" {
 		return urlpath
 	}
 
@@ -293,7 +292,29 @@ func TracerSetup(svc string, ttype TracerType) (func(), error) {
 
 // NewTracerProvider creates a new tracer with a provider and exporter based
 // on the passed in `TraceType`.
+//
+// When an external OTLP endpoint is configured (see mirror.go), spans are
+// additionally exported there, leaving the type-specific sink untouched.
 func newTracer(ctx context.Context, opts TracerOpts) (Tracer, error) {
+	t, err := newSinkTracer(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	mirror, err := newMirrorSpanProcessor(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if mirror != nil {
+		// Provider shutdown drains registered processors, so the tracer's own
+		// shutdown func needs no changes.
+		t.Provider().RegisterSpanProcessor(mirror)
+	}
+
+	return t, nil
+}
+
+func newSinkTracer(ctx context.Context, opts TracerOpts) (Tracer, error) {
 	switch opts.Type {
 	case TracerTypeOTLP:
 		return newOTLPGRPCTraceProvider(ctx, opts)

--- a/pkg/telemetry/trace/tracer.go
+++ b/pkg/telemetry/trace/tracer.go
@@ -264,12 +264,16 @@ func (t *tracer) Shutdown(ctx context.Context) func() {
 }
 
 func (t *tracer) Export(span trace.ReadOnlySpan) error {
-	if t.processor == nil {
+	if t.processor == nil && t.mirror == nil {
 		logger.StdlibLogger(context.Background()).Trace("no exporter available to export custom spans")
 		return nil
 	}
 
-	t.processor.OnEnd(span)
+	// The noop tracer has no processor, so the two sinks are independent: a
+	// configured mirror still has to receive the span.
+	if t.processor != nil {
+		t.processor.OnEnd(span)
+	}
 
 	// Legacy run and step spans (pkg/run) only reach an exporter here, and
 	// are re-emitted as a run progresses. Ingestion dedupes them, and trace

--- a/pkg/telemetry/trace/tracer.go
+++ b/pkg/telemetry/trace/tracer.go
@@ -243,6 +243,12 @@ type tracer struct {
 	propagator propagation.TextMapPropagator
 	shutdown   func(context.Context)
 	processor  trace.SpanProcessor
+
+	// mirror ships spans to an external OTLP collector in addition to
+	// processor. It is registered on provider as well, so spans created
+	// through the normal otel API reach it without any help from us; the
+	// field exists for Export, which deliberately bypasses the provider.
+	mirror trace.SpanProcessor
 }
 
 func (t *tracer) Provider() *trace.TracerProvider {
@@ -266,6 +272,16 @@ func (t *tracer) Export(span trace.ReadOnlySpan) error {
 	}
 
 	t.processor.OnEnd(span)
+
+	// Legacy run and step spans (pkg/run) only ever reach an exporter through
+	// here, so skipping the mirror would hide exactly the spans an external
+	// backend is wanted for. These spans can be emitted more than once as a
+	// run progresses, by design: Inngest's own ingestion dedupes them, and
+	// trace backends key on trace and span IDs, so the last write wins.
+	if t.mirror != nil {
+		t.mirror.OnEnd(span)
+	}
+
 	return nil
 }
 
@@ -301,20 +317,29 @@ func newTracer(ctx context.Context, opts TracerOpts) (Tracer, error) {
 		return nil, err
 	}
 
+	// A misconfigured mirror degrades telemetry; it must not stop the server
+	// from booting, since the sink the platform itself depends on is already
+	// up by this point.
 	mirror, err := newMirrorSpanProcessor(ctx)
 	if err != nil {
-		return nil, err
+		logger.StdlibLogger(ctx).Error(
+			"error configuring external OTLP trace export; continuing without it",
+			"error", err,
+			"service", opts.ServiceName,
+		)
+		return t, nil
 	}
 	if mirror != nil {
 		// Provider shutdown drains registered processors, so the tracer's own
 		// shutdown func needs no changes.
-		t.Provider().RegisterSpanProcessor(mirror)
+		t.provider.RegisterSpanProcessor(mirror)
+		t.mirror = mirror
 	}
 
 	return t, nil
 }
 
-func newSinkTracer(ctx context.Context, opts TracerOpts) (Tracer, error) {
+func newSinkTracer(ctx context.Context, opts TracerOpts) (*tracer, error) {
 	switch opts.Type {
 	case TracerTypeOTLP:
 		return newOTLPGRPCTraceProvider(ctx, opts)
@@ -333,7 +358,7 @@ func newSinkTracer(ctx context.Context, opts TracerOpts) (Tracer, error) {
 	}
 }
 
-func newJaegerTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) {
+func newJaegerTraceProvider(ctx context.Context, opts TracerOpts) (*tracer, error) {
 	exp, err := jaegerExporter()
 	if err != nil {
 		return nil, fmt.Errorf("error setting up Jaeger exporter: %w", err)
@@ -359,7 +384,7 @@ func newJaegerTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error
 }
 
 // IOTraceProvider is expected to be used for debugging purposes and not for production usage
-func newIOTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) {
+func newIOTraceProvider(ctx context.Context, opts TracerOpts) (*tracer, error) {
 	exp, err := stdouttrace.New(
 		stdouttrace.WithWriter(os.Stderr),
 	)
@@ -388,7 +413,7 @@ func newIOTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) {
 	}, nil
 }
 
-func newNoopTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) {
+func newNoopTraceProvider(ctx context.Context, opts TracerOpts) (*tracer, error) {
 	tp := trace.NewTracerProvider(
 		trace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
@@ -402,7 +427,7 @@ func newNoopTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) 
 	}, nil
 }
 
-func newOTLPHTTPTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) {
+func newOTLPHTTPTraceProvider(ctx context.Context, opts TracerOpts) (*tracer, error) {
 	endpoint := opts.Endpoint()
 	urlpath := opts.URLPath()
 
@@ -438,7 +463,7 @@ func newOTLPHTTPTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, err
 	}, nil
 }
 
-func newOTLPGRPCTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) {
+func newOTLPGRPCTraceProvider(ctx context.Context, opts TracerOpts) (*tracer, error) {
 	endpoint := opts.Endpoint()
 	maxPayloadSize := opts.MaxPayloadSizeBytes()
 
@@ -502,7 +527,7 @@ func newTextMapPropagator() propagation.TextMapPropagator {
 	)
 }
 
-func newNatsTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) {
+func newNatsTraceProvider(ctx context.Context, opts TracerOpts) (*tracer, error) {
 	if len(opts.NATS) == 0 {
 		return nil, fmt.Errorf("nats options not provided")
 	}
@@ -564,7 +589,7 @@ func newNatsTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, error) 
 	}, nil
 }
 
-func newKafkaTraceExporter(ctx context.Context, opts TracerOpts) (Tracer, error) {
+func newKafkaTraceExporter(ctx context.Context, opts TracerOpts) (*tracer, error) {
 	exp, err := exporters.NewKafkaSpanExporter(ctx, opts.Kafka...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating Kafka trace client: %w", err)

--- a/pkg/telemetry/trace/tracer_test.go
+++ b/pkg/telemetry/trace/tracer_test.go
@@ -6,10 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTracerOptsURLPath covers the resolution order of the exported URLPath
-// accessor. The final case is a regression: it used to return the empty string
-// when neither the struct field nor the environment supplied a path, handing
-// callers a path they cannot POST to.
+// The final case is a regression: URLPath used to return the empty string when
+// neither the struct field nor the environment supplied a path.
 func TestTracerOptsURLPath(t *testing.T) {
 	const envURLPath = "OTEL_TRACE_COLLECTOR_URL_PATH"
 

--- a/pkg/telemetry/trace/tracer_test.go
+++ b/pkg/telemetry/trace/tracer_test.go
@@ -1,0 +1,46 @@
+package trace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTracerOptsURLPath covers the resolution order of the exported URLPath
+// accessor. The final case is a regression: it used to return the empty string
+// when neither the struct field nor the environment supplied a path, handing
+// callers a path they cannot POST to.
+func TestTracerOptsURLPath(t *testing.T) {
+	const envURLPath = "OTEL_TRACE_COLLECTOR_URL_PATH"
+
+	tests := []struct {
+		name     string
+		opts     TracerOpts
+		env      string
+		expected string
+	}{
+		{
+			name:     "struct field wins over the environment",
+			opts:     TracerOpts{TraceURLPath: "/dev/traces"},
+			env:      "/env/traces",
+			expected: "/dev/traces",
+		},
+		{
+			name:     "environment is used when the struct field is empty",
+			env:      "/env/traces",
+			expected: "/env/traces",
+		},
+		{
+			name:     "neither configured resolves to the OTLP trace path",
+			expected: "/v1/traces",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(envURLPath, test.env)
+
+			require.Equal(t, test.expected, test.opts.URLPath())
+		})
+	}
+}


### PR DESCRIPTION
## Description

Self-hosted Inngest currently has no way to get its spans into an external OTLP collector.

`inngest dev` and `inngest start` construct both tracers with `TraceEndpoint`/`TraceURLPath` pointing at the server's own `/dev/traces` endpoint (`cmd/start/start.go:43-67`, `cmd/devserver/devserver.go:125-147`). Because `TracerOpts.Endpoint()` returns the struct field before consulting the environment (`pkg/telemetry/trace/tracer.go:84-90`), `OTEL_TRACES_COLLECTOR_ENDPOINT` is unreachable on those paths.

Repointing the exporter is not a workaround: `/dev/traces` is the ingestion endpoint that persists spans for the run details UI (`pkg/devserver/api.go:78` → `OTLPTrace` → `newSpanIngestionHandler`), so redirecting it would silently empty the UI.

So this makes the external export **additive**. When one of the standard OpenTelemetry variables is set, a second batch span processor is registered on the tracer's own provider:

| Variable | Effect |
| --- | --- |
| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base URL; `/v1/traces` is appended (spec behaviour) |
| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Used verbatim, must carry the full path; wins over the generic form |
| `OTEL_EXPORTER_OTLP_PROTOCOL` / `..._TRACES_PROTOCOL` | `grpc` or `http/protobuf` (default) |

Everything else — headers, TLS, compression, timeout — is left to the upstream OTLP exporters, which already read the spec-defined variables themselves. `http/json` is rejected with an explicit error rather than silently downgraded, since the Go SDK ships no such trace exporter.

Because the mirror is registered on the existing provider, it inherits that provider's resource and is drained by the existing `ForceFlush`/`Shutdown` paths — no new lifecycle plumbing. **When the variables are unset, `newMirrorSpanProcessor` returns `nil` and nothing changes.**

Also fixes `TracerOpts.URLPath()`, which returned `""` instead of `/v1/traces` when `OTEL_TRACE_COLLECTOR_URL_PATH` was unset, due to an inverted guard.

### Deliberately out of scope

Kept small on purpose; happy to follow up on any of these:

- **Metrics.** `NewOTLPMeterProvider` honours `OTEL_METRICS_COLLECTOR_ENDPOINT` but `MeterSetup` has no callers, so the global meter provider is never installed. The Prometheus endpoint on `/metrics` is the only working metrics surface today.
- **`service.name`.** Mirrored spans carry the provider's existing resource, i.e. `tracing` and `tracing-system`. Honouring `OTEL_SERVICE_NAME`/`OTEL_RESOURCE_ATTRIBUTES` would make them nicer to query but changes the resource on the internal sink too, so it felt like a separate decision.
- **Logs.** No OTLP log exporter exists; `INNGEST_JSON` stdout remains the only option.

### Review fixes (e1e7b6e)

- **`Export()` now fans out to the mirror.** The legacy run/step span tree (`pkg/run/trace_lifecycle.go`) is hand-rolled `ReadOnlySpan`s that reach an exporter only via `Tracer.Export`, bypassing the provider — so provider registration alone missed exactly the spans an external backend is wanted for. Measured on a real function run (`step.run` x2 + `step.sleep`), decoding the OTLP payloads with `ptrace`: 65 spans before, all `tracing`/`tracing-system` queue and event spans; 106 after, including 8 under `service.name=inngest` (`trigger`, function, `execute` x2, `sleep`, `nap`). These spans are re-emitted as a run progresses by design; Inngest's ingestion dedupes them and backends key on trace/span ID, so the last write wins.
- **A misconfigured mirror no longer stops the server booting.** Only reachable via an unsupported `OTEL_EXPORTER_OTLP_PROTOCOL` (the exporters do not dial eagerly, so an unreachable collector was never fatal). It is now logged and the tracer continues without a mirror.

## Testing

`go test ./pkg/telemetry/trace/ -count=1 -race` — 8 tests / 22 cases, including an end-to-end test that runs two `httptest` collectors, asserts a single span is decoded from **both** the internal `/dev/traces` sink and the mirrored endpoint, and fails if `RegisterSpanProcessor` is removed.

Smoke tested against the real binary: `inngest dev --no-discovery` with the mirror pointed at a local collector, verifying live spans arrive as `application/x-protobuf` on `/v1/traces` for `OTEL_EXPORTER_OTLP_ENDPOINT` and on the verbatim path for `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, while the run details UI keeps its traces.

## Release note

Self-hosted Inngest can now export traces to an external OpenTelemetry collector by setting `OTEL_EXPORTER_OTLP_ENDPOINT` (or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`). Spans are sent to the collector in addition to the Inngest server, so the run details UI is unaffected.

## Migration note

None. The new export is opt-in and inactive unless an `OTEL_EXPORTER_OTLP_*` endpoint variable is set.
