### PR TITLE
fix: 64 bit linux download link for install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -245,7 +245,7 @@ uname_os() {
 uname_arch() {
   arch=$(uname -m)
   case $arch in
-    x86_64) arch="x86_64" ;;
+    x86_64) arch="amd64" ;;
     x86) arch="386" ;;
     i686) arch="386" ;;
     i386) arch="386" ;;


### PR DESCRIPTION
## Description

install.sh from docs references x86_64 instead of amd64 for linux 64 bit download links:
```
curl -sSfL https://cli.inngest.com/install.sh | sh
inngestcl: info checking GitHub for latest version
inngestcl: debug http https://api.github.com/repos/inngest/inngest/releases/latest
inngestcl: debug downloading files into /tmp/tmp.sRml2xNRcn
inngestcl: debug http https://github.com/inngest/inngest/releases/download/v1.41.1/inngest_1.41.1_linux_x86_64.tar.gz
curl: (22) The requested URL returned error: 404
```

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
