### PR TITLE
feat: Surface event scheduling in the dashboard

### DIFF
--- a/ui/packages/components/src/DetailsCard/Element.tsx
+++ b/ui/packages/components/src/DetailsCard/Element.tsx
@@ -100,10 +100,16 @@ export function TextElement({ children }: React.PropsWithChildren) {
   );
 }
 
-export function TimeElement({ date }: { date: Date }) {
+export function TimeElement({
+  date,
+  tooltipDescription,
+}: {
+  date: Date;
+  tooltipDescription?: string;
+}) {
   return (
     <span className={cn(cellStyles, 'font-medium')}>
-      <Time value={date} />
+      <Time value={date} tooltipDescription={tooltipDescription} />
     </span>
   );
 }

--- a/ui/packages/components/src/DetailsCard/Element.tsx
+++ b/ui/packages/components/src/DetailsCard/Element.tsx
@@ -8,7 +8,9 @@ import {
 } from '@inngest/components/Pill';
 import { Skeleton } from '@inngest/components/Skeleton';
 import { Time } from '@inngest/components/Time';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
 import { cn } from '@inngest/components/utils/classNames';
+import { RiInformationLine } from '@remixicon/react';
 
 import { isLazyDone, type Lazy } from '../utils/lazyLoad';
 
@@ -18,10 +20,23 @@ export function ElementWrapper({
   label,
   children,
   className,
-}: React.PropsWithChildren<{ label: string; className?: string }>) {
+  tooltip,
+}: React.PropsWithChildren<{ label: string; className?: string; tooltip?: React.ReactNode }>) {
   return (
     <div className={cn('text-sm', className)}>
-      <dt className="text-muted text-xs">{label}</dt>
+      <dt className="text-muted flex items-center gap-1 text-xs">
+        {label}
+        {tooltip && (
+          <Tooltip>
+            <TooltipTrigger>
+              <RiInformationLine className="text-muted h-3.5 w-3.5" />
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs whitespace-normal text-left">
+              {tooltip}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </dt>
       <dd className="truncate">{children}</dd>
     </div>
   );
@@ -100,16 +115,10 @@ export function TextElement({ children }: React.PropsWithChildren) {
   );
 }
 
-export function TimeElement({
-  date,
-  tooltipDescription,
-}: {
-  date: Date;
-  tooltipDescription?: string;
-}) {
+export function TimeElement({ date }: { date: Date }) {
   return (
     <span className={cn(cellStyles, 'font-medium')}>
-      <Time value={date} tooltipDescription={tooltipDescription} />
+      <Time value={date} />
     </span>
   );
 }

--- a/ui/packages/components/src/RunDetailsShared/types.ts
+++ b/ui/packages/components/src/RunDetailsShared/types.ts
@@ -8,6 +8,7 @@ export type Trace = {
   name: string;
   outputID: string | null;
   queuedAt: string;
+  scheduledAt?: string | null;
   spanID: string;
   stepID?: string | null;
   startedAt: string | null;

--- a/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
@@ -186,11 +186,11 @@ export const RunInfo = ({
           </OptimisticElementWrapper>
 
           {scheduledFor && (
-            <ElementWrapper label="Scheduled at">
-              <TimeElement
-                date={scheduledFor}
-                tooltipDescription="Scheduled to run at, based on the triggering event."
-              />
+            <ElementWrapper
+              label="Scheduled at"
+              tooltip="Scheduled to run at, based on the triggering event."
+            >
+              <TimeElement date={scheduledFor} />
             </ElementWrapper>
           )}
 

--- a/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
@@ -188,7 +188,7 @@ export const RunInfo = ({
           {scheduledFor && (
             <ElementWrapper
               label="Scheduled at"
-              tooltip="Scheduled to run at, based on the triggering event."
+              tooltip="When this run is scheduled to start, taken from the triggering event's ts timestamp."
             >
               <TimeElement date={scheduledFor} />
             </ElementWrapper>

--- a/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
@@ -18,7 +18,7 @@ import { toMaybeDate } from '../utils/date';
 import { isLazyDone, type Lazy } from '../utils/lazyLoad';
 import { Actions } from './Actions';
 import { Nav } from './Nav';
-import { formatDuration } from './runDetailsUtils';
+import { formatDuration, getScheduledFor } from './runDetailsUtils';
 
 type Props = {
   standalone: boolean;
@@ -45,6 +45,7 @@ type Run = {
     childrenSpans?: unknown[];
     endedAt: string | null;
     queuedAt: string;
+    scheduledAt?: string | null;
     startedAt: string | null;
     status: string;
     stepID?: string | null;
@@ -63,6 +64,9 @@ export const RunInfo = ({
 }: Props) => {
   const [expanded, setExpanded] = useState(true);
   const allowCancel = isLazyDone(run) && !Boolean(run.trace.endedAt);
+  const scheduledFor = isLazyDone(run)
+    ? getScheduledFor(run.trace.queuedAt, run.trace.scheduledAt)
+    : null;
   const { pathCreator } = usePathCreator();
 
   return (
@@ -180,6 +184,15 @@ export const RunInfo = ({
               return <TimeElement date={new Date(run.trace.queuedAt)} />;
             }}
           </OptimisticElementWrapper>
+
+          {scheduledFor && (
+            <ElementWrapper label="Scheduled at">
+              <TimeElement
+                date={scheduledFor}
+                tooltipDescription="Scheduled to run at, based on the triggering event."
+              />
+            </ElementWrapper>
+          )}
 
           <OptimisticElementWrapper
             label="Started at"

--- a/ui/packages/components/src/RunDetailsV4/runDetailsUtils.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/runDetailsUtils.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { getScheduledFor } from './runDetailsUtils';
+
+describe('getScheduledFor', () => {
+  const queuedAt = '2026-08-05T20:27:47.704Z';
+
+  it('returns the scheduled time when it is materially after queuedAt', () => {
+    // e.g. a triggering event sent with a future `ts`
+    const scheduledAt = '2026-08-05T20:37:47.458Z';
+
+    expect(getScheduledFor(queuedAt, scheduledAt)).toEqual(new Date(scheduledAt));
+  });
+
+  it('returns null for the scheduling fudge on immediate runs', () => {
+    // scheduledAt is pinned to be >= queuedAt, so immediate runs drift by a few ms
+    expect(getScheduledFor(queuedAt, '2026-08-05T20:27:47.705Z')).toBeNull();
+  });
+
+  it('returns null when scheduledAt equals queuedAt', () => {
+    expect(getScheduledFor(queuedAt, queuedAt)).toBeNull();
+  });
+
+  it('returns null when scheduledAt is before queuedAt', () => {
+    expect(getScheduledFor(queuedAt, '2026-08-05T20:27:40.000Z')).toBeNull();
+  });
+
+  it('returns null when scheduledAt is missing', () => {
+    expect(getScheduledFor(queuedAt, null)).toBeNull();
+    expect(getScheduledFor(queuedAt, undefined)).toBeNull();
+  });
+
+  it('returns null for unparseable timestamps', () => {
+    expect(getScheduledFor(queuedAt, 'not-a-date')).toBeNull();
+    expect(getScheduledFor('not-a-date', '2026-08-05T20:37:47.458Z')).toBeNull();
+  });
+});

--- a/ui/packages/components/src/RunDetailsV4/runDetailsUtils.ts
+++ b/ui/packages/components/src/RunDetailsV4/runDetailsUtils.ts
@@ -155,6 +155,37 @@ export const formatDuration = (ms: number): string => {
   return `${hours}h ${minutes}m`;
 };
 
+//
+// The executor pins a run's scheduledAt to be >= queuedAt, so the two differ
+// by a few milliseconds on every run. Only a materially later scheduledAt
+// (e.g. a triggering event with a future `ts`) means the run was deliberately
+// deferred.
+const SCHEDULED_FOR_THRESHOLD_MS = 1_000;
+
+//
+// Returns the time a run was deliberately scheduled to start in the future,
+// or null when the run was scheduled to start immediately.
+export const getScheduledFor = (
+  queuedAt: string,
+  scheduledAt: string | null | undefined
+): Date | null => {
+  if (!scheduledAt) {
+    return null;
+  }
+
+  const queued = new Date(queuedAt);
+  const scheduled = new Date(scheduledAt);
+  if (isNaN(queued.getTime()) || isNaN(scheduled.getTime())) {
+    return null;
+  }
+
+  if (scheduled.getTime() - queued.getTime() <= SCHEDULED_FOR_THRESHOLD_MS) {
+    return null;
+  }
+
+  return scheduled;
+};
+
 export const getSpanName = (name: string) => {
   return name === FINAL_SPAN_NAME ? FINAL_SPAN_DISPLAY : name;
 };

--- a/ui/packages/components/src/Time.tsx
+++ b/ui/packages/components/src/Time.tsx
@@ -16,11 +16,6 @@ type Props = {
   format?: 'relative';
   value: Date | string;
   copyable?: boolean;
-  /**
-   * Optional description shown in the tooltip alongside the UTC/local
-   * timestamps, e.g. to explain where the time comes from.
-   */
-  tooltipDescription?: string;
 };
 
 function formatDate(date: Date) {
@@ -31,7 +26,7 @@ function formatUTCDate(date: Date) {
   return formatInTimeZone(date, 'UTC', 'dd MMM yyyy, HH:mm:ss');
 }
 
-export function Time({ className, format, value, copyable = true, tooltipDescription }: Props) {
+export function Time({ className, format, value, copyable = true }: Props) {
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
     toast.success('Copied to clipboard');
@@ -86,11 +81,6 @@ export function Time({ className, format, value, copyable = true, tooltipDescrip
           </div>
           <time className="text-onContrast">{localTimeString}</time>
         </div>
-        {tooltipDescription && (
-          <div className="text-light mb-[6px] ml-3 mr-4 max-w-xs whitespace-normal text-sm">
-            {tooltipDescription}
-          </div>
-        )}
       </TooltipContent>
     </Tooltip>
   );

--- a/ui/packages/components/src/Time.tsx
+++ b/ui/packages/components/src/Time.tsx
@@ -16,6 +16,11 @@ type Props = {
   format?: 'relative';
   value: Date | string;
   copyable?: boolean;
+  /**
+   * Optional description shown in the tooltip alongside the UTC/local
+   * timestamps, e.g. to explain where the time comes from.
+   */
+  tooltipDescription?: string;
 };
 
 function formatDate(date: Date) {
@@ -26,7 +31,7 @@ function formatUTCDate(date: Date) {
   return formatInTimeZone(date, 'UTC', 'dd MMM yyyy, HH:mm:ss');
 }
 
-export function Time({ className, format, value, copyable = true }: Props) {
+export function Time({ className, format, value, copyable = true, tooltipDescription }: Props) {
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
     toast.success('Copied to clipboard');
@@ -81,6 +86,11 @@ export function Time({ className, format, value, copyable = true }: Props) {
           </div>
           <time className="text-onContrast">{localTimeString}</time>
         </div>
+        {tooltipDescription && (
+          <div className="text-light mb-[6px] ml-3 mr-4 max-w-xs whitespace-normal text-sm">
+            {tooltipDescription}
+          </div>
+        )}
       </TooltipContent>
     </Tooltip>
   );


### PR DESCRIPTION
## Description

- Users can schedule events in the future via the `ts` field on events
- I've responded to customer tickets asking why their runs are stuck queued. Sometimes, the answer is that they scheduled their run in the future
- For these scheduled runs, I'd like to make it clearer to the user why their run is queued and not running
- I display a `scheduled at` when scheduled at exists and is offset from it's queued (i.e in the future)
- I've added a (i) hover to provide some more detail. I'm not sold that it's useful enough to justify its own existence. Open to edits or removal!

After:
<img width="836" height="394" alt="Screenshot 2026-08-06 at 4 54 05 PM" src="https://github.com/user-attachments/assets/98c5d4fc-b6d6-4f3a-af44-aa0865787fc4" />




Before:
<img width="749" height="411" alt="Screenshot 2026-08-05 at 3 20 12 PM" src="https://github.com/user-attachments/assets/664cd60d-aa9b-4cc5-a407-0858dd8b0ab6" />

- I also validated this with crons, the other user of `ts` for scheduling

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
- Surface scheduled at in the dashboard's run's page iff the event is scheduled in the future

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
