### PR TITLE
feat(queue): let custom scanners declare roles

### DIFF
--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -910,30 +911,28 @@ func (q *queueProcessor) configureQueueRoles() {
 	q.roles = filterQueueRoles(q.QueueOptions, q.roles)
 }
 
-// configureScannerRoles replaces processor defaults with roles declared by a
-// custom scanner. Registration happens after shard selection and before role
-// goroutines start, which also supports dynamically assigned shard groups.
-func (q *queueProcessor) configureScannerRoles(scanner QueueScanner) {
+// configureScannerRoles appends roles declared by the selected scanner.
+// Registration happens after shard selection and before role goroutines start,
+// which also supports dynamically assigned shard groups.
+func (q *queueProcessor) configureScannerRoles(scanner QueueScanner) error {
 	provider, ok := scanner.(QueueScannerRoleProvider)
 	if !ok {
-		return
+		return nil
 	}
 	provided := filterQueueRoles(q.QueueOptions, provider.QueueScannerRoles())
-	if len(provided) == 0 {
-		return
-	}
-
-	replaced := make(map[string]struct{}, len(provided))
-	for _, role := range provided {
-		replaced[role.Name()] = struct{}{}
-	}
-	roles := make([]QueueRole, 0, len(q.roles)+len(provided))
+	existing := make(map[string]struct{}, len(q.roles)+len(provided))
 	for _, role := range q.roles {
-		if _, ok := replaced[role.Name()]; !ok {
-			roles = append(roles, role)
-		}
+		existing[role.Name()] = struct{}{}
 	}
-	q.roles = append(roles, provided...)
+	for _, role := range provided {
+		name := role.Name()
+		if _, ok := existing[name]; ok {
+			return fmt.Errorf("queue scanner role %q is already configured", name)
+		}
+		existing[name] = struct{}{}
+	}
+	q.roles = append(q.roles, provided...)
+	return nil
 }
 
 func (q *queueProcessor) defaultQueueRoles() []QueueRole {

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -938,9 +938,6 @@ func (q *queueProcessor) configureScannerRoles(scanner QueueScanner) {
 
 func (q *queueProcessor) defaultQueueRoles() []QueueRole {
 	roles := []QueueRole{}
-	if includeSequentialRole(q.QueueOptions) {
-		roles = append(roles, NewSequentialRole())
-	}
 	if q.runMode.Scavenger {
 		roles = append(roles, NewScavengerRole())
 	}

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -910,6 +910,32 @@ func (q *queueProcessor) configureQueueRoles() {
 	q.roles = filterQueueRoles(q.QueueOptions, q.roles)
 }
 
+// configureScannerRoles replaces processor defaults with roles declared by a
+// custom scanner. Registration happens after shard selection and before role
+// goroutines start, which also supports dynamically assigned shard groups.
+func (q *queueProcessor) configureScannerRoles(scanner QueueScanner) {
+	provider, ok := scanner.(QueueScannerRoleProvider)
+	if !ok {
+		return
+	}
+	provided := filterQueueRoles(q.QueueOptions, provider.QueueScannerRoles())
+	if len(provided) == 0 {
+		return
+	}
+
+	replaced := make(map[string]struct{}, len(provided))
+	for _, role := range provided {
+		replaced[role.Name()] = struct{}{}
+	}
+	roles := make([]QueueRole, 0, len(q.roles)+len(provided))
+	for _, role := range q.roles {
+		if _, ok := replaced[role.Name()]; !ok {
+			roles = append(roles, role)
+		}
+	}
+	q.roles = append(roles, provided...)
+}
+
 func (q *queueProcessor) defaultQueueRoles() []QueueRole {
 	roles := []QueueRole{}
 	if includeSequentialRole(q.QueueOptions) {

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -231,15 +231,15 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 		l.Info("Executor started in assignedQueueShard Mode", "queue_shard", q.Shard().Name())
 	}
 
-	for _, role := range q.roles {
-		go q.runRole(ctx, role)
-	}
-
 	scanner := QueueScanner(partitionQueueScanner{q: q})
 	if shard := q.Shard(); shard != nil {
 		if shardScanner, ok := shard.(QueueScanner); ok {
 			scanner = shardScanner
 		}
+	}
+	q.configureScannerRoles(scanner)
+	for _, role := range q.roles {
+		go q.runRole(ctx, role)
 	}
 
 	dispatch := func(ctx context.Context, item ProcessItem) (DispatchedItem, error) {
@@ -258,7 +258,7 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 		Leaser:          q,
 		Dispatch:        dispatch,
 		WorkerSemaphore: q.Semaphore(),
-		IsSequential:    q.isSequential,
+		IsRoleActive:    q.isRoleActive,
 	}
 	if rt.Leaser == nil {
 		return ErrQueueScannerMissingLeaser

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -237,7 +237,9 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 			scanner = shardScanner
 		}
 	}
-	q.configureScannerRoles(scanner)
+	if err := q.configureScannerRoles(scanner); err != nil {
+		return err
+	}
 	for _, role := range q.roles {
 		go q.runRole(ctx, role)
 	}

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -258,6 +258,7 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 		Leaser:          q,
 		Dispatch:        dispatch,
 		WorkerSemaphore: q.Semaphore(),
+		IsSequential:    q.isSequential,
 	}
 	if rt.Leaser == nil {
 		return ErrQueueScannerMissingLeaser

--- a/pkg/execution/queue/role_test.go
+++ b/pkg/execution/queue/role_test.go
@@ -79,29 +79,29 @@ func TestWithQueueRoles(t *testing.T) {
 	})
 }
 
-func TestConfigureScannerRolesReplacesDefaultByName(t *testing.T) {
+func TestConfigureScannerRolesAppendsUniqueRoles(t *testing.T) {
 	opts := NewQueueOptions()
 	qp := &queueProcessor{QueueOptions: opts}
 	qp.configureQueueRoles()
 
-	customSequential := NewSequentialRole(WithRoleRunInterval(time.Second))
-	qp.configureScannerRoles(roleProvidingScanner{roles: []QueueRole{customSequential}})
+	require.NoError(t, qp.configureScannerRoles(roleProvidingScanner{roles: []QueueRole{NewSequentialRole()}}))
+	require.Contains(t, roleNames(qp.roles), QueueRoleSequential)
+}
 
-	sequential := []QueueRole{}
-	for _, role := range qp.roles {
-		if role.Name() == QueueRoleSequential {
-			sequential = append(sequential, role)
-		}
-	}
-	require.Len(t, sequential, 1)
-	require.Equal(t, time.Second, sequential[0].RunInterval())
+func TestConfigureScannerRolesRejectsDuplicateNames(t *testing.T) {
+	opts := NewQueueOptions(WithQueueRoles(NewSequentialRole()))
+	qp := &queueProcessor{QueueOptions: opts}
+	qp.configureQueueRoles()
+
+	err := qp.configureScannerRoles(roleProvidingScanner{roles: []QueueRole{NewSequentialRole()}})
+	require.EqualError(t, err, `queue scanner role "sequential" is already configured`)
 }
 
 func TestConfigureScannerRolesHonorsSequentialFilter(t *testing.T) {
 	opts := NewQueueOptions(WithAllowQueueNames("critical"))
 	qp := &queueProcessor{QueueOptions: opts}
 	qp.configureQueueRoles()
-	qp.configureScannerRoles(roleProvidingScanner{roles: []QueueRole{NewSequentialRole()}})
+	require.NoError(t, qp.configureScannerRoles(roleProvidingScanner{roles: []QueueRole{NewSequentialRole()}}))
 	require.NotContains(t, roleNames(qp.roles), QueueRoleSequential)
 }
 
@@ -117,7 +117,9 @@ func configuredRoleOptions(options ...QueueOpt) *QueueOptions {
 	opts := NewQueueOptions(options...)
 	qp := &queueProcessor{QueueOptions: opts}
 	qp.configureQueueRoles()
-	qp.configureScannerRoles(partitionQueueScanner{q: qp})
+	if err := qp.configureScannerRoles(partitionQueueScanner{q: qp}); err != nil {
+		panic(err)
+	}
 	return opts
 }
 

--- a/pkg/execution/queue/role_test.go
+++ b/pkg/execution/queue/role_test.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"context"
 	"crypto/rand"
 	"sync"
 	"testing"
@@ -9,6 +10,13 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 )
+
+type roleProvidingScanner struct {
+	roles []QueueRole
+}
+
+func (roleProvidingScanner) Run(context.Context, QueueScannerRuntime) error { return nil }
+func (s roleProvidingScanner) QueueScannerRoles() []QueueRole               { return s.roles }
 
 func TestWithQueueRoles(t *testing.T) {
 	t.Run("appends custom roles to defaults", func(t *testing.T) {
@@ -69,6 +77,32 @@ func TestWithQueueRoles(t *testing.T) {
 		require.Contains(t, names, QueueRoleInstrumentation)
 		require.Contains(t, names, "custom")
 	})
+}
+
+func TestConfigureScannerRolesReplacesDefaultByName(t *testing.T) {
+	opts := NewQueueOptions()
+	qp := &queueProcessor{QueueOptions: opts}
+	qp.configureQueueRoles()
+
+	customSequential := NewSequentialRole(WithRoleRunInterval(time.Second))
+	qp.configureScannerRoles(roleProvidingScanner{roles: []QueueRole{customSequential}})
+
+	sequential := []QueueRole{}
+	for _, role := range qp.roles {
+		if role.Name() == QueueRoleSequential {
+			sequential = append(sequential, role)
+		}
+	}
+	require.Len(t, sequential, 1)
+	require.Equal(t, time.Second, sequential[0].RunInterval())
+}
+
+func TestConfigureScannerRolesHonorsSequentialFilter(t *testing.T) {
+	opts := NewQueueOptions(WithAllowQueueNames("critical"))
+	qp := &queueProcessor{QueueOptions: opts}
+	qp.configureQueueRoles()
+	qp.configureScannerRoles(roleProvidingScanner{roles: []QueueRole{NewSequentialRole()}})
+	require.NotContains(t, roleNames(qp.roles), QueueRoleSequential)
 }
 
 func roleNames(roles []QueueRole) map[string]struct{} {

--- a/pkg/execution/queue/role_test.go
+++ b/pkg/execution/queue/role_test.go
@@ -117,6 +117,7 @@ func configuredRoleOptions(options ...QueueOpt) *QueueOptions {
 	opts := NewQueueOptions(options...)
 	qp := &queueProcessor{QueueOptions: opts}
 	qp.configureQueueRoles()
+	qp.configureScannerRoles(partitionQueueScanner{q: qp})
 	return opts
 }
 

--- a/pkg/execution/queue/scanner.go
+++ b/pkg/execution/queue/scanner.go
@@ -34,6 +34,10 @@ type partitionQueueScanner struct {
 	q *queueProcessor
 }
 
+func (partitionQueueScanner) QueueScannerRoles() []QueueRole {
+	return []QueueRole{NewSequentialRole()}
+}
+
 func (s partitionQueueScanner) Run(ctx context.Context, rt QueueScannerRuntime) error {
 	q := s.q
 

--- a/pkg/execution/queue/scanner.go
+++ b/pkg/execution/queue/scanner.go
@@ -11,16 +11,23 @@ type QueueScannerRuntime struct {
 	Leaser          QueueItemLeaser
 	Dispatch        DispatchFunc
 	WorkerSemaphore util.TrackingSemaphore
-	// IsSequential reports whether this processor currently owns the sequential
-	// scanner role. Custom scanners should evaluate it for each scan pass because
-	// role ownership can change while Run is active.
-	IsSequential func() bool
+	// IsRoleActive reports whether this processor currently owns a scanner role.
+	// Custom scanners should evaluate it for each scan pass because ownership can
+	// change while Run is active.
+	IsRoleActive func(name string) bool
 }
 
 // QueueScanner discovers and leases queue work. It should hand leased items to
 // the dispatch function and leave item execution to the common queue processor layer.
 type QueueScanner interface {
 	Run(ctx context.Context, rt QueueScannerRuntime) error
+}
+
+// QueueScannerRoleProvider allows a custom scanner to declare leased roles it
+// needs. The queue processor owns acquisition and renewal of these roles and
+// exposes their current state through QueueScannerRuntime.IsRoleActive.
+type QueueScannerRoleProvider interface {
+	QueueScannerRoles() []QueueRole
 }
 
 type partitionQueueScanner struct {

--- a/pkg/execution/queue/scanner.go
+++ b/pkg/execution/queue/scanner.go
@@ -11,6 +11,10 @@ type QueueScannerRuntime struct {
 	Leaser          QueueItemLeaser
 	Dispatch        DispatchFunc
 	WorkerSemaphore util.TrackingSemaphore
+	// IsSequential reports whether this processor currently owns the sequential
+	// scanner role. Custom scanners should evaluate it for each scan pass because
+	// role ownership can change while Run is active.
+	IsSequential func() bool
 }
 
 // QueueScanner discovers and leases queue work. It should hand leased items to


### PR DESCRIPTION
## Description

Allow queue scanners to declare leased roles through `QueueScannerRoleProvider`. The queue processor registers those roles after shard selection and continues to own acquisition, renewal, metrics, and active-role reporting. Duplicate names between configured and scanner-declared roles fail startup rather than silently choosing an owner. The built-in partition scanner now declares the sequential role instead of receiving it as a processor default.

`QueueScannerRuntime.IsRoleActive` gives scanners a dynamic ownership check for each scan pass. This avoids treating static run-mode eligibility as active ownership and supports future scanner-specific roles without adding dedicated runtime flags.

## Release note

None

## Migration note

None

## Validation

- `go test -count=1 ./pkg/execution/queue`
