### PR TITLE
refactor(connect): remove executor ACK RPC

### DIFF
--- a/pkg/connect/grpc/grpc.go
+++ b/pkg/connect/grpc/grpc.go
@@ -159,11 +159,6 @@ func (i *gatewayGRPCManager) Reply(ctx context.Context, req *connectpb.ReplyRequ
 	return &connectpb.ReplyResponse{Success: false}, nil
 }
 
-// TODO: Only kept for next rollout, can be removed after
-func (i *gatewayGRPCManager) Ack(ctx context.Context, req *connectpb.AckMessage) (*connectpb.AckResponse, error) {
-	return &connectpb.AckResponse{Success: true}, nil
-}
-
 func (i *gatewayGRPCManager) Ping(ctx context.Context, req *connectpb.PingRequest) (*connectpb.PingResponse, error) {
 	return &connectpb.PingResponse{Message: "ok"}, nil
 }

--- a/pkg/connect/grpc/grpc_test.go
+++ b/pkg/connect/grpc/grpc_test.go
@@ -91,10 +91,6 @@ func (m *mockConnectGatewayServer) Forward(ctx context.Context, req *connectpb.F
 	return &connectpb.ForwardResponse{Success: true}, nil
 }
 
-func (m *mockConnectGatewayServer) Ack(ctx context.Context, req *connectpb.AckMessage) (*connectpb.AckResponse, error) {
-	return &connectpb.AckResponse{Success: true}, nil
-}
-
 func (m *mockConnectGatewayServer) getPingCount() int {
 	return m.pingCount
 }

--- a/proto/connect/v1/service.proto
+++ b/proto/connect/v1/service.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package connect.v1;
 
-import "google/protobuf/timestamp.proto";
 import "connect/v1/connect.proto";
 
 option go_package = "github.com/inngest/inngest/proto/gen/connect/v1;connect";
@@ -30,7 +29,6 @@ message PingResponse {
 
 service ConnectExecutor {
   rpc Reply(ReplyRequest) returns (ReplyResponse) {}
-  rpc Ack(AckMessage) returns (AckResponse) {}
   rpc Ping(PingRequest) returns (PingResponse) {}
 }
 
@@ -41,13 +39,3 @@ message ReplyRequest {
 message ReplyResponse {
   bool success = 1;
 }
-
-message AckMessage {
-  string request_id = 1;
-  google.protobuf.Timestamp ts = 2;
-}
-
-message AckResponse {
-  bool success = 1;
-}
-

--- a/proto/gen/connect/v1/connectconnect/service.connect.go
+++ b/proto/gen/connect/v1/connectconnect/service.connect.go
@@ -41,8 +41,6 @@ const (
 	ConnectGatewayPingProcedure = "/connect.v1.ConnectGateway/Ping"
 	// ConnectExecutorReplyProcedure is the fully-qualified name of the ConnectExecutor's Reply RPC.
 	ConnectExecutorReplyProcedure = "/connect.v1.ConnectExecutor/Reply"
-	// ConnectExecutorAckProcedure is the fully-qualified name of the ConnectExecutor's Ack RPC.
-	ConnectExecutorAckProcedure = "/connect.v1.ConnectExecutor/Ack"
 	// ConnectExecutorPingProcedure is the fully-qualified name of the ConnectExecutor's Ping RPC.
 	ConnectExecutorPingProcedure = "/connect.v1.ConnectExecutor/Ping"
 )
@@ -146,7 +144,6 @@ func (UnimplementedConnectGatewayHandler) Ping(context.Context, *connect.Request
 // ConnectExecutorClient is a client for the connect.v1.ConnectExecutor service.
 type ConnectExecutorClient interface {
 	Reply(context.Context, *connect.Request[v1.ReplyRequest]) (*connect.Response[v1.ReplyResponse], error)
-	Ack(context.Context, *connect.Request[v1.AckMessage]) (*connect.Response[v1.AckResponse], error)
 	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
 }
 
@@ -167,12 +164,6 @@ func NewConnectExecutorClient(httpClient connect.HTTPClient, baseURL string, opt
 			connect.WithSchema(connectExecutorMethods.ByName("Reply")),
 			connect.WithClientOptions(opts...),
 		),
-		ack: connect.NewClient[v1.AckMessage, v1.AckResponse](
-			httpClient,
-			baseURL+ConnectExecutorAckProcedure,
-			connect.WithSchema(connectExecutorMethods.ByName("Ack")),
-			connect.WithClientOptions(opts...),
-		),
 		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
 			httpClient,
 			baseURL+ConnectExecutorPingProcedure,
@@ -185,18 +176,12 @@ func NewConnectExecutorClient(httpClient connect.HTTPClient, baseURL string, opt
 // connectExecutorClient implements ConnectExecutorClient.
 type connectExecutorClient struct {
 	reply *connect.Client[v1.ReplyRequest, v1.ReplyResponse]
-	ack   *connect.Client[v1.AckMessage, v1.AckResponse]
 	ping  *connect.Client[v1.PingRequest, v1.PingResponse]
 }
 
 // Reply calls connect.v1.ConnectExecutor.Reply.
 func (c *connectExecutorClient) Reply(ctx context.Context, req *connect.Request[v1.ReplyRequest]) (*connect.Response[v1.ReplyResponse], error) {
 	return c.reply.CallUnary(ctx, req)
-}
-
-// Ack calls connect.v1.ConnectExecutor.Ack.
-func (c *connectExecutorClient) Ack(ctx context.Context, req *connect.Request[v1.AckMessage]) (*connect.Response[v1.AckResponse], error) {
-	return c.ack.CallUnary(ctx, req)
 }
 
 // Ping calls connect.v1.ConnectExecutor.Ping.
@@ -207,7 +192,6 @@ func (c *connectExecutorClient) Ping(ctx context.Context, req *connect.Request[v
 // ConnectExecutorHandler is an implementation of the connect.v1.ConnectExecutor service.
 type ConnectExecutorHandler interface {
 	Reply(context.Context, *connect.Request[v1.ReplyRequest]) (*connect.Response[v1.ReplyResponse], error)
-	Ack(context.Context, *connect.Request[v1.AckMessage]) (*connect.Response[v1.AckResponse], error)
 	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
 }
 
@@ -224,12 +208,6 @@ func NewConnectExecutorHandler(svc ConnectExecutorHandler, opts ...connect.Handl
 		connect.WithSchema(connectExecutorMethods.ByName("Reply")),
 		connect.WithHandlerOptions(opts...),
 	)
-	connectExecutorAckHandler := connect.NewUnaryHandler(
-		ConnectExecutorAckProcedure,
-		svc.Ack,
-		connect.WithSchema(connectExecutorMethods.ByName("Ack")),
-		connect.WithHandlerOptions(opts...),
-	)
 	connectExecutorPingHandler := connect.NewUnaryHandler(
 		ConnectExecutorPingProcedure,
 		svc.Ping,
@@ -240,8 +218,6 @@ func NewConnectExecutorHandler(svc ConnectExecutorHandler, opts ...connect.Handl
 		switch r.URL.Path {
 		case ConnectExecutorReplyProcedure:
 			connectExecutorReplyHandler.ServeHTTP(w, r)
-		case ConnectExecutorAckProcedure:
-			connectExecutorAckHandler.ServeHTTP(w, r)
 		case ConnectExecutorPingProcedure:
 			connectExecutorPingHandler.ServeHTTP(w, r)
 		default:
@@ -255,10 +231,6 @@ type UnimplementedConnectExecutorHandler struct{}
 
 func (UnimplementedConnectExecutorHandler) Reply(context.Context, *connect.Request[v1.ReplyRequest]) (*connect.Response[v1.ReplyResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.v1.ConnectExecutor.Reply is not implemented"))
-}
-
-func (UnimplementedConnectExecutorHandler) Ack(context.Context, *connect.Request[v1.AckMessage]) (*connect.Response[v1.AckResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.v1.ConnectExecutor.Ack is not implemented"))
 }
 
 func (UnimplementedConnectExecutorHandler) Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {

--- a/proto/gen/connect/v1/service.pb.go
+++ b/proto/gen/connect/v1/service.pb.go
@@ -9,7 +9,6 @@ package connect
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
-	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -286,108 +285,12 @@ func (x *ReplyResponse) GetSuccess() bool {
 	return false
 }
 
-type AckMessage struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	Ts            *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=ts,proto3" json:"ts,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *AckMessage) Reset() {
-	*x = AckMessage{}
-	mi := &file_connect_v1_service_proto_msgTypes[6]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AckMessage) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AckMessage) ProtoMessage() {}
-
-func (x *AckMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_connect_v1_service_proto_msgTypes[6]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use AckMessage.ProtoReflect.Descriptor instead.
-func (*AckMessage) Descriptor() ([]byte, []int) {
-	return file_connect_v1_service_proto_rawDescGZIP(), []int{6}
-}
-
-func (x *AckMessage) GetRequestId() string {
-	if x != nil {
-		return x.RequestId
-	}
-	return ""
-}
-
-func (x *AckMessage) GetTs() *timestamppb.Timestamp {
-	if x != nil {
-		return x.Ts
-	}
-	return nil
-}
-
-type AckResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *AckResponse) Reset() {
-	*x = AckResponse{}
-	mi := &file_connect_v1_service_proto_msgTypes[7]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AckResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AckResponse) ProtoMessage() {}
-
-func (x *AckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_connect_v1_service_proto_msgTypes[7]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use AckResponse.ProtoReflect.Descriptor instead.
-func (*AckResponse) Descriptor() ([]byte, []int) {
-	return file_connect_v1_service_proto_rawDescGZIP(), []int{7}
-}
-
-func (x *AckResponse) GetSuccess() bool {
-	if x != nil {
-		return x.Success
-	}
-	return false
-}
-
 var File_connect_v1_service_proto protoreflect.FileDescriptor
 
 const file_connect_v1_service_proto_rawDesc = "" +
 	"\n" +
 	"\x18connect/v1/service.proto\x12\n" +
-	"connect.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x18connect/v1/connect.proto\"p\n" +
+	"connect.v1\x1a\x18connect/v1/connect.proto\"p\n" +
 	"\x0eForwardRequest\x12\"\n" +
 	"\fconnectionID\x18\x01 \x01(\tR\fconnectionID\x12:\n" +
 	"\x04data\x18\x02 \x01(\v2&.connect.v1.GatewayExecutorRequestDataR\x04data\"+\n" +
@@ -399,20 +302,12 @@ const file_connect_v1_service_proto_rawDesc = "" +
 	"\fReplyRequest\x12+\n" +
 	"\x04data\x18\x01 \x01(\v2\x17.connect.v1.SDKResponseR\x04data\")\n" +
 	"\rReplyResponse\x12\x18\n" +
-	"\asuccess\x18\x01 \x01(\bR\asuccess\"W\n" +
-	"\n" +
-	"AckMessage\x12\x1d\n" +
-	"\n" +
-	"request_id\x18\x01 \x01(\tR\trequestId\x12*\n" +
-	"\x02ts\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x02ts\"'\n" +
-	"\vAckResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess2\x93\x01\n" +
 	"\x0eConnectGateway\x12D\n" +
 	"\aForward\x12\x1a.connect.v1.ForwardRequest\x1a\x1b.connect.v1.ForwardResponse\"\x00\x12;\n" +
-	"\x04Ping\x12\x17.connect.v1.PingRequest\x1a\x18.connect.v1.PingResponse\"\x002\xc8\x01\n" +
+	"\x04Ping\x12\x17.connect.v1.PingRequest\x1a\x18.connect.v1.PingResponse\"\x002\x8e\x01\n" +
 	"\x0fConnectExecutor\x12>\n" +
-	"\x05Reply\x12\x18.connect.v1.ReplyRequest\x1a\x19.connect.v1.ReplyResponse\"\x00\x128\n" +
-	"\x03Ack\x12\x16.connect.v1.AckMessage\x1a\x17.connect.v1.AckResponse\"\x00\x12;\n" +
+	"\x05Reply\x12\x18.connect.v1.ReplyRequest\x1a\x19.connect.v1.ReplyResponse\"\x00\x12;\n" +
 	"\x04Ping\x12\x17.connect.v1.PingRequest\x1a\x18.connect.v1.PingResponse\"\x00B9Z7github.com/inngest/inngest/proto/gen/connect/v1;connectb\x06proto3"
 
 var (
@@ -427,7 +322,7 @@ func file_connect_v1_service_proto_rawDescGZIP() []byte {
 	return file_connect_v1_service_proto_rawDescData
 }
 
-var file_connect_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_connect_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_connect_v1_service_proto_goTypes = []any{
 	(*ForwardRequest)(nil),             // 0: connect.v1.ForwardRequest
 	(*ForwardResponse)(nil),            // 1: connect.v1.ForwardResponse
@@ -435,31 +330,25 @@ var file_connect_v1_service_proto_goTypes = []any{
 	(*PingResponse)(nil),               // 3: connect.v1.PingResponse
 	(*ReplyRequest)(nil),               // 4: connect.v1.ReplyRequest
 	(*ReplyResponse)(nil),              // 5: connect.v1.ReplyResponse
-	(*AckMessage)(nil),                 // 6: connect.v1.AckMessage
-	(*AckResponse)(nil),                // 7: connect.v1.AckResponse
-	(*GatewayExecutorRequestData)(nil), // 8: connect.v1.GatewayExecutorRequestData
-	(*SDKResponse)(nil),                // 9: connect.v1.SDKResponse
-	(*timestamppb.Timestamp)(nil),      // 10: google.protobuf.Timestamp
+	(*GatewayExecutorRequestData)(nil), // 6: connect.v1.GatewayExecutorRequestData
+	(*SDKResponse)(nil),                // 7: connect.v1.SDKResponse
 }
 var file_connect_v1_service_proto_depIdxs = []int32{
-	8,  // 0: connect.v1.ForwardRequest.data:type_name -> connect.v1.GatewayExecutorRequestData
-	9,  // 1: connect.v1.ReplyRequest.data:type_name -> connect.v1.SDKResponse
-	10, // 2: connect.v1.AckMessage.ts:type_name -> google.protobuf.Timestamp
-	0,  // 3: connect.v1.ConnectGateway.Forward:input_type -> connect.v1.ForwardRequest
-	2,  // 4: connect.v1.ConnectGateway.Ping:input_type -> connect.v1.PingRequest
-	4,  // 5: connect.v1.ConnectExecutor.Reply:input_type -> connect.v1.ReplyRequest
-	6,  // 6: connect.v1.ConnectExecutor.Ack:input_type -> connect.v1.AckMessage
-	2,  // 7: connect.v1.ConnectExecutor.Ping:input_type -> connect.v1.PingRequest
-	1,  // 8: connect.v1.ConnectGateway.Forward:output_type -> connect.v1.ForwardResponse
-	3,  // 9: connect.v1.ConnectGateway.Ping:output_type -> connect.v1.PingResponse
-	5,  // 10: connect.v1.ConnectExecutor.Reply:output_type -> connect.v1.ReplyResponse
-	7,  // 11: connect.v1.ConnectExecutor.Ack:output_type -> connect.v1.AckResponse
-	3,  // 12: connect.v1.ConnectExecutor.Ping:output_type -> connect.v1.PingResponse
-	8,  // [8:13] is the sub-list for method output_type
-	3,  // [3:8] is the sub-list for method input_type
-	3,  // [3:3] is the sub-list for extension type_name
-	3,  // [3:3] is the sub-list for extension extendee
-	0,  // [0:3] is the sub-list for field type_name
+	6, // 0: connect.v1.ForwardRequest.data:type_name -> connect.v1.GatewayExecutorRequestData
+	7, // 1: connect.v1.ReplyRequest.data:type_name -> connect.v1.SDKResponse
+	0, // 2: connect.v1.ConnectGateway.Forward:input_type -> connect.v1.ForwardRequest
+	2, // 3: connect.v1.ConnectGateway.Ping:input_type -> connect.v1.PingRequest
+	4, // 4: connect.v1.ConnectExecutor.Reply:input_type -> connect.v1.ReplyRequest
+	2, // 5: connect.v1.ConnectExecutor.Ping:input_type -> connect.v1.PingRequest
+	1, // 6: connect.v1.ConnectGateway.Forward:output_type -> connect.v1.ForwardResponse
+	3, // 7: connect.v1.ConnectGateway.Ping:output_type -> connect.v1.PingResponse
+	5, // 8: connect.v1.ConnectExecutor.Reply:output_type -> connect.v1.ReplyResponse
+	3, // 9: connect.v1.ConnectExecutor.Ping:output_type -> connect.v1.PingResponse
+	6, // [6:10] is the sub-list for method output_type
+	2, // [2:6] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	2, // [2:2] is the sub-list for extension extendee
+	0, // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_connect_v1_service_proto_init() }
@@ -474,7 +363,7 @@ func file_connect_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_connect_v1_service_proto_rawDesc), len(file_connect_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/proto/gen/connect/v1/service_grpc.pb.go
+++ b/proto/gen/connect/v1/service_grpc.pb.go
@@ -160,7 +160,6 @@ var ConnectGateway_ServiceDesc = grpc.ServiceDesc{
 
 const (
 	ConnectExecutor_Reply_FullMethodName = "/connect.v1.ConnectExecutor/Reply"
-	ConnectExecutor_Ack_FullMethodName   = "/connect.v1.ConnectExecutor/Ack"
 	ConnectExecutor_Ping_FullMethodName  = "/connect.v1.ConnectExecutor/Ping"
 )
 
@@ -169,7 +168,6 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type ConnectExecutorClient interface {
 	Reply(ctx context.Context, in *ReplyRequest, opts ...grpc.CallOption) (*ReplyResponse, error)
-	Ack(ctx context.Context, in *AckMessage, opts ...grpc.CallOption) (*AckResponse, error)
 	Ping(ctx context.Context, in *PingRequest, opts ...grpc.CallOption) (*PingResponse, error)
 }
 
@@ -191,16 +189,6 @@ func (c *connectExecutorClient) Reply(ctx context.Context, in *ReplyRequest, opt
 	return out, nil
 }
 
-func (c *connectExecutorClient) Ack(ctx context.Context, in *AckMessage, opts ...grpc.CallOption) (*AckResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(AckResponse)
-	err := c.cc.Invoke(ctx, ConnectExecutor_Ack_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
 func (c *connectExecutorClient) Ping(ctx context.Context, in *PingRequest, opts ...grpc.CallOption) (*PingResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(PingResponse)
@@ -216,7 +204,6 @@ func (c *connectExecutorClient) Ping(ctx context.Context, in *PingRequest, opts 
 // for forward compatibility.
 type ConnectExecutorServer interface {
 	Reply(context.Context, *ReplyRequest) (*ReplyResponse, error)
-	Ack(context.Context, *AckMessage) (*AckResponse, error)
 	Ping(context.Context, *PingRequest) (*PingResponse, error)
 	mustEmbedUnimplementedConnectExecutorServer()
 }
@@ -230,9 +217,6 @@ type UnimplementedConnectExecutorServer struct{}
 
 func (UnimplementedConnectExecutorServer) Reply(context.Context, *ReplyRequest) (*ReplyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Reply not implemented")
-}
-func (UnimplementedConnectExecutorServer) Ack(context.Context, *AckMessage) (*AckResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method Ack not implemented")
 }
 func (UnimplementedConnectExecutorServer) Ping(context.Context, *PingRequest) (*PingResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Ping not implemented")
@@ -276,24 +260,6 @@ func _ConnectExecutor_Reply_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ConnectExecutor_Ack_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(AckMessage)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(ConnectExecutorServer).Ack(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: ConnectExecutor_Ack_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ConnectExecutorServer).Ack(ctx, req.(*AckMessage))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
 func _ConnectExecutor_Ping_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(PingRequest)
 	if err := dec(in); err != nil {
@@ -322,10 +288,6 @@ var ConnectExecutor_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Reply",
 			Handler:    _ConnectExecutor_Reply_Handler,
-		},
-		{
-			MethodName: "Ack",
-			Handler:    _ConnectExecutor_Ack_Handler,
 		},
 		{
 			MethodName: "Ping",


### PR DESCRIPTION
## Description

Follow-up to https://github.com/inngest/inngest/pull/4215. Removes the temporary executor ACK RPC retained for that rollout.

## Release note

None

## Migration note

None