### PR TITLE
chore(queue): remove system queue migrations

### DIFF
--- a/pkg/execution/deletion/delete.go
+++ b/pkg/execution/deletion/delete.go
@@ -100,7 +100,7 @@ func (d *deleteManager) DeleteQueueItem(ctx context.Context, shard queue.QueueSh
 	case queue.KindEdge, queue.KindEdgeError, queue.KindStart, queue.KindSleep:
 		break
 	// The following system queues do not have associated state we need to clean up
-	case queue.KindQueueMigrate, queue.KindCancel, queue.KindJobPromote, queue.KindPauseBlockFlush:
+	case queue.KindCancel, queue.KindJobPromote, queue.KindPauseBlockFlush:
 		break
 	default:
 		// If the queue item kind is unknown and we have a handler func, execute this to perform external cleanup operations.

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -282,9 +282,6 @@ func (s *svc) Run(ctx context.Context) error {
 			err = s.handleCron(ctx, item)
 		case queue.KindCronHealthCheck:
 			err = s.handleCronHealthCheck(ctx, item)
-		case queue.KindQueueMigrate:
-			// NOOP:
-			// this kind don't work in the Dev server
 		case queue.KindFunctionPause, queue.KindFunctionUnpause:
 			// NOOP:
 			// Function pausing and unpausing is not implemented in the dev server.

--- a/pkg/execution/queue/kind.go
+++ b/pkg/execution/queue/kind.go
@@ -9,8 +9,7 @@ const (
 	KindPause           = "pause"
 	KindDebounce        = "debounce"
 	KindScheduleBatch   = "schedule-batch"
-	KindEdgeError       = "edge-error" // KindEdgeError is used to indicate a final step error attempting a graceful save.
-	KindQueueMigrate    = "queue-migrate"
+	KindEdgeError       = "edge-error"        // KindEdgeError is used to indicate a final step error attempting a graceful save.
 	KindPauseBlockFlush = "pbf"               // Flushes pauses from the buffer to blocks.
 	KindJobPromote      = "jps"               // job promotion service
 	KindCancel          = "cancel"            // cancel signals eager cancellation of queue items

--- a/pkg/execution/queue/migrate.go
+++ b/pkg/execution/queue/migrate.go
@@ -2,103 +2,25 @@ package queue
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"sync/atomic"
 	"time"
-
-	"github.com/inngest/inngest/pkg/logger"
-	"github.com/inngest/inngest/pkg/telemetry/redis_telemetry"
-	"github.com/jonboulle/clockwork"
-	"github.com/redis/rueidis"
-	"golang.org/x/sync/errgroup"
 )
 
-type queueMigrator struct {
+type queueMigrationLocker struct {
 	shards QueueShardRegistry
-	clock  clockwork.Clock
 }
 
-func newQueueMigrator(shards QueueShardRegistry, clock clockwork.Clock) Migrator {
-	return &queueMigrator{
+func newQueueMigrationLocker(shards QueueShardRegistry) MigrationLocker {
+	return &queueMigrationLocker{
 		shards: shards,
-		clock:  clock,
 	}
 }
 
-func (m *queueMigrator) SetFunctionMigrate(ctx context.Context, sourceShard string, scope Scope, migrateLockUntil *time.Time) error {
+func (m *queueMigrationLocker) SetFunctionMigrate(ctx context.Context, sourceShard string, scope Scope, migrateLockUntil *time.Time) error {
 	shard, err := m.shards.ByName(sourceShard)
 	if err != nil {
 		return fmt.Errorf("could not find shard %q", sourceShard)
 	}
 
 	return shard.SetFunctionMigrate(ctx, scope, migrateLockUntil)
-}
-
-func (m *queueMigrator) Migrate(ctx context.Context, sourceShardName string, scope Scope, limit int64, concurrency int, handler QueueMigrationHandler) (int64, error) {
-	l := logger.StdlibLogger(ctx)
-	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "MigrationPeek"), redis_telemetry.ScopeQueue)
-
-	shard, err := m.shards.ByName(sourceShardName)
-	if err != nil {
-		return -1, fmt.Errorf("no queue shard available for '%s'", sourceShardName)
-	}
-
-	from := time.Time{}
-	// setting it to 5 years ahead should be enough to cover all queue items in the partition
-	until := m.clock.Now().Add(24 * time.Hour * 365 * 5)
-	items, err := shard.ItemsByPartition(ctx, scope, scope.FunctionID.String(), from, until,
-		WithQueueItemIterBatchSize(limit),
-	)
-	if err != nil {
-		// the partition doesn't exist, meaning there are no workloads
-		if errors.Is(err, rueidis.Nil) {
-			return 0, nil
-		}
-
-		return -1, fmt.Errorf("error preparing partition iteration: %w", err)
-	}
-
-	// Should process in order because we don't want out of order execution when moved over
-	var processed int64
-
-	process := func(qi *QueueItem) error {
-		if err := handler(ctx, qi); err != nil {
-			return err
-		}
-
-		if err := shard.Dequeue(ctx, *qi); err != nil {
-			l.ReportError(err, "error dequeueing queue item after migration")
-		}
-
-		atomic.AddInt64(&processed, 1)
-		return nil
-	}
-
-	if concurrency > 0 {
-		eg := errgroup.Group{}
-		eg.SetLimit(concurrency)
-
-		for qi := range items {
-			i := qi
-			eg.Go(func() error {
-				return process(i)
-			})
-		}
-
-		err := eg.Wait()
-		if err != nil {
-			return atomic.LoadInt64(&processed), err
-		}
-
-		return atomic.LoadInt64(&processed), nil
-	}
-
-	for qi := range items {
-		if err := process(qi); err != nil {
-			return processed, err
-		}
-	}
-
-	return atomic.LoadInt64(&processed), nil
 }

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -72,7 +72,7 @@ func New(
 		),
 		Consumer:        NewConsumer(shards),
 		JobQueueReader:  newJobQueueReader(shards, o.AccountShardIterationEnabled),
-		Migrator:        newQueueMigrator(shards, o.Clock),
+		MigrationLocker: newQueueMigrationLocker(shards),
 		Unpauser:        newQueueUnpauser(shards),
 		AttemptResetter: newAttemptResetter(shards),
 
@@ -110,7 +110,7 @@ type queueProcessor struct {
 	Producer
 	Consumer
 	JobQueueReader
-	Migrator
+	MigrationLocker
 	Unpauser
 	AttemptResetter
 

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -7,7 +7,6 @@ import (
 	"iter"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -16,7 +15,7 @@ type Queue interface {
 	Consumer
 
 	JobQueueReader
-	Migrator
+	MigrationLocker
 	Unpauser
 	AttemptResetter
 	RoleStatusReader
@@ -125,15 +124,10 @@ type RoleStatusReader interface {
 	ActiveRoles() []QueueRoleStatus
 }
 
-type QueueMigrationHandler func(ctx context.Context, qi *QueueItem) error
-
-type Migrator interface {
+type MigrationLocker interface {
 	// SetFunctionMigrate updates the function metadata to signal it's being migrated to
 	// another queue shard
 	SetFunctionMigrate(ctx context.Context, sourceShard string, scope Scope, migrateLockUntil *time.Time) error
-	// Migration does a peek operation like the normal peek, but ignores leases and other conditions a normal peek cares about.
-	// The sore goal is to grab things and migrate them to somewhere else
-	Migrate(ctx context.Context, shard string, scope Scope, limit int64, concurrency int, handler QueueMigrationHandler) (int64, error)
 }
 
 type Unpauser interface {
@@ -314,31 +308,4 @@ type JobQueueReader interface {
 	// NOTE
 	// The queue technically shouldn't know about runIDs, so we should make this more generic with certain type of indices in the future
 	ItemsByRunID(ctx context.Context, queueShard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error)
-}
-
-// MigratePayload stores the information to be used when migrating a queue shard to another one
-type MigratePayload struct {
-	AccountID  uuid.UUID
-	EnvID      uuid.UUID
-	FunctionID uuid.UUID
-
-	// Source is the source queue where the migration will occur on
-	Source string
-	// Dest is the target destination the queue will be moved to
-	Dest string
-
-	// DisableFnPause is a flag to disable the function pausing during migration
-	// if it's considered okay to do so
-	DisableFnPause bool
-
-	// Concurrency optionally specifies the concurrency for running the migrate handler over each batch of queue items.
-	Concurrency int
-}
-
-func (p MigratePayload) Scope() Scope {
-	return Scope{
-		AccountID:  p.AccountID,
-		EnvID:      p.EnvID,
-		FunctionID: p.FunctionID,
-	}
 }

--- a/pkg/execution/queue/queue_test.go
+++ b/pkg/execution/queue/queue_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,19 +96,4 @@ func TestAsRetryAt(t *testing.T) {
 	require.NotNil(t, AsRetryAtError(base))
 	require.NotNil(t, AsRetryAtError(wrapped))
 	require.Nil(t, AsRetryAtError(fmt.Errorf("no")))
-}
-
-func TestMigratePayloadScope(t *testing.T) {
-	payload := MigratePayload{
-		AccountID:  uuid.New(),
-		EnvID:      uuid.New(),
-		FunctionID: uuid.New(),
-	}
-
-	require.Equal(t, Scope{
-		AccountID:  payload.AccountID,
-		EnvID:      payload.EnvID,
-		FunctionID: payload.FunctionID,
-	}, payload.Scope())
-	require.NoError(t, payload.Scope().Validate())
 }

--- a/pkg/execution/state/redis_state/backlog_test.go
+++ b/pkg/execution/state/redis_state/backlog_test.go
@@ -105,7 +105,7 @@ func TestQueueItemBacklogs(t *testing.T) {
 	})
 
 	t.Run("system queue", func(t *testing.T) {
-		sysQueueName := osqueue.KindQueueMigrate
+		sysQueueName := osqueue.KindCancel
 
 		expected := osqueue.QueueBacklog{
 			// expect default backlog to be used
@@ -693,7 +693,7 @@ func TestQueueItemShadowPartition(t *testing.T) {
 	})
 
 	t.Run("system queue", func(t *testing.T) {
-		sysQueueName := osqueue.KindQueueMigrate
+		sysQueueName := osqueue.KindCancel
 
 		expected := osqueue.QueueShadowPartition{
 			PartitionID:     sysQueueName,
@@ -706,7 +706,7 @@ func TestQueueItemShadowPartition(t *testing.T) {
 		shadowPart := osqueue.ItemShadowPartition(ctx, osqueue.QueueItem{
 			ID: "test",
 			Data: osqueue.Item{
-				Kind:                  osqueue.KindQueueMigrate,
+				Kind:                  osqueue.KindCancel,
 				Identifier:            state.Identifier{},
 				Throttle:              nil,
 				CustomConcurrencyKeys: nil,

--- a/pkg/execution/state/redis_state/queue_bench_test.go
+++ b/pkg/execution/state/redis_state/queue_bench_test.go
@@ -39,7 +39,7 @@ func BenchmarkKeyQueues(b *testing.B) {
 		osqueue.WithKindToQueueMapping(map[string]string{
 			osqueue.KindPause:           osqueue.KindPause,
 			osqueue.KindDebounce:        osqueue.KindDebounce,
-			osqueue.KindQueueMigrate:    osqueue.KindQueueMigrate,
+			osqueue.KindCancel:          osqueue.KindCancel,
 			osqueue.KindPauseBlockFlush: osqueue.KindPauseBlockFlush,
 			osqueue.KindScheduleBatch:   osqueue.KindScheduleBatch,
 		}),

--- a/pkg/execution/state/redis_state/queue_lease_test.go
+++ b/pkg/execution/state/redis_state/queue_lease_test.go
@@ -1422,7 +1422,7 @@ func TestQueueLeaseWithoutValidation(t *testing.T) {
 		t.Run("should lease item", func(t *testing.T) {
 			require.Len(t, r.Keys(), 0)
 
-			sysQueueName := osqueue.KindQueueMigrate
+			sysQueueName := osqueue.KindCancel
 
 			item1 := osqueue.QueueItem{
 				ID: "test",

--- a/pkg/execution/state/redis_state/queue_requeue_test.go
+++ b/pkg/execution/state/redis_state/queue_requeue_test.go
@@ -705,7 +705,7 @@ func TestQueueRequeueToBacklog(t *testing.T) {
 		// use future timestamp because scores will be bounded to the present
 		at := now.Add(10 * time.Minute)
 
-		sysQueueName := osqueue.KindQueueMigrate
+		sysQueueName := osqueue.KindCancel
 
 		t.Run("should requeue item to backlog", func(t *testing.T) {
 			require.Len(t, r.Keys(), 0)

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -126,7 +126,7 @@ func TestQueueItemScore(t *testing.T) {
 	kinds = []string{
 		osqueue.KindDebounce,
 		osqueue.KindScheduleBatch,
-		osqueue.KindQueueMigrate,
+		osqueue.KindCancel,
 		osqueue.KindPauseBlockFlush,
 		osqueue.KindJobPromote,
 	}
@@ -2158,149 +2158,6 @@ func TestQueueRoleLeaseSequential(t *testing.T) {
 	})
 }
 
-func TestMigrate(t *testing.T) {
-	ctx := context.Background()
-
-	testcases := []struct {
-		name     string
-		keyQueue bool
-	}{
-		{
-			name: "without key queues",
-		},
-		{
-			name:     "with key queues",
-			keyQueue: true,
-		},
-	}
-
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			clock := clockwork.NewFakeClock()
-
-			// default redis
-			r1 := miniredis.RunT(t)
-			rc1, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: []string{r1.Addr()}, DisableCache: true})
-			require.NoError(t, err)
-			defer rc1.Close()
-
-			// other redis
-			r2 := miniredis.RunT(t)
-			rc2, err := rueidis.NewClient(rueidis.ClientOption{InitAddress: []string{r2.Addr()}, DisableCache: true})
-			require.NoError(t, err)
-			defer rc2.Close()
-
-			idempotencyTTL := 5 * time.Second
-			opts := []osqueue.QueueOpt{
-				osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
-					return tc.keyQueue
-				}),
-				osqueue.WithIdempotencyTTL(idempotencyTTL),
-			}
-
-			shard1 := shardFromClient("default", rc1, opts...)
-			shard2 := shardFromClient("yolo", rc2, opts...)
-
-			shards := mapFromShards(shard1, shard2)
-
-			registry1, err := osqueue.NewShardRegistry(shards, osqueue.WithShardSelector(alwaysSelectShard(shard1)), osqueue.WithPrimary(shard1))
-			require.NoError(t, err)
-			q1, err := osqueue.New(
-				context.Background(),
-				"q1",
-				registry1,
-				opts...,
-			)
-			require.NoError(t, err)
-
-			require.Equal(t, idempotencyTTL, q1.QueueOptions.IdempotencyTTL)
-
-			registry2, err := osqueue.NewShardRegistry(shards, osqueue.WithShardSelector(alwaysSelectShard(shard2)), osqueue.WithPrimary(shard2))
-			require.NoError(t, err)
-			q2, err := osqueue.New(
-				context.Background(),
-				"q2",
-				registry2,
-				opts...,
-			)
-			require.NoError(t, err)
-
-			acctID := uuid.New()
-			envID := uuid.New()
-			fnID := uuid.New()
-			scope := osqueue.Scope{
-				AccountID:  acctID,
-				EnvID:      envID,
-				FunctionID: fnID,
-			}
-
-			expectItemCountForPartition := func(ctx context.Context, shard RedisQueueShard, partitionID uuid.UUID, expected int) {
-				var count int
-
-				from := time.Time{}
-				until := clock.Now().Add(24 * time.Hour * 365)
-				items, err := shard.ItemsByPartition(ctx, scope, partitionID.String(), from, until)
-				require.NoError(t, err)
-
-				for range items {
-					count++
-				}
-				require.Equal(t, expected, count)
-			}
-
-			// Enqueue to shard 1
-			for range 5 {
-				id := state.Identifier{AccountID: acctID, WorkspaceID: envID, WorkflowID: fnID, EventID: ulid.MustNew(ulid.Now(), rand.Reader), RunID: ulid.MustNew(ulid.Now(), rand.Reader)}
-				err := q1.Enqueue(ctx, osqueue.Item{Identifier: id}, clock.Now(), osqueue.EnqueueOpts{})
-				require.NoError(t, err)
-			}
-
-			items, err := r1.HKeys(shard1.Client().kg.QueueItem())
-			require.NoError(t, err)
-
-			// Don't really need it since there are no executors to process the enqueued items
-			lockUntil := clock.Now().Add(10 * time.Minute)
-			err = q1.SetFunctionMigrate(ctx, shard1.Name(), scope, &lockUntil)
-			require.NoError(t, err)
-
-			// Verify that there are expected number of items in it
-			expectItemCountForPartition(ctx, shard1, fnID, 5)
-
-			// Attempt to migrate from shard1 to shard2
-			processed, err := q1.Migrate(ctx, shard1.Name(), scope, 10, 0, func(ctx context.Context, qi *osqueue.QueueItem) error {
-				return q2.Enqueue(ctx, qi.Data, time.UnixMilli(qi.AtMS), osqueue.EnqueueOpts{PassthroughJobId: true})
-			})
-			require.NoError(t, err)
-			require.Equal(t, int64(5), processed)
-
-			// Verify that shard2 now have all the items
-			expectItemCountForPartition(ctx, shard2, fnID, 5)
-
-			// shard1 should no longer have anything
-			expectItemCountForPartition(ctx, shard1, fnID, 0)
-
-			clock.Advance(idempotencyTTL + 5*time.Second)
-			r1.FastForward(idempotencyTTL + 5*time.Second)
-
-			remainingTTL := r1.TTL(shard1.Client().kg.Idempotency(items[0]))
-			require.Equal(t, time.Duration(0), remainingTTL, remainingTTL.String())
-
-			// Now, move everything back to queue 1
-			returned, err := q2.Migrate(ctx, shard2.Name(), scope, 10, 0, func(ctx context.Context, qi *osqueue.QueueItem) error {
-				return q1.Enqueue(ctx, qi.Data, time.UnixMilli(qi.AtMS), osqueue.EnqueueOpts{PassthroughJobId: true})
-			})
-			require.NoError(t, err, "r1", r1.Dump())
-			require.Equal(t, int64(5), returned)
-
-			// shard1 should have the queue items again
-			expectItemCountForPartition(ctx, shard1, fnID, 5)
-
-			// Verify that shard2 now have nothing
-			expectItemCountForPartition(ctx, shard2, fnID, 0)
-		})
-	}
-}
-
 func getQueueItem(t *testing.T, r *miniredis.Miniredis, id string) osqueue.QueueItem {
 	t.Helper()
 	kg := &queueKeyGenerator{
@@ -3012,7 +2869,7 @@ func TestQueueEnqueueToBacklog(t *testing.T) {
 		// use future timestamp because scores will be bounded to the present
 		at := now.Add(10 * time.Minute)
 
-		sysQueueName := osqueue.KindQueueMigrate
+		sysQueueName := osqueue.KindCancel
 
 		t.Run("should enqueue item to backlog", func(t *testing.T) {
 			require.Len(t, r.Keys(), 0)
@@ -3020,7 +2877,7 @@ func TestQueueEnqueueToBacklog(t *testing.T) {
 			item := osqueue.QueueItem{
 				ID: "test",
 				Data: osqueue.Item{
-					Kind:                  osqueue.KindQueueMigrate,
+					Kind:                  osqueue.KindCancel,
 					Identifier:            state.Identifier{},
 					QueueName:             &sysQueueName,
 					Throttle:              nil,

--- a/tests/execution/queue/system_queue_test.go
+++ b/tests/execution/queue/system_queue_test.go
@@ -27,7 +27,7 @@ func TestSystemQueueConfigs(t *testing.T) {
 		queue.KindScheduleBatch: queue.KindScheduleBatch,
 		"pause-event":           "pause-event",
 		queue.KindDebounce:      queue.KindDebounce,
-		queue.KindQueueMigrate:  queue.KindQueueMigrate,
+		queue.KindCancel:        queue.KindCancel,
 	}
 
 	r := miniredis.RunT(t)


### PR DESCRIPTION
## Description

Remove the remaining OSS surface for the retired `queue-migrate` system queue path:

- remove `KindQueueMigrate` and its dev-server/deletion classifications
- remove the legacy `MigratePayload`, bulk `Migrate` API, and implementation
- narrow the queue's migration interface to the still-active migration-lock operation
- replace migration-kind test fixtures with an active system queue kind

Queue migration item movement now lives in the cloud migration implementation. Migration locking remains in OSS because queue processing still uses it to prevent work from starting during an active migration.

This follows the cloud cleanup in inngest/monorepo#8172. That PR now uses a private migration payload and no longer depends on the removed OSS type.

## Release note

None

## Migration note

None

## Validation

- `go test -count=1 ./pkg/execution/queue ./pkg/execution/state/redis_state ./pkg/execution/executor ./pkg/execution/deletion ./tests/execution/queue`
- `git diff --check`
