### PR TITLE
fix(redis-state): tolerate legacy idempotency tombstones

### DIFF
--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -26,7 +26,17 @@ end
 return 0
 `
 
-var releaseFinalizationClaimScript = NewClusterLuaScript(releaseFinalizationClaimLua)
+const cleanupOldIdempotencyKeyLua = `
+if redis.call("GET", KEYS[1]) == ARGV[1] and redis.call("TTL", KEYS[1]) == -1 then
+	return redis.call("DEL", KEYS[1])
+end
+return 0
+`
+
+var (
+	releaseFinalizationClaimScript = NewClusterLuaScript(releaseFinalizationClaimLua)
+	cleanupOldIdempotencyKeyScript = NewClusterLuaScript(cleanupOldIdempotencyKeyLua)
+)
 
 func MustRunServiceV2(m statev1.Manager, opts ...MgrV2Opt) state.RunService {
 	o := &mgrV2Opts{}
@@ -424,6 +434,30 @@ func (v v2) LookupIdempotency(ctx context.Context, id state.ID, key string) (*st
 	if len(val) > 0 && val[0] == consts.FunctionIdempotencyTombstone {
 		entry.IsTombstone = true
 		val = val[1:]
+		if val == "" {
+			deleted, err := cleanupOldIdempotencyKeyScript.Exec(
+				ctx,
+				client,
+				[]string{redisKey},
+				[]string{string(consts.FunctionIdempotencyTombstone)},
+			).AsInt64()
+			if err != nil {
+				logger.StdlibLogger(ctx).Warn(
+					"failed to clean up old idempotency key",
+					"error", err,
+					"redis_key", redisKey,
+				)
+				return entry, nil
+			}
+			if deleted == 1 {
+				logger.StdlibLogger(ctx).Warn(
+					"deleted old idempotency key with no TTL",
+					"redis_key", redisKey,
+				)
+				return nil, nil
+			}
+			return entry, nil
+		}
 	}
 	runID, err := ulid.Parse(val)
 	if err != nil {

--- a/pkg/execution/state/redis_state/v2_adapter_test.go
+++ b/pkg/execution/state/redis_state/v2_adapter_test.go
@@ -1009,6 +1009,36 @@ func TestV2AdapterLookupIdempotency(t *testing.T) {
 	assert.True(t, entry.IsTombstone)
 }
 
+func TestV2AdapterLookupIdempotencyCleansUpOldMarkerOnlyTombstone(t *testing.T) {
+	ctx := context.Background()
+	svc, redis := mustV2Service(t, ctx)
+	id := statev2.ID{
+		RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
+		FunctionID: uuid.New(),
+		Tenant: statev2.Tenant{
+			AccountID: uuid.New(),
+			EnvID:     uuid.New(),
+			AppID:     uuid.New(),
+		},
+	}
+	key := "old-marker-only-tombstone"
+	redisKey := fmt.Sprintf("{estate:%s}:key:%s", id.Tenant.AccountID, key)
+	require.NoError(t, redis.Set(redisKey, string(consts.FunctionIdempotencyTombstone)))
+
+	entry, err := svc.LookupIdempotency(ctx, id, key)
+	require.NoError(t, err)
+	assert.Nil(t, entry)
+	assert.False(t, redis.Exists(redisKey))
+
+	require.NoError(t, redis.Set(redisKey, string(consts.FunctionIdempotencyTombstone)))
+	redis.SetTTL(redisKey, time.Hour)
+	entry, err = svc.LookupIdempotency(ctx, id, key)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.True(t, entry.IsTombstone)
+	assert.True(t, redis.Exists(redisKey))
+}
+
 // recordingPauseDeleter counts DeletePausesForRun calls for verifying
 // Delete's cascade behavior.
 type recordingPauseDeleter struct{ calls int }


### PR DESCRIPTION
## Description
Pre-TTL idempotency keys used older value formats,
and some persistent keys are still lingering. Treat
marker-only tombstones as stale entries so scheduling
can proceed, while logging that the key needs cleanup.
<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
