### PR TITLE
fix(queue): preserve sentinel shard selection errors

### DIFF
--- a/pkg/execution/queue/shard.go
+++ b/pkg/execution/queue/shard.go
@@ -36,7 +36,7 @@ func (q *queueProducer) selectShard(ctx context.Context, shardName string, qi Qu
 	if shardName != "" {
 		shard, err := q.shards.ByName(shardName)
 		if err != nil {
-			return nil, fmt.Errorf("tried to force invalid queue shard %q", shardName)
+			return nil, fmt.Errorf("tried to force queue shard %q: %w", shardName, err)
 		}
 		return shard, nil
 	}

--- a/pkg/execution/queue/shard_test.go
+++ b/pkg/execution/queue/shard_test.go
@@ -1,0 +1,48 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueProducerSelectShardPreservesCanonicalErrors(t *testing.T) {
+	resolveErr := errors.New("resolve shard")
+
+	tests := []struct {
+		name      string
+		shardName string
+		selector  shardSelector
+		expected  error
+	}{
+		{
+			name:      "forced shard not found",
+			shardName: "missing",
+			selector:  alwaysShard(nil),
+			expected:  ErrQueueShardNotFound,
+		},
+		{
+			name: "selector error",
+			selector: func(context.Context, Scope, *string) (QueueShard, error) {
+				return nil, resolveErr
+			},
+			expected: resolveErr,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := mustShardRegistry(t,
+				map[string]QueueShard{"available": newTestShard("available", "")},
+				WithShardSelector(test.selector),
+			)
+			producer := &queueProducer{shards: registry}
+
+			_, err := producer.selectShard(context.Background(), test.shardName, QueueItem{})
+
+			require.ErrorIs(t, err, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Preserve sentinel shard-registry errosr when a producer is forced to enqueue to an unknown queue shard. Previously, `queueProducer.selectShard` replaced the `ErrQueueShardNotFound` sentinel with a newly formatted error, preventing callers such as queue-proxy from recognizing and classifying the failure.

## Release note

None

## Migration note

None

## Checks

- `go test -count=1 ./pkg/execution/queue`
- `git diff --check`
