### PR TITLE
fix(traces): scope span self-join by run_id

### DIFF
--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -3608,3 +3608,48 @@ func TestCQRSGetSpanReparentsUserland(t *testing.T) {
 		})
 	}
 }
+
+// dynamic_span_id is deterministic per step position, so it collides across
+// runs; a query scoped to one run must not surface another run's groups.
+func TestCQRSGetSpansByRunIDsAndNameNoCrossRunBleed(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	runA := ulid.MustNew(ulid.Now(), rand.Reader)
+	runB := ulid.MustNew(ulid.Now(), rand.Reader)
+	const dynamicSpanID = "step-x"
+	sharedTraceID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runA.String(),
+		TraceID:       sharedTraceID,
+		DynamicSpanID: dynamicSpanID,
+		Name:          meta.SpanNameRun,
+		Attributes:    []byte(`{"_inngest.dynamic.status":"Running"}`),
+	})
+	// UpdateSpan follow-up: shares run A's run_id and dynamic_span_id, not its name.
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runA.String(),
+		TraceID:       sharedTraceID,
+		DynamicSpanID: dynamicSpanID,
+		Name:          meta.SpanNameDynamicExtension,
+		Attributes:    []byte(`{"_inngest.dynamic.status":"Completed"}`),
+	})
+	// Colliding dynamic_span_id from an unrelated run.
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runB.String(),
+		DynamicSpanID: dynamicSpanID,
+		Name:          meta.SpanNameRun,
+		Attributes:    []byte(`{"_inngest.dynamic.status":"Running"}`),
+	})
+
+	spansByRun, err := cm.(wrapper).GetSpansByRunIDsAndName(t.Context(), []ulid.ULID{runA}, meta.SpanNameRun)
+	require.NoError(t, err)
+
+	require.Len(t, spansByRun, 1, "only run A should be present in the result")
+	require.NotContains(t, spansByRun, runB, "run B must not bleed into a query scoped to run A")
+
+	groupA := spansByRun[runA]
+	require.Len(t, groupA, 1, "run A's single dynamic_span_id should collapse into one merged span")
+	assert.Equal(t, enums.StepStatusCompleted, groupA[0].Status, "the EXTEND follow-up's status must be merged onto the named row")
+}

--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -520,7 +520,7 @@ SELECT
     'input_span_id', CASE WHEN s.input IS NOT NULL THEN s.span_id ELSE NULL END
   ) ORDER BY s.start_time ASC, s.end_time ASC, s.span_id ASC) AS span_fragments
 FROM spans AS s
-JOIN spans AS m ON m.dynamic_span_id = s.dynamic_span_id
+JOIN spans AS m ON m.dynamic_span_id = s.dynamic_span_id AND m.run_id = s.run_id
 WHERE m.name = sqlc.arg('name')
   AND m.run_id IN (SELECT UNNEST(sqlc.slice('run_ids')::TEXT[]))
 GROUP BY s.run_id, s.trace_id, s.dynamic_span_id, s.parent_span_id

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -1667,7 +1667,7 @@ SELECT
     'input_span_id', CASE WHEN s.input IS NOT NULL THEN s.span_id ELSE NULL END
   ) ORDER BY s.start_time ASC, s.end_time ASC, s.span_id ASC) AS span_fragments
 FROM spans AS s
-JOIN spans AS m ON m.dynamic_span_id = s.dynamic_span_id
+JOIN spans AS m ON m.dynamic_span_id = s.dynamic_span_id AND m.run_id = s.run_id
 WHERE m.name = $1
   AND m.run_id IN (SELECT UNNEST($2::TEXT[]))
 GROUP BY s.run_id, s.trace_id, s.dynamic_span_id, s.parent_span_id

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -728,7 +728,7 @@ SELECT
     'input_span_id', CASE WHEN s.input IS NOT NULL THEN s.span_id ELSE NULL END
   )) AS span_fragments
 FROM spans AS s
-JOIN spans AS m ON m.dynamic_span_id = s.dynamic_span_id
+JOIN spans AS m ON m.dynamic_span_id = s.dynamic_span_id AND m.run_id = s.run_id
 WHERE m.name = ?
   AND m.run_id IN (sqlc.slice('run_ids'))
 GROUP BY s.run_id, s.trace_id, s.dynamic_span_id, s.parent_span_id

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -1707,7 +1707,7 @@ SELECT
     'input_span_id', CASE WHEN s.input IS NOT NULL THEN s.span_id ELSE NULL END
   )) AS span_fragments
 FROM spans AS s
-JOIN spans AS m ON m.dynamic_span_id = s.dynamic_span_id
+JOIN spans AS m ON m.dynamic_span_id = s.dynamic_span_id AND m.run_id = s.run_id
 WHERE m.name = ?
   AND m.run_id IN (/*SLICE:run_ids*/?)
 GROUP BY s.run_id, s.trace_id, s.dynamic_span_id, s.parent_span_id


### PR DESCRIPTION
## Description

`GetSpansByRunIDsAndName` self-joined `spans` on `dynamic_span_id` alone. That column has no usable index, so the join forced a full table scan on every runs-list page — and since `dynamic_span_id` is deterministic per step position, colliding IDs could bleed results across runs.

The join now also matches `run_id`, which uses the existing `idx_spans_run_id` index and scopes the merge to the requested runs. Same invariant `loadTraceRunSpanDetails` already relies on; a new CQRS test pins the no-bleed behavior.

Fixes #4690

## Release note

Fixed the runs list hanging on large Postgres deployments when `deferredFrom`/`isDeferred` was selected. No migration or manual index needed.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*