### PR TITLE
fix(dashboard): allow vercel and do marketplace users to manage api keys

### DIFF
--- a/ui/apps/dashboard/src/components/APIKeys/permissions.test.ts
+++ b/ui/apps/dashboard/src/components/APIKeys/permissions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { canManageAPIKeys } from './permissions';
+
+describe('canManageAPIKeys', () => {
+  it('allows Clerk organization admins', () => {
+    expect(
+      canManageAPIKeys({
+        isMarketplace: false,
+        organizationRole: 'org:admin',
+      }),
+    ).toBe(true);
+  });
+
+  it('allows marketplace users without a Clerk organization role', () => {
+    expect(
+      canManageAPIKeys({
+        isMarketplace: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('denies non-admin Clerk organization members', () => {
+    expect(
+      canManageAPIKeys({
+        isMarketplace: false,
+        organizationRole: 'org:member',
+      }),
+    ).toBe(false);
+  });
+});

--- a/ui/apps/dashboard/src/components/APIKeys/permissions.test.ts
+++ b/ui/apps/dashboard/src/components/APIKeys/permissions.test.ts
@@ -1,29 +1,36 @@
 import { describe, expect, it } from 'vitest';
 
+import { Marketplace } from '@/gql/graphql';
 import { canManageAPIKeys } from './permissions';
 
 describe('canManageAPIKeys', () => {
   it('allows Clerk organization admins', () => {
     expect(
       canManageAPIKeys({
-        isMarketplace: false,
+        marketplace: null,
         organizationRole: 'org:admin',
       }),
     ).toBe(true);
   });
 
-  it('allows marketplace users without a Clerk organization role', () => {
-    expect(
-      canManageAPIKeys({
-        isMarketplace: true,
-      }),
-    ).toBe(true);
-  });
+  it.each([Marketplace.Vercel, Marketplace.DigitalOcean])(
+    'allows %s marketplace users without a Clerk organization role',
+    (marketplace) => {
+      expect(canManageAPIKeys({ marketplace })).toBe(true);
+    },
+  );
+
+  it.each([Marketplace.Aws, Marketplace.Partner])(
+    'does not infer admin access for %s accounts',
+    (marketplace) => {
+      expect(canManageAPIKeys({ marketplace })).toBe(false);
+    },
+  );
 
   it('denies non-admin Clerk organization members', () => {
     expect(
       canManageAPIKeys({
-        isMarketplace: false,
+        marketplace: null,
         organizationRole: 'org:member',
       }),
     ).toBe(false);

--- a/ui/apps/dashboard/src/components/APIKeys/permissions.ts
+++ b/ui/apps/dashboard/src/components/APIKeys/permissions.ts
@@ -1,0 +1,12 @@
+type APIKeyPermissions = {
+  isMarketplace: boolean;
+  organizationRole?: string;
+};
+
+export const canManageAPIKeys = ({
+  isMarketplace,
+  organizationRole,
+}: APIKeyPermissions) => {
+  // Marketplace sessions use JWT auth and have no Clerk organization role.
+  return isMarketplace || organizationRole === 'org:admin';
+};

--- a/ui/apps/dashboard/src/components/APIKeys/permissions.ts
+++ b/ui/apps/dashboard/src/components/APIKeys/permissions.ts
@@ -1,12 +1,18 @@
+import { Marketplace } from '@/gql/graphql';
+
 type APIKeyPermissions = {
-  isMarketplace: boolean;
+  marketplace: Marketplace | null;
   organizationRole?: string;
 };
 
 export const canManageAPIKeys = ({
-  isMarketplace,
+  marketplace,
   organizationRole,
 }: APIKeyPermissions) => {
-  // Marketplace sessions use JWT auth and have no Clerk organization role.
-  return isMarketplace || organizationRole === 'org:admin';
+  // Vercel and DigitalOcean sessions use their provisioned admin over JWT.
+  return (
+    marketplace === Marketplace.Vercel ||
+    marketplace === Marketplace.DigitalOcean ||
+    organizationRole === 'org:admin'
+  );
 };

--- a/ui/apps/dashboard/src/queries/server/profile.ts
+++ b/ui/apps/dashboard/src/queries/server/profile.ts
@@ -1,4 +1,5 @@
 import { graphql } from '@/gql';
+import { type Marketplace } from '@/gql/graphql';
 import {
   auth,
   clerkClient,
@@ -16,6 +17,7 @@ export type ProfileType = {
 
 export type ProfileDisplayType = {
   isMarketplace: boolean;
+  marketplace: Marketplace | null;
   orgName?: string;
   displayName: string;
   orgProfilePic: string | null;
@@ -60,6 +62,7 @@ export const getProfileDisplay = createServerFn({
 
   return {
     isMarketplace: Boolean(res.account.marketplace),
+    marketplace: res.account.marketplace,
     orgName,
     displayName,
     orgProfilePic,

--- a/ui/apps/dashboard/src/routes/_authed/settings/api-keys/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/settings/api-keys/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@inngest/components/Tooltip';
 import { useOrganization } from '@clerk/tanstack-react-start';
 import { RiAddLine } from '@remixicon/react';
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, getRouteApi } from '@tanstack/react-router';
 
 import LoadingIcon from '@/components/Icons/LoadingIcon';
 import { APIKeysEmptyState } from '@/components/APIKeys/EmptyState';
@@ -20,17 +20,23 @@ import { CreateAPIKeyModal } from '@/components/APIKeys/CreateAPIKeyModal';
 import { DeleteAPIKeyModal } from '@/components/APIKeys/DeleteAPIKeyModal';
 import { RenameAPIKeyModal } from '@/components/APIKeys/RenameAPIKeyModal';
 import { useAPIKeys } from '@/components/APIKeys/useAPIKeys';
+import { canManageAPIKeys } from '@/components/APIKeys/permissions';
 
 export const Route = createFileRoute('/_authed/settings/api-keys/')({
   component: APIKeysPage,
 });
 
 const ADMIN_TOOLTIP = 'Only organization admins can manage API keys.';
+const authedRoute = getRouteApi('/_authed');
 
 function APIKeysPage() {
   const res = useAPIKeys();
+  const { profile } = authedRoute.useLoaderData();
   const { membership, isLoaded: orgLoaded } = useOrganization();
-  const isAdmin = membership?.role === 'org:admin';
+  const canManage = canManageAPIKeys({
+    isMarketplace: profile.isMarketplace,
+    organizationRole: membership?.role,
+  });
 
   // Create modal state is owned here so it survives the empty->populated
   // transition that unmounts the EmptyState.
@@ -41,7 +47,7 @@ function APIKeysPage() {
   if (res.error) {
     throw res.error;
   }
-  if ((res.isLoading && !res.data) || !orgLoaded) {
+  if ((res.isLoading && !res.data) || (!profile.isMarketplace && !orgLoaded)) {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <LoadingIcon />
@@ -64,7 +70,7 @@ function APIKeysPage() {
       iconSide="left"
       label="Create API key"
       onClick={() => setCreateOpen(true)}
-      disabled={!isAdmin}
+      disabled={!canManage}
     />
   );
 
@@ -85,7 +91,7 @@ function APIKeysPage() {
             </Link>
           </p>
         </div>
-        {isAdmin ? (
+        {canManage ? (
           createButton
         ) : (
           <Tooltip>
@@ -100,13 +106,13 @@ function APIKeysPage() {
       {keys.length === 0 ? (
         <APIKeysEmptyState
           onCreate={() => setCreateOpen(true)}
-          canCreate={isAdmin}
+          canCreate={canManage}
           disabledTooltip={ADMIN_TOOLTIP}
         />
       ) : (
         <APIKeysTable
           keys={keys}
-          canManage={isAdmin}
+          canManage={canManage}
           onRename={setRenameTarget}
           onDelete={setDeleteTarget}
         />

--- a/ui/apps/dashboard/src/routes/_authed/settings/api-keys/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/settings/api-keys/index.tsx
@@ -34,7 +34,7 @@ function APIKeysPage() {
   const { profile } = authedRoute.useLoaderData();
   const { membership, isLoaded: orgLoaded } = useOrganization();
   const canManage = canManageAPIKeys({
-    isMarketplace: profile.isMarketplace,
+    marketplace: profile.marketplace,
     organizationRole: membership?.role,
   });
 
@@ -47,7 +47,7 @@ function APIKeysPage() {
   if (res.error) {
     throw res.error;
   }
-  if ((res.isLoading && !res.data) || (!profile.isMarketplace && !orgLoaded)) {
+  if ((res.isLoading && !res.data) || (!canManage && !orgLoaded)) {
     return (
       <div className="flex h-full w-full items-center justify-center">
         <LoadingIcon />


### PR DESCRIPTION
## Summary

when we restricted access for api creation to admins only, we used clerks useOrg hook for this, which broke api creation for vercel and do marketplace users because they use plain jwt. since vercel and do marketplace users are by definition admins, we can simply enable for them.

## Release note

fixes api key generation for vercel marketplace users.

## Migration note

None.
