### PR TITLE
fix(traces): hide expand/collapse all when there is nothing to toggle

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/Timeline.test.tsx
+++ b/ui/packages/components/src/RunDetailsV4/Timeline.test.tsx
@@ -240,6 +240,50 @@ describe('Timeline', () => {
       fireEvent.click(screen.getByRole('button', { name: /expand all/i }));
       expect(screen.getByText('Inngest')).toBeTruthy();
     });
+
+    it('hides both actions when there is nothing to expand or collapse', () => {
+      const dataWithNothingExpandable: TimelineData = {
+        ...mockData,
+        bars: [
+          {
+            id: 'root',
+            name: 'Run',
+            startTime: new Date('2024-01-01T00:00:00Z'),
+            endTime: new Date('2024-01-01T00:00:10Z'),
+            style: 'root',
+            isRoot: true,
+            status: 'QUEUED',
+          },
+        ],
+      };
+
+      render(<Timeline data={dataWithNothingExpandable} />, { wrapper: Wrapper });
+
+      expect(screen.queryByRole('button', { name: /expand all/i })).toBeNull();
+      expect(screen.queryByRole('button', { name: /collapse all/i })).toBeNull();
+    });
+
+    it('hides collapse all until something is expanded', () => {
+      render(<Timeline data={mockData} />, { wrapper: Wrapper });
+
+      expect(screen.getByRole('button', { name: /expand all/i })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: /collapse all/i })).toBeNull();
+
+      // Expand the first step manually
+      const rows = screen.getAllByTestId('timeline-bar-row');
+      fireEvent.click(rows[1]!);
+
+      expect(screen.getByRole('button', { name: /collapse all/i })).toBeTruthy();
+    });
+
+    it('hides expand all once everything is expanded', () => {
+      render(<Timeline data={mockData} />, { wrapper: Wrapper });
+
+      fireEvent.click(screen.getByRole('button', { name: /expand all/i }));
+
+      expect(screen.queryByRole('button', { name: /expand all/i })).toBeNull();
+      expect(screen.getByRole('button', { name: /collapse all/i })).toBeTruthy();
+    });
   });
 
   describe('nested steps', () => {

--- a/ui/packages/components/src/RunDetailsV4/Timeline.tsx
+++ b/ui/packages/components/src/RunDetailsV4/Timeline.tsx
@@ -885,39 +885,54 @@ export function Timeline({ data, onSelectStep }: Props): JSX.Element {
     [onSelectStep]
   );
 
+  const expandableIds = useMemo(() => collectExpandableIds(bars), [bars]);
+
   const handleExpandAll = useCallback(() => {
-    const allExpandableIds = collectExpandableIds(bars);
-    setExpandedBars(new Set([...rootBarIds, ...allExpandableIds]));
-  }, [bars, rootBarIds]);
+    setExpandedBars(new Set([...rootBarIds, ...expandableIds]));
+  }, [expandableIds, rootBarIds]);
 
   const handleCollapseAll = useCallback(() => {
     setExpandedBars(new Set(rootBarIds));
   }, [rootBarIds]);
 
+  // Only offer each action when it would actually change something: expanding
+  // requires a collapsed expandable bar, collapsing requires an expanded
+  // non-root bar (roots are always expanded).
+  const canExpandAll = expandableIds.some((id) => !expandedBars.has(id));
+  const canCollapseAll = useMemo(() => {
+    const roots = new Set(rootBarIds);
+    return [...expandedBars].some((id) => !roots.has(id));
+  }, [expandedBars, rootBarIds]);
+
   const expandCollapseActions = useMemo(
-    () => (
-      <span className="flex shrink-0 items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
-        <Button
-          size="small"
-          appearance="ghost"
-          icon={<RiExpandUpDownLine className="h-3.5 w-3.5" />}
-          title="Expand all"
-          tooltip="Expand all"
-          aria-label="Expand all"
-          onClick={handleExpandAll}
-        />
-        <Button
-          size="small"
-          appearance="ghost"
-          icon={<RiContractUpDownLine className="h-3.5 w-3.5" />}
-          title="Collapse all"
-          tooltip="Collapse all"
-          aria-label="Collapse all"
-          onClick={handleCollapseAll}
-        />
-      </span>
-    ),
-    [handleExpandAll, handleCollapseAll]
+    () =>
+      canExpandAll || canCollapseAll ? (
+        <span className="flex shrink-0 items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
+          {canExpandAll && (
+            <Button
+              size="small"
+              appearance="ghost"
+              icon={<RiExpandUpDownLine className="h-3.5 w-3.5" />}
+              title="Expand all"
+              tooltip="Expand all"
+              aria-label="Expand all"
+              onClick={handleExpandAll}
+            />
+          )}
+          {canCollapseAll && (
+            <Button
+              size="small"
+              appearance="ghost"
+              icon={<RiContractUpDownLine className="h-3.5 w-3.5" />}
+              title="Collapse all"
+              tooltip="Collapse all"
+              aria-label="Collapse all"
+              onClick={handleCollapseAll}
+            />
+          )}
+        </span>
+      ) : undefined,
+    [canExpandAll, canCollapseAll, handleExpandAll, handleCollapseAll]
   );
 
   // Handle timeline brush selection change


### PR DESCRIPTION
## Description

- I was feeling a little baited when I clicked the expand button on a run  and nothing expanded. There were simply no nested items to display
- Let's show the icons only when they will actually expand or contract
- Users get more information with less visual noise!
- Retain our current behavior of not expanding the "Inngest (i)" trees
- also ran this by design!

https://github.com/user-attachments/assets/5fdc92e4-d1a9-4ee4-ac21-bf64ce2cbba8



## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Expand and contract buttons in the trace viewer are hidden when they will not change what's displayed

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
