### PR TITLE
feat(scores): show recorded scores on timeline bars

### DIFF
--- a/ui/packages/components/src/RunDetails/ScoresAttrs.test.ts
+++ b/ui/packages/components/src/RunDetails/ScoresAttrs.test.ts
@@ -29,6 +29,23 @@ describe('scoreRows', () => {
 
     expect(rows.map((r) => r.name)).toEqual(['ok']);
   });
+
+  it('keeps only the latest write when a score name is recorded more than once', () => {
+    const rows = scoreRows([
+      {
+        kind: 'inngest.score',
+        updatedAt: '2026-06-23T00:00:09Z',
+        values: { relevance: { value: 0.9 } },
+      },
+      {
+        kind: 'inngest.score',
+        updatedAt: '2026-06-23T00:00:05Z',
+        values: { relevance: { value: 0.5 } },
+      },
+    ]);
+
+    expect(rows).toEqual([{ name: 'relevance', value: 0.9, updatedAt: '2026-06-23T00:00:09Z' }]);
+  });
 });
 
 describe('collectScoreMetadata', () => {

--- a/ui/packages/components/src/RunDetails/ScoresAttrs.tsx
+++ b/ui/packages/components/src/RunDetails/ScoresAttrs.tsx
@@ -33,7 +33,7 @@ export function collectScoreMetadata(trace?: ScoreTrace): ScoreMetadata[] {
 
 // Trim floating-point noise and excess precision from non-integer scores;
 // integers and booleans render as-is.
-function formatScoreValue(value: number | boolean): string {
+export function formatScoreValue(value: number | boolean): string {
   if (typeof value === 'number' && !Number.isInteger(value)) {
     return String(Number(value.toPrecision(4)));
   }

--- a/ui/packages/components/src/RunDetails/ScoresAttrs.tsx
+++ b/ui/packages/components/src/RunDetails/ScoresAttrs.tsx
@@ -40,18 +40,30 @@ export function formatScoreValue(value: number | boolean): string {
   return String(value);
 }
 
+function isScoreValue(raw: unknown): raw is { value: number | boolean } {
+  if (typeof raw !== 'object' || raw === null || !('value' in raw)) {
+    return false;
+  }
+  const { value } = raw;
+  return typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value));
+}
+
 export function scoreRows(metadata: ScoreMetadata[]): ScoreRow[] {
-  return metadata
-    .flatMap((md) =>
-      Object.entries(md.values).flatMap(([name, raw]) => {
-        const value = (raw as { value?: unknown } | null)?.value;
-        if (typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value))) {
-          return [{ name, value, updatedAt: md.updatedAt }];
-        }
-        return [];
-      })
-    )
-    .sort((a, b) => a.name.localeCompare(b.name) || a.updatedAt.localeCompare(b.updatedAt));
+  const latest = new Map<string, ScoreRow>();
+
+  for (const md of metadata) {
+    for (const [name, raw] of Object.entries(md.values)) {
+      if (!isScoreValue(raw)) {
+        continue;
+      }
+      const prev = latest.get(name);
+      if (!prev || md.updatedAt >= prev.updatedAt) {
+        latest.set(name, { name, value: raw.value, updatedAt: md.updatedAt });
+      }
+    }
+  }
+
+  return [...latest.values()].sort((a, b) => a.name.localeCompare(b.name));
 }
 
 export const ScoresAttrs = ({ metadata }: { metadata: ScoreMetadata[] }) => {
@@ -72,9 +84,9 @@ export const ScoresAttrs = ({ metadata }: { metadata: ScoreMetadata[] }) => {
         <div>Value</div>
         <div>Updated at</div>
       </div>
-      {rows.map((row, index) => (
+      {rows.map((row) => (
         <div
-          key={`score-${row.name}-${row.updatedAt}-${index}`}
+          key={row.name}
           className="border-muted grid grid-cols-[minmax(10rem,1fr)_8rem_12rem] gap-4 border-b px-4 py-3 text-sm last:border-b-0"
         >
           <div className="text-basis min-w-0 font-medium [overflow-wrap:anywhere]">{row.name}</div>

--- a/ui/packages/components/src/RunDetailsV4/Timeline.tsx
+++ b/ui/packages/components/src/RunDetailsV4/Timeline.tsx
@@ -607,6 +607,7 @@ function TimelineBarRenderer({
       hasExperiment={bar.hasExperiment}
       insideExperiment={insideExperiment}
       experimentMetadata={bar.experimentMetadata}
+      scores={bar.scores}
     >
       {/* Inngest timing bar — positioned to match the queue segment of the parent.
           Only for non-root bars; the root uses timingBreakdown only for compound segments. */}

--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.test.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.test.tsx
@@ -279,4 +279,32 @@ describe('TimelineBar', () => {
       expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('score badge', () => {
+    it('renders no badge when the span has no scores', () => {
+      render(<TimelineBar {...defaultProps} />, { wrapper: Wrapper });
+      expect(screen.queryByTestId('score-badge')).toBeNull();
+    });
+
+    it('renders a badge when the span has scores', () => {
+      render(<TimelineBar {...defaultProps} scores={[{ name: 'relevance', value: 0.9 }]} />, {
+        wrapper: Wrapper,
+      });
+      expect(screen.getByTestId('score-badge')).toBeTruthy();
+    });
+
+    it('lets badge clicks fall through to row selection', () => {
+      const onClick = vi.fn();
+      render(
+        <TimelineBar
+          {...defaultProps}
+          onClick={onClick}
+          scores={[{ name: 'relevance', value: 0.9 }]}
+        />,
+        { wrapper: Wrapper }
+      );
+      fireEvent.click(screen.getByTestId('score-badge'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
@@ -613,7 +613,7 @@ function ScoreBadge({ scores }: { scores: ScoreBadgeData[] }) {
           <RiPercentLine className="h-3 w-3" />
         </span>
       </HoverCardTrigger>
-      <HoverCardContent side="top" align="start" className="border-muted max-w-none border">
+      <HoverCardContent side="top" align="start" className="border-muted max-w-xs border">
         <ScoreHoverCardContent scores={scores} />
       </HoverCardContent>
     </HoverCardRoot>
@@ -627,7 +627,6 @@ function ScoreBadge({ scores }: { scores: ScoreBadgeData[] }) {
 function ScoreHoverCardContent({ scores }: { scores: ScoreBadgeData[] }) {
   return (
     <div className="whitespace-nowrap px-1 py-0.5 text-xs">
-      <p className="text-light mb-0.5">Scores</p>
       <div className="border-subtle flex justify-between gap-6 border-b pb-1">
         <span className="text-light">Score</span>
         <span className="text-light">Value</span>
@@ -637,8 +636,12 @@ function ScoreHoverCardContent({ scores }: { scores: ScoreBadgeData[] }) {
           key={score.name}
           className="border-subtle flex items-center justify-between gap-6 border-b py-1 last:border-b-0"
         >
-          <span className="text-basis font-medium">{score.name}</span>
-          <span className="text-basis font-mono tabular-nums">{formatScoreValue(score.value)}</span>
+          <span className="text-basis min-w-0 truncate font-medium" title={score.name}>
+            {score.name}
+          </span>
+          <span className="text-basis shrink-0 font-mono tabular-nums">
+            {formatScoreValue(score.value)}
+          </span>
         </div>
       ))}
     </div>

--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
@@ -21,6 +21,7 @@ import {
   RiFunctionLine,
   RiInformationLine,
   RiMailLine,
+  RiPercentLine,
   RiSettings3Line,
   RiStopCircleFill,
   RiTimeLine,
@@ -29,6 +30,7 @@ import { format } from 'date-fns';
 
 import { formatVariantWeight } from '../Experiments/format';
 import { HoverCardContent, HoverCardRoot, HoverCardTrigger } from '../HoverCard';
+import { formatScoreValue } from '../RunDetails/ScoresAttrs';
 import { usePathCreator } from '../SharedContext/usePathCreator';
 import { getStatusBackgroundClass, getStatusTextClass } from '../Status/statusClasses';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip/Tooltip';
@@ -40,6 +42,7 @@ import type {
   BarSegment,
   BarStyle,
   BarStyleKey,
+  ScoreBadgeData,
   TimelineBarProps,
   TimingDetail,
 } from './TimelineBar.types';
@@ -478,6 +481,9 @@ function BarHoverCardContent({
   );
 }
 
+const BADGE_CLASS =
+  'bg-canvasSubtle border-subtle text-subtle hover:bg-canvasMuted inline-flex h-5 w-5 items-center justify-center rounded border transition-colors';
+
 /**
  * Experiment badge shown beside a step that ran under an experiment. Renders
  * the flask icon in the standard IconTile treatment (subtle bg + border, thin
@@ -494,9 +500,6 @@ function ExperimentBadge({ metadata }: { metadata?: TimelineBarProps['experiment
         })
       : null;
 
-  const badgeClass =
-    'bg-canvasSubtle border-subtle text-subtle hover:bg-canvasMuted inline-flex h-5 w-5 items-center justify-center rounded border transition-colors';
-
   const badge = <RiFlaskLine className="h-3 w-3" />;
 
   return (
@@ -505,7 +508,7 @@ function ExperimentBadge({ metadata }: { metadata?: TimelineBarProps['experiment
         {href ? (
           <a
             href={href}
-            className={badgeClass}
+            className={BADGE_CLASS}
             onClick={(e) => e.stopPropagation()}
             onMouseDown={(e) => e.stopPropagation()}
           >
@@ -513,7 +516,7 @@ function ExperimentBadge({ metadata }: { metadata?: TimelineBarProps['experiment
           </a>
         ) : (
           <span
-            className={badgeClass}
+            className={BADGE_CLASS}
             onClick={(e) => e.stopPropagation()}
             onMouseDown={(e) => e.stopPropagation()}
           >
@@ -593,6 +596,51 @@ function ExperimentHoverCardContent({
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Score badge shown beside a span that recorded scores. Mirrors the experiment
+ * badge treatment; scores have no dedicated page, so the badge never links out
+ * and clicks fall through to row selection.
+ */
+function ScoreBadge({ scores }: { scores: ScoreBadgeData[] }) {
+  return (
+    <HoverCardRoot openDelay={200} closeDelay={0}>
+      <HoverCardTrigger asChild>
+        <span data-testid="score-badge" className={BADGE_CLASS}>
+          <RiPercentLine className="h-3 w-3" />
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent side="top" align="start" className="border-muted max-w-none border">
+        <ScoreHoverCardContent scores={scores} />
+      </HoverCardContent>
+    </HoverCardRoot>
+  );
+}
+
+/**
+ * Hover card content for the score badge, listing each recorded score name and
+ * its formatted value.
+ */
+function ScoreHoverCardContent({ scores }: { scores: ScoreBadgeData[] }) {
+  return (
+    <div className="whitespace-nowrap px-1 py-0.5 text-xs">
+      <p className="text-light mb-0.5">Scores</p>
+      <div className="border-subtle flex justify-between gap-6 border-b pb-1">
+        <span className="text-light">Score</span>
+        <span className="text-light">Value</span>
+      </div>
+      {scores.map((score) => (
+        <div
+          key={score.name}
+          className="border-subtle flex items-center justify-between gap-6 border-b py-1 last:border-b-0"
+        >
+          <span className="text-basis font-medium">{score.name}</span>
+          <span className="text-basis font-mono tabular-nums">{formatScoreValue(score.value)}</span>
+        </div>
+      ))}
     </div>
   );
 }
@@ -781,6 +829,7 @@ export function TimelineBar({
   hasExperiment,
   insideExperiment,
   experimentMetadata,
+  scores,
 }: TimelineBarProps): JSX.Element {
   const showExperimentBackground = hasExperiment || insideExperiment;
   const barStyle = getBarStyle(style);
@@ -910,9 +959,11 @@ export function TimelineBar({
           </span>
         </div>
 
-        {/* Experiment badge - centered between left panel and bars */}
-        <span className="inline-flex w-7 shrink-0 items-center justify-center">
+        {/* Experiment and score badges - centered between left panel and bars.
+            Width is fixed so bars stay aligned across rows regardless of badges. */}
+        <span className="inline-flex w-12 shrink-0 items-center justify-center gap-1">
           {hasExperiment && <ExperimentBadge metadata={experimentMetadata} />}
+          {scores && scores.length > 0 && <ScoreBadge scores={scores} />}
         </span>
 
         {/* Right panel - visual bar with optional hover card */}

--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.types.ts
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.types.ts
@@ -226,6 +226,17 @@ export interface TimelineBarProps {
     variantWeights?: Record<string, number>;
     functionSlug?: string;
   };
+
+  /** Scores recorded on this span (shows badge with hover card) */
+  scores?: ScoreBadgeData[];
+}
+
+/**
+ * A single score recorded on a span, shown in the score badge hover card.
+ */
+export interface ScoreBadgeData {
+  name: string;
+  value: number | boolean;
 }
 
 /**
@@ -312,6 +323,9 @@ export interface TimelineBarData {
     variantWeights?: Record<string, number>;
     functionSlug?: string;
   };
+
+  /** Scores recorded on this span */
+  scores?: ScoreBadgeData[];
 }
 
 /**

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
@@ -768,26 +768,6 @@ describe('traceConversion', () => {
       expect(result.bars[0]?.children?.[1]?.scores).toBeUndefined();
     });
 
-    it('ignores score values that are not finite numbers or booleans', () => {
-      const trace = createTrace({
-        isRoot: true,
-        metadata: [
-          {
-            scope: 'run',
-            kind: 'inngest.score',
-            updatedAt: '2024-01-01T00:00:05Z',
-            values: {
-              broken: { value: Infinity as unknown as number },
-              fine: { value: 1 },
-            },
-          },
-        ],
-      });
-      const result = traceToTimelineData(trace, { runID: 'run-1' });
-
-      expect(result.bars[0]?.scores).toEqual([{ name: 'fine', value: 1 }]);
-    });
-
     it('preserves spanID as bar id', () => {
       const trace = createTrace({
         isRoot: true,

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
@@ -732,6 +732,62 @@ describe('traceConversion', () => {
       expect(result.bars[0]?.children?.[0]?.children?.[0]?.name).toBe('child');
     });
 
+    it('attaches each span its own scores without walking children', () => {
+      const trace = createTrace({
+        isRoot: true,
+        metadata: [
+          {
+            scope: 'run',
+            kind: 'inngest.score',
+            updatedAt: '2024-01-01T00:00:05Z',
+            values: { relevance: { value: 0.98765 } },
+          },
+        ],
+        childrenSpans: [
+          createTrace({
+            spanID: 'scored-step',
+            metadata: [
+              {
+                scope: 'step',
+                kind: 'inngest.score',
+                updatedAt: '2024-01-01T00:00:06Z',
+                values: { passed: { value: true }, accuracy: { value: 3 } },
+              },
+            ],
+          }),
+          createTrace({ spanID: 'unscored-step', stepID: 'step-2' }),
+        ],
+      });
+      const result = traceToTimelineData(trace, { runID: 'run-1' });
+
+      expect(result.bars[0]?.scores).toEqual([{ name: 'relevance', value: 0.98765 }]);
+      expect(result.bars[0]?.children?.[0]?.scores).toEqual([
+        { name: 'accuracy', value: 3 },
+        { name: 'passed', value: true },
+      ]);
+      expect(result.bars[0]?.children?.[1]?.scores).toBeUndefined();
+    });
+
+    it('ignores score values that are not finite numbers or booleans', () => {
+      const trace = createTrace({
+        isRoot: true,
+        metadata: [
+          {
+            scope: 'run',
+            kind: 'inngest.score',
+            updatedAt: '2024-01-01T00:00:05Z',
+            values: {
+              broken: { value: Infinity as unknown as number },
+              fine: { value: 1 },
+            },
+          },
+        ],
+      });
+      const result = traceToTimelineData(trace, { runID: 'run-1' });
+
+      expect(result.bars[0]?.scores).toEqual([{ name: 'fine', value: 1 }]);
+    });
+
     it('preserves spanID as bar id', () => {
       const trace = createTrace({
         isRoot: true,

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -6,6 +6,7 @@
 import { maxDateString, toMaybeDate } from '@inngest/components/utils/date';
 import { max, min } from 'date-fns';
 
+import { scoreRows } from '../../RunDetails/ScoresAttrs';
 import { KindInngestExperiment } from '../../generated';
 import type {
   BarStyleKey,
@@ -218,18 +219,10 @@ function getHTTPTimingFromMetadata(metadata?: SpanMetadata[]): HTTPTimingBreakdo
  * not walked: the timeline already renders them as their own bars.
  */
 function getScores(metadata?: SpanMetadata[]): ScoreBadgeData[] | undefined {
-  const scores =
-    metadata
-      ?.filter(isScoreMetadata)
-      .flatMap((md) =>
-        Object.entries(md.values).flatMap(([name, raw]) => {
-          const value = raw?.value;
-          return typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value))
-            ? [{ name, value }]
-            : [];
-        })
-      )
-      .sort((a, b) => a.name.localeCompare(b.name)) ?? [];
+  const scores = scoreRows(metadata?.filter(isScoreMetadata) ?? []).map(({ name, value }) => ({
+    name,
+    value,
+  }));
 
   return scores.length > 0 ? scores : undefined;
 }

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -11,12 +11,14 @@ import type {
   BarStyleKey,
   HTTPTimingBreakdownData,
   InngestBreakdownData,
+  ScoreBadgeData,
   TimelineBarData,
   TimelineData,
 } from '../TimelineBar.types';
 import { traceWalk } from '../runDetailsUtils';
 import {
   isExperimentMetadata,
+  isScoreMetadata,
   isStepInfoRun,
   type SpanMetadata,
   type SpanMetadataInngestHTTPTiming,
@@ -212,6 +214,27 @@ function getHTTPTimingFromMetadata(metadata?: SpanMetadata[]): HTTPTimingBreakdo
 }
 
 /**
+ * Extract scores recorded directly on this span. Child spans are deliberately
+ * not walked: the timeline already renders them as their own bars.
+ */
+function getScores(metadata?: SpanMetadata[]): ScoreBadgeData[] | undefined {
+  const scores =
+    metadata
+      ?.filter(isScoreMetadata)
+      .flatMap((md) =>
+        Object.entries(md.values).flatMap(([name, raw]) => {
+          const value = raw?.value;
+          return typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value))
+            ? [{ name, value }]
+            : [];
+        })
+      )
+      .sort((a, b) => a.name.localeCompare(b.name)) ?? [];
+
+  return scores.length > 0 ? scores : undefined;
+}
+
+/**
  * Convert a single Trace to TimelineBarData
  */
 function traceToBarData(
@@ -288,6 +311,7 @@ function traceToBarData(
     delayMs,
     hasExperiment,
     experimentMetadata,
+    scores: getScores(trace.metadata),
   };
 }
 


### PR DESCRIPTION
## Description

Spans that recorded scores now show a badge beside their bar in the run details timeline. Hovering it lists each score name and value.

The badge reuses the experiment badge treatment.

### Screenshots

<img width="1614" height="1050" alt="Screenshot 2026-08-11 at 1 14 14 PM" src="https://github.com/user-attachments/assets/360f56ed-91ad-414b-a6ad-f350b104849c" />
<img width="1614" height="1050" alt="Screenshot 2026-08-11 at 1 14 18 PM" src="https://github.com/user-attachments/assets/9408d9c3-0969-4857-86ce-b32f3e13e2c6" />


## Release note

Scores recorded on a step now appear as a badge on that step's bar in the run
timeline, with a hover card listing each score and its value.

## Migration note

None.

## Related

[EXE-1832: Scoring with the trace view](https://linear.app/inngest/issue/EXE-1832/scoring-with-the-trace-view)
