### PR TITLE
feat(ai-overview): Cost display improvements/caveats

### DIFF
--- a/ui/apps/dashboard/src/components/AIOverview/Dashboard.tsx
+++ b/ui/apps/dashboard/src/components/AIOverview/Dashboard.tsx
@@ -27,8 +27,10 @@ import { CHART_COLORS } from '../InsightsMetrics/colors';
 import { Section, SectionGroupHeading } from '../InsightsMetrics/Section';
 import { AIOverviewEmptyState } from './EmptyState';
 import {
+  COST_TOOLTIP,
   formatCost,
   formatCostAxis,
+  formatCostAxisBar,
   formatMs,
   formatSeconds,
   formatSecondsAxis,
@@ -63,7 +65,7 @@ const DEFAULT_DURATION = { days: 7 };
 
 const formatRuns = (value: number) => `${formatCompactNumber(value)} runs`;
 
-// Shared by "Cost over time" and "Cost by model" — both plot ai_token_trend/
+// Shared by "Estimated cost over time" and "Estimated cost by model" — both plot ai_token_trend/
 // ai_model_distribution's `cost` column, which carries input/output tokens
 // alongside it in the same row (see InsightsMetrics/queries.ts), so the
 // tooltip can show token counts without adding a visual series for them.
@@ -440,14 +442,19 @@ export const AIOverviewDashboard = ({ envSlug }: { envSlug: string }) => {
 
         <SectionGroupHeading>Cost</SectionGroupHeading>
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <Section title="Cost over time" query={tokenTrend.data?.query} queryName="AI cost over time">
+          <Section
+            title="Estimated cost over time"
+            tooltip={COST_TOOLTIP}
+            query={tokenTrend.data?.query}
+            queryName="AI cost over time"
+          >
             <TrendChart
               points={toTrendPoints(tokenTrend.data)}
               isLoading={tokenTrend.fetching && !tokenTrend.data}
               hasData={hasAnyCalls}
               chartType="bar"
               format={formatCost}
-              axisFormat={formatCostAxis}
+              axisFormat={formatCostAxisBar}
               allowDecimals
               series={[
                 {
@@ -461,7 +468,8 @@ export const AIOverviewDashboard = ({ envSlug }: { envSlug: string }) => {
             />
           </Section>
           <Section
-            title="Cost per run over time"
+            title="Estimated cost per run over time"
+            tooltip={COST_TOOLTIP}
             query={costPerRunTrend.data?.query}
             queryName="AI cost per run over time"
           >
@@ -476,13 +484,19 @@ export const AIOverviewDashboard = ({ envSlug }: { envSlug: string }) => {
               defaultValue={0}
             />
           </Section>
-          <Section title="Cost by model" query={modelDistribution.data?.query} queryName="AI cost by model">
+          <Section
+            title="Estimated cost by model"
+            tooltip={COST_TOOLTIP}
+            query={modelDistribution.data?.query}
+            queryName="AI cost by model"
+          >
             <CategoricalChart
               items={toListItems(modelDistribution.data)}
               isLoading={modelDistribution.fetching && !modelDistribution.data}
               valueName="cost"
               colors={CHART_COLORS}
               format={formatCost}
+              valueLabelFormat={formatCostAxisBar}
               tooltipExtras={TOKEN_TOOLTIP_EXTRAS}
               showYAxisLine={false}
               showTooltipValueName={false}
@@ -490,7 +504,8 @@ export const AIOverviewDashboard = ({ envSlug }: { envSlug: string }) => {
             />
           </Section>
           <Section
-            title="Cost by function"
+            title="Estimated cost by function"
+            tooltip={COST_TOOLTIP}
             query={topFunctionsByCost.data?.query}
             queryName="AI cost by function"
           >
@@ -500,6 +515,7 @@ export const AIOverviewDashboard = ({ envSlug }: { envSlug: string }) => {
               valueName="cost"
               colors={CHART_COLORS}
               format={formatCost}
+              valueLabelFormat={formatCostAxisBar}
               formatIdentifier={(id) => functionsBySlug.get(id)?.name ?? id}
               showYAxisLine={false}
               showTooltipValueName={false}
@@ -509,6 +525,7 @@ export const AIOverviewDashboard = ({ envSlug }: { envSlug: string }) => {
           </Section>
           <Section
             title="Most expensive runs"
+            tooltip={COST_TOOLTIP}
             query={mostExpensiveRuns.data?.query}
             queryName="AI most expensive runs"
           >
@@ -531,6 +548,7 @@ export const AIOverviewDashboard = ({ envSlug }: { envSlug: string }) => {
           </Section>
           <Section
             title="Most expensive steps"
+            tooltip={COST_TOOLTIP}
             query={mostExpensiveSteps.data?.query}
             queryName="AI most expensive steps"
           >
@@ -552,6 +570,7 @@ export const AIOverviewDashboard = ({ envSlug }: { envSlug: string }) => {
           </Section>
           <Section
             title="Most expensive sessions"
+            tooltip={COST_TOOLTIP}
             className="lg:col-span-2"
             query={mostExpensiveSessions.data?.query}
             queryName="AI most expensive sessions"

--- a/ui/apps/dashboard/src/components/AIOverview/utils.ts
+++ b/ui/apps/dashboard/src/components/AIOverview/utils.ts
@@ -43,21 +43,38 @@ export function formatCostAxis(value: number): string {
   return `$${parseFloat(toSigFigs(value, 3))}`;
 }
 
-// headlineCaveat surfaces the ai_headline registry entry's unpriced-usage
-// tracking (see pkg/applogic/dashboards/registry.go) as a human caveat, so
-// the cost tile doesn't look artificially complete when some calls used a
-// model the pricing table doesn't know about.
-export function headlineCaveat(values: NamedValue[] | undefined): string | undefined {
-  if (!values) return undefined;
+// formatCostAxisBar is formatCostAxis's bar-chart counterpart — sub-cent
+// values collapse to "<$0.01" rather than a string of leading zeros, which
+// reads as noise at axis-label size. Bar charts (unlike line charts) plot
+// discrete per-bucket totals that can legitimately land near zero, so this
+// only applies there.
+export function formatCostAxisBar(value: number): string {
+  if (value > 0 && value < 0.01) {
+    return '<$0.01';
+  }
+  return formatCostAxis(value);
+}
+
+// COST_TOOLTIP explains how every cost figure across the AI Overview/
+// FunctionAI dashboards is derived, so each cost tile/chart can share the
+// same wording via its `tooltip` prop.
+export const COST_TOOLTIP =
+  "Estimated from uncached input and output token usage, priced using each model's published per-token rates.";
+
+// headlineCaveat is COST_TOOLTIP plus the ai_headline registry entry's
+// unpriced-usage tracking (see pkg/applogic/dashboards/registry.go), shown
+// when some calls used a model the pricing table doesn't know about.
+export function headlineCaveat(values: NamedValue[] | undefined): string {
+  if (!values) return COST_TOOLTIP;
   const byName = new Map(values.map((v) => [v.name, v.value]));
   const unpricedCalls = byName.get('unpriced_calls') ?? 0;
-  if (unpricedCalls <= 0) return undefined;
+  if (unpricedCalls <= 0) return COST_TOOLTIP;
 
   const unpricedTokens =
     (byName.get('unpriced_input_tokens') ?? 0) +
     (byName.get('unpriced_output_tokens') ?? 0);
 
-  return `${formatCompactNumber(unpricedCalls)} call${unpricedCalls === 1 ? '' : 's'} (${formatCompactNumber(unpricedTokens)} tokens) used a model without pricing data and are excluded from cost.`;
+  return `${COST_TOOLTIP}\n${formatCompactNumber(unpricedCalls)} call${unpricedCalls === 1 ? '' : 's'} (${formatCompactNumber(unpricedTokens)} tokens) used a model without pricing data and are excluded from cost.`;
 }
 
 // withTotalTokens appends a synthetic `total_tokens` value (input_tokens +

--- a/ui/apps/dashboard/src/components/Functions/FunctionAI.tsx
+++ b/ui/apps/dashboard/src/components/Functions/FunctionAI.tsx
@@ -36,8 +36,10 @@ import { ViewToggle, type ViewMode } from '@/components/InsightsMetrics/ViewTogg
 import { formatCompactNumber } from '@/components/InfraDashboard/utils';
 import { useEnvironment } from '@/components/Environments/environment-context';
 import {
+  COST_TOOLTIP,
   formatCost,
   formatCostAxis,
+  formatCostAxisBar,
   formatMs,
   formatSeconds,
   formatSecondsAxis,
@@ -49,12 +51,12 @@ import { renderFunctionLink, renderRunLink } from '@/components/AIOverview/rende
 
 const DEFAULT_DURATION = { days: 7 };
 
-// "Cost over time" gets twice the buckets of every other trend chart here —
+// "Estimated cost over time" gets twice the buckets of every other trend chart here —
 // it's the sole full-width chart in the Cost section, so it has the
 // horizontal room to render a finer-grained trend.
 const COST_TREND_BUCKET_LIMIT = TREND_BUCKET_LIMIT * 2;
 
-// Shared by "Cost over time" and "Cost by model" — both plot ai_token_trend/
+// Shared by "Estimated cost over time" and "Estimated cost by model" — both plot ai_token_trend/
 // ai_model_distribution's `cost` column, which carries input/output tokens
 // alongside it in the same row, so the tooltip can show token counts
 // without adding a visual series for them.
@@ -141,7 +143,7 @@ export const FunctionAI = ({ functionSlug }: Props) => {
     pause,
   });
   // Separate from tokenTrend (same registry key, double the buckets) so
-  // "Cost over time" can render at finer granularity than "Tokens over
+  // "Estimated cost over time" can render at finer granularity than "Tokens over
   // time" without doubling the latter's bucket count too.
   const costTrend = useInsightsMetric('ai_token_trend', {
     workspaceID,
@@ -396,7 +398,8 @@ export const FunctionAI = ({ functionSlug }: Props) => {
         <SectionGroupHeading>Cost</SectionGroupHeading>
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <Section
-            title="Cost over time"
+            title="Estimated cost over time"
+            tooltip={COST_TOOLTIP}
             className="lg:col-span-2"
             query={costTrend.data?.query}
             queryName="AI cost over time"
@@ -407,7 +410,7 @@ export const FunctionAI = ({ functionSlug }: Props) => {
               hasData={hasAnyCalls}
               chartType="bar"
               format={formatCost}
-              axisFormat={formatCostAxis}
+              axisFormat={formatCostAxisBar}
               allowDecimals
               series={[
                 {
@@ -421,7 +424,8 @@ export const FunctionAI = ({ functionSlug }: Props) => {
             />
           </Section>
           <Section
-            title="Cost per run over time"
+            title="Estimated cost per run over time"
+            tooltip={COST_TOOLTIP}
             query={costPerRunTrend.data?.query}
             queryName="AI cost per run over time"
           >
@@ -436,13 +440,19 @@ export const FunctionAI = ({ functionSlug }: Props) => {
               defaultValue={0}
             />
           </Section>
-          <Section title="Cost by model" query={modelDistribution.data?.query} queryName="AI cost by model">
+          <Section
+            title="Estimated cost by model"
+            tooltip={COST_TOOLTIP}
+            query={modelDistribution.data?.query}
+            queryName="AI cost by model"
+          >
             <CategoricalChart
               items={toListItems(modelDistribution.data)}
               isLoading={modelDistribution.fetching && !modelDistribution.data}
               valueName="cost"
               colors={CHART_COLORS}
               format={formatCost}
+              valueLabelFormat={formatCostAxisBar}
               tooltipExtras={TOKEN_TOOLTIP_EXTRAS}
               showYAxisLine={false}
               showTooltipValueName={false}
@@ -451,6 +461,7 @@ export const FunctionAI = ({ functionSlug }: Props) => {
           </Section>
           <Section
             title="Most expensive runs"
+            tooltip={COST_TOOLTIP}
             query={mostExpensiveRuns.data?.query}
             queryName="AI most expensive runs"
           >
@@ -473,6 +484,7 @@ export const FunctionAI = ({ functionSlug }: Props) => {
           </Section>
           <Section
             title="Most expensive steps"
+            tooltip={COST_TOOLTIP}
             query={mostExpensiveSteps.data?.query}
             queryName="AI most expensive steps"
           >

--- a/ui/apps/dashboard/src/components/InsightsMetrics/CategoricalChart.tsx
+++ b/ui/apps/dashboard/src/components/InsightsMetrics/CategoricalChart.tsx
@@ -51,6 +51,12 @@ type Props = {
   // side by side (multi-measure form only).
   stacked?: boolean;
   format?: (value: number) => string;
+  // Overrides `format` for the persistent value-label column
+  // (`showValueLabels`) only — e.g. a bar-chart-specific cost formatter that
+  // collapses sub-cent values to "<$0.01", while the hover tooltip (still
+  // using `format`) keeps full precision for drill-down. Defaults to
+  // `format`.
+  valueLabelFormat?: (value: number) => string;
   // Maps an item's raw identifier to its y-axis display label — e.g.
   // resolving a function slug to its human-readable name. Defaults to the
   // identifier as-is (already human-readable for callers like model names).
@@ -227,6 +233,7 @@ export function CategoricalChart({
   series,
   stacked = false,
   format = defaultFormat,
+  valueLabelFormat = format,
   formatIdentifier = (identifier) => identifier,
   showYAxisLine = true,
   showValueLabels = false,
@@ -367,7 +374,7 @@ export function CategoricalChart({
       <g>
         {effectiveSeries.map((s, i) => {
           const raw = row?.[s.valueName];
-          const text = typeof raw === 'number' ? format(raw) : '';
+          const text = typeof raw === 'number' ? valueLabelFormat(raw) : '';
           const columnX = x + i * VALUE_COLUMN_STEP;
           return (
             <g key={s.valueName}>

--- a/ui/apps/dashboard/src/components/InsightsMetrics/HeadlineStats.tsx
+++ b/ui/apps/dashboard/src/components/InsightsMetrics/HeadlineStats.tsx
@@ -76,7 +76,7 @@ function InfoTooltip({ tooltip }: { tooltip: string }) {
       <TooltipTrigger>
         <RiInformationLine className="text-subtle h-3.5 w-3.5" />
       </TooltipTrigger>
-      <TooltipContent>{tooltip}</TooltipContent>
+      <TooltipContent className="whitespace-pre-line">{tooltip}</TooltipContent>
     </Tooltip>
   );
 }

--- a/ui/apps/dashboard/src/components/InsightsMetrics/Section.tsx
+++ b/ui/apps/dashboard/src/components/InsightsMetrics/Section.tsx
@@ -5,7 +5,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@inngest/components/DropdownMenu/DropdownMenu';
-import { RiArrowRightUpLine, RiMoreFill } from '@remixicon/react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
+import { RiArrowRightUpLine, RiInformationLine, RiMoreFill } from '@remixicon/react';
 import { useNavigate } from '@tanstack/react-router';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
@@ -17,6 +18,7 @@ export function SectionGroupHeading({ children }: { children: React.ReactNode })
 
 export function Section({
   title,
+  tooltip,
   className,
   children,
   query,
@@ -24,6 +26,10 @@ export function Section({
   plain = false,
 }: {
   title?: string;
+  // When set alongside `title`, renders a small info icon next to the title
+  // — hovering shows this text (e.g. how the section's metric is
+  // calculated) in a tooltip.
+  tooltip?: string;
   className?: string;
   children: React.ReactNode;
   // The exact Insights-dialect SQL that produced this card's data (the
@@ -47,7 +53,19 @@ export function Section({
       className={`${plain ? '' : 'border-subtle bg-canvasBase shadow-xs rounded-md border p-4'} ${className ?? ''}`}
     >
       <div className="mb-3 flex items-center justify-between gap-2">
-        {title && <h2 className="text-basis text-sm font-medium">{title}</h2>}
+        {title && (
+          <h2 className="text-basis flex items-center gap-1.5 text-sm font-medium">
+            {title}
+            {tooltip && (
+              <Tooltip>
+                <TooltipTrigger>
+                  <RiInformationLine className="text-subtle h-3.5 w-3.5" />
+                </TooltipTrigger>
+                <TooltipContent className="whitespace-pre-line">{tooltip}</TooltipContent>
+              </Tooltip>
+            )}
+          </h2>
+        )}
         {query && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild className="ml-auto">
@@ -55,6 +73,12 @@ export function Section({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem
+                // -m-0.5 cancels DropdownMenuContent's p-0.5, so this
+                // single-item menu's hover background runs flush to the
+                // container's border on every side instead of leaving an
+                // inset gap — same rounded-md radius as the container, now
+                // with zero inset, so the corners align exactly.
+                className="-m-0.5 rounded-md focus:outline-none"
                 onSelect={() =>
                   navigate({
                     to: pathCreator.insights({ envSlug: env.slug }),

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -2132,7 +2132,6 @@ export enum ReplayRunStatus {
 }
 
 export enum ReplayType {
-  Event = 'EVENT',
   Function = 'FUNCTION'
 }
 


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

- Estimated Cost tile always shows a tooltip explaining cost is based on uncached token usage (previously only shown when some calls were unpriced). 
  <img width="420" height="222" alt="image" src="https://github.com/user-attachments/assets/0e9cc2a1-a388-48bc-89f2-3e768d658e4c" />

- Renamed cost charts to "Estimated cost ..." / "Estimated cost by ..." across both AI dashboards.
  <img width="1493" height="649" alt="image" src="https://github.com/user-attachments/assets/3f9e9099-724b-49df-b45c-de402744f7c4" />
- Added tooltip icons to every chart in the Cost section explaining how cost is calculated.
  <img width="369" height="118" alt="image" src="https://github.com/user-attachments/assets/ccb5abd2-8564-4aea-8038-d3218db9d851" />
- Cost values under $0.01 now show as <$0.01 on bar chart axes and labels (line charts/tooltips keep full precision) (previously it would overflow).
  <img width="167" height="230" alt="image" src="https://github.com/user-attachments/assets/71d60e92-5810-4f7f-aaa1-193b40bb1968" />
- Fixed the "Open in Insights" menu item's hover highlight to align flush with the menu border, and removed its stray focus outline. 
  <img width="211" height="132" alt="image" src="https://github.com/user-attachments/assets/d0249205-120f-4752-92ba-7ba0bf1b2a71" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
