### PR TITLE
feat(scores): Hide scores page behind feature flag

### DIFF
--- a/ui/apps/dashboard/src/components/NavigationV2/Navigation.tsx
+++ b/ui/apps/dashboard/src/components/NavigationV2/Navigation.tsx
@@ -27,11 +27,15 @@ export const getNavRoute = (activeEnv: EnvType, link: string) =>
 
 export default function Navigation({ collapsed, activeEnv }: NavProps) {
   const isAIOverviewEnabled = useBooleanFlag('ai-overview-dashboard', false);
+  const isLegacyScoresPageEnabled = useBooleanFlag(
+    'legacy-scores-page-enabled',
+    false,
+  );
 
   const aiItems: NavItemConfig[] = [
     ...(isAIOverviewEnabled.value ? [aiOverviewItem] : []),
     experimentsItem,
-    scoresItem,
+    ...(isLegacyScoresPageEnabled.value ? [scoresItem] : []),
     sessionsItem,
     sandboxesItem,
   ];


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This puts the scores page behind the (false by default) flag `legacy-scores-page-enabled`

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
