### PR TITLE
feat(ai): add run-level AI usage summary

### DIFF
--- a/pkg/cqrs/manager/ai_summary_test.go
+++ b/pkg/cqrs/manager/ai_summary_test.go
@@ -1,0 +1,372 @@
+package manager
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testTraceID = "trace-ai-summary"
+	testRunID   = "01HQ4T3Z8B0000000000000000"
+)
+
+var testStart = time.Date(2026, 3, 17, 12, 0, 0, 0, time.UTC)
+
+// attrEncoding selects how a fragment's attributes field is delivered by the
+// backend: sqlite's json_object embeds the JSON column as a quoted string,
+// while postgres' json_build_object embeds jsonb as a nested object.
+type attrEncoding string
+
+const (
+	encodingSQLite   attrEncoding = "sqlite"
+	encodingPostgres attrEncoding = "postgres"
+)
+
+func eachEncoding(t *testing.T, fn func(t *testing.T, enc attrEncoding)) {
+	t.Helper()
+	for _, enc := range []attrEncoding{encodingSQLite, encodingPostgres} {
+		t.Run(string(enc), func(t *testing.T) { fn(t, enc) })
+	}
+}
+
+func encodeFragmentAttributes(t *testing.T, enc attrEncoding, rows []testSpanRow) {
+	t.Helper()
+	if enc != encodingSQLite {
+		return
+	}
+	for _, row := range rows {
+		for _, fragment := range row.fragments {
+			attrs, ok := fragment["attributes"].(map[string]any)
+			if !ok {
+				continue
+			}
+			raw, err := json.Marshal(attrs)
+			require.NoError(t, err)
+			fragment["attributes"] = string(raw)
+		}
+	}
+}
+
+type testSpanRow struct {
+	dynamicSpanID string
+	parentSpanID  string
+	fragments     []map[string]any
+}
+
+func (r testSpanRow) GetTraceID() string { return testTraceID }
+func (r testSpanRow) GetRunID() string   { return testRunID }
+func (r testSpanRow) GetDynamicSpanID() sql.NullString {
+	return sql.NullString{String: r.dynamicSpanID, Valid: r.dynamicSpanID != ""}
+}
+func (r testSpanRow) GetParentSpanID() sql.NullString {
+	return sql.NullString{String: r.parentSpanID, Valid: r.parentSpanID != ""}
+}
+func (r testSpanRow) GetStartTime() interface{} { return testStart }
+func (r testSpanRow) GetEndTime() interface{}   { return testStart.Add(time.Second) }
+func (r testSpanRow) GetSpanFragments() any {
+	raw, err := json.Marshal(r.fragments)
+	if err != nil {
+		panic(err)
+	}
+	return json.RawMessage(raw)
+}
+
+func runRow() testSpanRow {
+	return testSpanRow{
+		dynamicSpanID: "root",
+		fragments: []map[string]any{{
+			"span_id": "otel-root",
+			"name":    meta.SpanNameRun,
+		}},
+	}
+}
+
+func stepRow(id string, attrs map[string]any) testSpanRow {
+	fragment := map[string]any{
+		"span_id": "otel-" + id,
+		"name":    meta.SpanNameStep,
+	}
+	if attrs != nil {
+		fragment["attributes"] = attrs
+	}
+	return testSpanRow{
+		dynamicSpanID: id,
+		parentSpanID:  "root",
+		fragments:     []map[string]any{fragment},
+	}
+}
+
+// aiMetadataFragment mirrors the fragment shape a metadata span row carries in
+// the DB: the four _inngest.metadata.* attribute keys written by
+// tracing.RawMetadataAttrs, with values as a JSON-encoded string.
+func aiMetadataFragment(t *testing.T, scope metadata.Scope, values map[string]any) map[string]any {
+	t.Helper()
+	raw, err := json.Marshal(values)
+	require.NoError(t, err)
+	scopeText, err := scope.MarshalText()
+	require.NoError(t, err)
+	opText, err := enums.MetadataOpcodeMerge.MarshalText()
+	require.NoError(t, err)
+	return map[string]any{
+		"name": meta.SpanNameMetadata,
+		"attributes": map[string]any{
+			"_inngest.metadata.kind":   extractors.KindInngestAI.String(),
+			"_inngest.metadata.scope":  string(scopeText),
+			"_inngest.metadata.op":     string(opText),
+			"_inngest.metadata.values": string(raw),
+		},
+	}
+}
+
+func aiMetadataRow(id, parent string, fragments ...map[string]any) testSpanRow {
+	return testSpanRow{
+		dynamicSpanID: id,
+		parentSpanID:  parent,
+		fragments:     fragments,
+	}
+}
+
+var (
+	stepCallA = map[string]any{
+		"input_tokens": 37, "output_tokens": 10, "total_tokens": 47,
+		"estimated_cost": 0.000073, "latency_ms": 2246.002685546875,
+		"provider": "openai", "request_model": "gpt-5.4-mini",
+		"response_model": "gpt-5.4-mini-2026-03-17",
+	}
+	stepCallB = map[string]any{
+		"input_tokens": 30, "output_tokens": 19, "total_tokens": 49,
+		"estimated_cost": 0.000108, "latency_ms": 1737.404052734375,
+		"provider": "openai", "request_model": "gpt-5.4-mini",
+		"response_model": "gpt-5.4-mini-2026-03-17",
+	}
+	inferCall = map[string]any{
+		"input_tokens": 42, "output_tokens": 17, "total_tokens": 59,
+		"estimated_cost": 0.000275, "latency_ms": 661,
+		"provider": "openai-chat", "request_model": "gpt-4o",
+		"response_model": "gpt-4o-2024-08-06",
+	}
+	runCall = map[string]any{
+		"input_tokens": 11, "output_tokens": 3,
+		"estimated_cost": 0.000012,
+		"provider":       "anthropic", "request_model": "claude-opus-5",
+	}
+)
+
+func buildRoot(t *testing.T, enc attrEncoding, rows []testSpanRow) *cqrs.OtelSpan {
+	t.Helper()
+	encodeFragmentAttributes(t, enc, rows)
+	root, err := mapRootSpansFromRows(context.Background(), rows)
+	require.NoError(t, err)
+	return root
+}
+
+func findAISummaries(root *cqrs.OtelSpan) []*cqrs.SpanMetadata {
+	var found []*cqrs.SpanMetadata
+	for _, md := range root.Metadata {
+		if md.Kind == extractors.KindInngestAISummary {
+			found = append(found, md)
+		}
+	}
+	return found
+}
+
+func requireSummary(t *testing.T, root *cqrs.OtelSpan) extractors.AISummaryMetadata {
+	t.Helper()
+	found := findAISummaries(root)
+	require.Len(t, found, 1)
+	require.Equal(t, enums.MetadataScopeRun, found[0].Scope)
+	summary, err := extractors.AISummaryFromValues(found[0].Values)
+	require.NoError(t, err)
+	return summary
+}
+
+func TestAISummarySumsAcrossScopes(t *testing.T) {
+	eachEncoding(t, func(t *testing.T, enc attrEncoding) {
+		rows := []testSpanRow{
+			runRow(),
+			stepRow("step-a", nil),
+			stepRow("step-b", nil),
+			aiMetadataRow("md-step-a", "step-a", aiMetadataFragment(t, enums.MetadataScopeStep, stepCallA)),
+			aiMetadataRow("md-step-b", "step-b", aiMetadataFragment(t, enums.MetadataScopeStep, stepCallB)),
+			// The extended_trace entries are the same calls re-reported, and must
+			// not be counted twice.
+			aiMetadataRow("md-ext-a", "step-a", aiMetadataFragment(t, enums.MetadataScopeExtendedTrace, stepCallA)),
+			aiMetadataRow("md-ext-b", "step-b", aiMetadataFragment(t, enums.MetadataScopeExtendedTrace, stepCallB)),
+			aiMetadataRow("md-attempt", "step-b", aiMetadataFragment(t, enums.MetadataScopeStepAttempt, inferCall)),
+			// Run-scoped usage on a metadata span with no parent still counts.
+			aiMetadataRow("md-run", "", aiMetadataFragment(t, enums.MetadataScopeRun, runCall)),
+		}
+
+		summary := requireSummary(t, buildRoot(t, enc, rows))
+
+		require.Equal(t, int64(37+30+42+11), summary.InputTokens)
+		require.Equal(t, int64(10+19+17+3), summary.OutputTokens)
+		require.Equal(t, int64(47+49+59+14), summary.TotalTokens)
+		require.NotNil(t, summary.EstimatedCost)
+		require.InDelta(t, 0.000073+0.000108+0.000275+0.000012, *summary.EstimatedCost, 1e-12)
+		require.Equal(t, []string{"claude-opus-5", "gpt-4o-2024-08-06", "gpt-5.4-mini-2026-03-17"}, summary.Models)
+		require.Equal(t, []string{"anthropic", "openai", "openai-chat"}, summary.Providers)
+	})
+}
+
+func TestAISummaryExtendedTraceOnlyCounts(t *testing.T) {
+	eachEncoding(t, func(t *testing.T, enc attrEncoding) {
+		rows := []testSpanRow{
+			runRow(),
+			stepRow("step-a", nil),
+			aiMetadataRow("md-ext", "step-a", aiMetadataFragment(t, enums.MetadataScopeExtendedTrace, inferCall)),
+		}
+
+		summary := requireSummary(t, buildRoot(t, enc, rows))
+
+		require.Equal(t, int64(42), summary.InputTokens)
+		require.Equal(t, int64(17), summary.OutputTokens)
+		require.Equal(t, int64(59), summary.TotalTokens)
+		require.Equal(t, []string{"gpt-4o-2024-08-06"}, summary.Models)
+		require.Equal(t, []string{"openai-chat"}, summary.Providers)
+	})
+}
+
+func TestAISummaryMultipleEmissionsOneDynamicSpanSum(t *testing.T) {
+	// Two emissions share one dynamic span ID. The rollup's merge opcode is
+	// last-write-wins, so the summary must be seeded from the raw fragments or
+	// the first call's usage is silently dropped.
+	eachEncoding(t, func(t *testing.T, enc attrEncoding) {
+		rows := []testSpanRow{
+			runRow(),
+			stepRow("step-a", nil),
+			aiMetadataRow("md-multi", "step-a",
+				aiMetadataFragment(t, enums.MetadataScopeStep, stepCallA),
+				aiMetadataFragment(t, enums.MetadataScopeStep, stepCallB),
+			),
+		}
+
+		summary := requireSummary(t, buildRoot(t, enc, rows))
+
+		require.Equal(t, int64(37+30), summary.InputTokens)
+		require.Equal(t, int64(10+19), summary.OutputTokens)
+		require.Equal(t, int64(47+49), summary.TotalTokens)
+		require.NotNil(t, summary.EstimatedCost)
+		require.InDelta(t, 0.000073+0.000108, *summary.EstimatedCost, 1e-12)
+	})
+}
+
+func TestAISummaryAbsentWithoutAI(t *testing.T) {
+	eachEncoding(t, func(t *testing.T, enc attrEncoding) {
+		rows := []testSpanRow{
+			runRow(),
+			stepRow("step-a", nil),
+		}
+
+		root := buildRoot(t, enc, rows)
+		require.Empty(t, findAISummaries(root))
+	})
+}
+
+// aiMetadataAttributes builds the stored attributes blob for an inngest.ai
+// metadata span the way tracer_sqlc.go does, so a rename of any
+// _inngest.metadata.* key breaks these tests rather than silently passing.
+func aiMetadataAttributes(t *testing.T, scope metadata.Scope, values map[string]any) []byte {
+	t.Helper()
+
+	var v metadata.Values
+	require.NoError(t, v.FromStruct(values))
+
+	attrs := tracing.RawMetadataAttrs(extractors.KindInngestAI, v, enums.MetadataOpcodeMerge)
+	meta.AddAttr(attrs, meta.Attrs.MetadataScope, &scope)
+
+	out := map[string]any{}
+	for _, kv := range attrs.Serialize() {
+		out[string(kv.Key)] = kv.Value.AsInterface()
+	}
+
+	raw, err := json.Marshal(out)
+	require.NoError(t, err)
+	return raw
+}
+
+// insertRunScopedAI writes a root span plus one metadata span per call, all
+// sharing a single dynamic span ID. Two run-scoped AddRunMetadata POSTs collide
+// this way: the parent comes from the run and the dynamic span ID from
+// (parent, kind), so distinct calls differ only in span_id.
+func insertRunScopedAI(t *testing.T, cm cqrs.Manager, calls ...map[string]any) *cqrs.OtelSpan {
+	t.Helper()
+
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+	traceID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID.String(),
+		TraceID:       traceID,
+		DynamicSpanID: "dyn-root",
+		Name:          meta.SpanNameRun,
+	})
+
+	for _, call := range calls {
+		insertTestSpan(t, cm, testSpanFields{
+			RunID:         runID.String(),
+			TraceID:       traceID,
+			DynamicSpanID: "dyn-ai",
+			ParentSpanID:  "dyn-root",
+			Name:          meta.SpanNameMetadata,
+			Attributes:    aiMetadataAttributes(t, enums.MetadataScopeRun, call),
+		})
+	}
+
+	root, err := cm.GetSpansByRunID(t.Context(), runID)
+	require.NoError(t, err)
+	require.NotNil(t, root)
+	return root
+}
+
+func TestAISummaryRunScopedDistinctCallsSum(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	root := insertRunScopedAI(t, cm, stepCallA, stepCallB)
+	summary := requireSummary(t, root)
+
+	require.Equal(t, int64(37+30), summary.InputTokens)
+	require.Equal(t, int64(10+19), summary.OutputTokens)
+	require.Equal(t, int64(47+49), summary.TotalTokens)
+
+	// inngest.ai merges last-write-wins, so the entry the span itself carries
+	// holds a single call's values while the summary holds both. Which call
+	// wins is left to fragment order, which the sqlite query does not pin.
+	var stored []*cqrs.SpanMetadata
+	for _, md := range root.Metadata {
+		if md.Kind == extractors.KindInngestAI {
+			stored = append(stored, md)
+		}
+	}
+	require.Len(t, stored, 1)
+	var storedInput int64
+	require.NoError(t, json.Unmarshal(stored[0].Values["input_tokens"], &storedInput))
+	require.Contains(t, []int64{37, 30}, storedInput)
+}
+
+func TestAISummaryRunScopedIdenticalCallsBothCount(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	// Identical payloads are legitimately reachable (temperature 0, cache
+	// hits), so the fold must not dedupe on the values blob.
+	root := insertRunScopedAI(t, cm, stepCallA, stepCallA)
+	summary := requireSummary(t, root)
+
+	require.Equal(t, int64(37*2), summary.InputTokens)
+	require.Equal(t, int64(10*2), summary.OutputTokens)
+}

--- a/pkg/cqrs/manager/ai_summary_test.go
+++ b/pkg/cqrs/manager/ai_summary_test.go
@@ -240,10 +240,11 @@ func TestAISummaryExtendedTraceOnlyCounts(t *testing.T) {
 	})
 }
 
-func TestAISummaryMultipleEmissionsOneDynamicSpanSum(t *testing.T) {
-	// Two emissions share one dynamic span ID. The rollup's merge opcode is
-	// last-write-wins, so the summary must be seeded from the raw fragments or
-	// the first call's usage is silently dropped.
+func TestAISummaryMultipleEmissionsOneDynamicSpanMerge(t *testing.T) {
+	// Two emissions share one dynamic span ID. The merge opcode makes the
+	// later one a per-key update of the same entry — not a new call — so the
+	// summary counts the merged entry once, matching the state the span
+	// itself carries.
 	eachEncoding(t, func(t *testing.T, enc attrEncoding) {
 		rows := []testSpanRow{
 			runRow(),
@@ -256,11 +257,34 @@ func TestAISummaryMultipleEmissionsOneDynamicSpanSum(t *testing.T) {
 
 		summary := requireSummary(t, buildRoot(t, enc, rows))
 
-		require.Equal(t, int64(37+30), summary.InputTokens)
-		require.Equal(t, int64(10+19), summary.OutputTokens)
-		require.Equal(t, int64(47+49), summary.TotalTokens)
+		require.Equal(t, int64(30), summary.InputTokens)
+		require.Equal(t, int64(19), summary.OutputTokens)
+		require.Equal(t, int64(49), summary.TotalTokens)
 		require.NotNil(t, summary.EstimatedCost)
-		require.InDelta(t, 0.000073+0.000108, *summary.EstimatedCost, 1e-12)
+		require.InDelta(t, 0.000108, *summary.EstimatedCost, 1e-12)
+	})
+}
+
+func TestAISummaryPartialUpdateNotDoubleCounted(t *testing.T) {
+	// A later emission carrying only a corrected cost updates the entry's
+	// cost in place; its tokens and original cost must not be summed again.
+	eachEncoding(t, func(t *testing.T, enc attrEncoding) {
+		rows := []testSpanRow{
+			runRow(),
+			stepRow("step-a", nil),
+			aiMetadataRow("md-update", "step-a",
+				aiMetadataFragment(t, enums.MetadataScopeStep, stepCallA),
+				aiMetadataFragment(t, enums.MetadataScopeStep, map[string]any{"estimated_cost": 0.0002}),
+			),
+		}
+
+		summary := requireSummary(t, buildRoot(t, enc, rows))
+
+		require.Equal(t, int64(37), summary.InputTokens)
+		require.Equal(t, int64(10), summary.OutputTokens)
+		require.Equal(t, int64(47), summary.TotalTokens)
+		require.NotNil(t, summary.EstimatedCost)
+		require.InDelta(t, 0.0002, *summary.EstimatedCost, 1e-12)
 	})
 }
 
@@ -301,7 +325,8 @@ func aiMetadataAttributes(t *testing.T, scope metadata.Scope, values map[string]
 // insertRunScopedAI writes a root span plus one metadata span per call, all
 // sharing a single dynamic span ID. Two run-scoped AddRunMetadata POSTs collide
 // this way: the parent comes from the run and the dynamic span ID from
-// (parent, kind), so distinct calls differ only in span_id.
+// (parent, kind), so distinct calls differ only in span_id and merge
+// last-write-wins into one entry.
 func insertRunScopedAI(t *testing.T, cm cqrs.Manager, calls ...map[string]any) *cqrs.OtelSpan {
 	t.Helper()
 
@@ -332,20 +357,16 @@ func insertRunScopedAI(t *testing.T, cm cqrs.Manager, calls ...map[string]any) *
 	return root
 }
 
-func TestAISummaryRunScopedDistinctCallsSum(t *testing.T) {
+func TestAISummaryRunScopedCallsMergeLastWriteWins(t *testing.T) {
 	cm, cleanup := initCQRS(t)
 	defer cleanup()
 
 	root := insertRunScopedAI(t, cm, stepCallA, stepCallB)
 	summary := requireSummary(t, root)
 
-	require.Equal(t, int64(37+30), summary.InputTokens)
-	require.Equal(t, int64(10+19), summary.OutputTokens)
-	require.Equal(t, int64(47+49), summary.TotalTokens)
-
-	// inngest.ai merges last-write-wins, so the entry the span itself carries
-	// holds a single call's values while the summary holds both. Which call
-	// wins is left to fragment order, which the sqlite query does not pin.
+	// The summary must agree with the merged entry the span itself carries.
+	// Which call wins is left to fragment order, which the sqlite query does
+	// not pin.
 	var stored []*cqrs.SpanMetadata
 	for _, md := range root.Metadata {
 		if md.Kind == extractors.KindInngestAI {
@@ -356,17 +377,5 @@ func TestAISummaryRunScopedDistinctCallsSum(t *testing.T) {
 	var storedInput int64
 	require.NoError(t, json.Unmarshal(stored[0].Values["input_tokens"], &storedInput))
 	require.Contains(t, []int64{37, 30}, storedInput)
-}
-
-func TestAISummaryRunScopedIdenticalCallsBothCount(t *testing.T) {
-	cm, cleanup := initCQRS(t)
-	defer cleanup()
-
-	// Identical payloads are legitimately reachable (temperature 0, cache
-	// hits), so the fold must not dedupe on the values blob.
-	root := insertRunScopedAI(t, cm, stepCallA, stepCallA)
-	summary := requireSummary(t, root)
-
-	require.Equal(t, int64(37*2), summary.InputTokens)
-	require.Equal(t, int64(10*2), summary.OutputTokens)
+	require.Equal(t, storedInput, summary.InputTokens)
 }

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -34,6 +34,7 @@ import (
 	"github.com/inngest/inngest/pkg/run"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
 	"github.com/inngest/inngest/pkg/util"
 	connpb "github.com/inngest/inngest/proto/gen/connect/v1"
 	"github.com/oklog/ulid/v2"
@@ -280,6 +281,16 @@ type spanRollupInfo struct {
 	// This is needed because parent_span_id in the DB is an OTEL span ID,
 	// but the span tree is keyed by dynamic_span_id.
 	otelToDynamic map[string]string
+	// aiCandidates collects every raw inngest.ai fragment emission, before
+	// rollup: the AI merge opcode is last-write-wins per key, so summing from
+	// rolled-up entries would silently drop all but the last emission that
+	// shares a dynamic span ID.
+	aiCandidates []aiCandidate
+}
+
+type aiCandidate struct {
+	scope metadata.Scope
+	raw   []byte
 }
 
 // fragmentAttributesJSON returns the attributes field of a span fragment as
@@ -492,12 +503,20 @@ fragmentLoop:
 		}
 	}
 
-	if info != nil && isMetadata && parentSpanIDPtr != nil {
-		metadata, err := rollupSpanMetadataFromFragments(ctx, fragments, parsedEndTime)
-		if err != nil {
-			logger.StdlibLogger(ctx).Error("error rolling up metadata span", "error", err)
-		} else {
-			info.metadataByParent[*parentSpanIDPtr] = append(info.metadataByParent[*parentSpanIDPtr], metadata)
+	if info != nil && isMetadata {
+		for _, fragment := range fragments {
+			if candidate, ok := parseAICandidate(fragment); ok {
+				info.aiCandidates = append(info.aiCandidates, candidate)
+			}
+		}
+
+		if parentSpanIDPtr != nil {
+			metadata, err := rollupSpanMetadataFromFragments(ctx, fragments, parsedEndTime)
+			if err != nil {
+				logger.StdlibLogger(ctx).Error("error rolling up metadata span", "error", err)
+			} else {
+				info.metadataByParent[*parentSpanIDPtr] = append(info.metadataByParent[*parentSpanIDPtr], metadata)
+			}
 		}
 	}
 
@@ -581,12 +600,13 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 	var runID ulid.ULID
 	var err error
 
+	info := spanRollupInfo{
+		dynamicRefs:      dynamicRefs,
+		metadataByParent: metadataByParent,
+		otelToDynamic:    otelToDynamic,
+	}
+
 	for _, span := range spans {
-		info := spanRollupInfo{
-			dynamicRefs:      dynamicRefs,
-			metadataByParent: metadataByParent,
-			otelToDynamic:    otelToDynamic,
-		}
 		newSpan, err := mapSpanFromRow(ctx, span, &info)
 		if err != nil {
 			return nil, err
@@ -811,8 +831,29 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 		return nil, fmt.Errorf("no root span found for run %s", runID.String())
 	}
 
+	// Fold order doesn't matter: the builder rounds the summed cost to
+	// extractors.RoundCost's granularity, absorbing float addition's order
+	// sensitivity, and every other field is order-independent.
+	aiUsage := extractors.NewAISummaryBuilder()
+	hasStepAI := slices.ContainsFunc(info.aiCandidates, func(c aiCandidate) bool {
+		return extractors.AIUsageStepScoped(c.scope)
+	})
+	for _, c := range info.aiCandidates {
+		if !extractors.AIUsageEntryCounted(c.scope, hasStepAI) {
+			continue
+		}
+		if err := aiUsage.AddCallJSON(c.raw); err != nil {
+			logger.StdlibLogger(ctx).Warn(
+				"skipping malformed inngest.ai metadata entry",
+				"run_id", root.RunID.String(),
+				"error", err,
+			)
+		}
+	}
+
 	sorter(root)
 	computeAndAttachUsageMetadata(root)
+	computeAndAttachAISummaryMetadata(ctx, root, aiUsage)
 
 	return root, nil
 }
@@ -893,6 +934,34 @@ func rollupSpanMetadataFromFragments(ctx context.Context, fragments []map[string
 	return ret, nil
 }
 
+// parseAICandidate pulls the scope and raw values JSON from a single
+// inngest.ai fragment. Collection is best effort — fragments that fail to
+// parse are dropped here, and entries the summary builder can't parse are
+// skipped there — leaving the rollup's error handling untouched.
+func parseAICandidate(fragment map[string]any) (aiCandidate, bool) {
+	attrs, ok := fragmentAttributesJSON(fragment["attributes"])
+	if !ok {
+		return aiCandidate{}, false
+	}
+
+	var fragmentAttr struct {
+		Scope  *metadata.Scope `json:"_inngest.metadata.scope"`
+		Kind   *metadata.Kind  `json:"_inngest.metadata.kind"`
+		Values *string         `json:"_inngest.metadata.values"`
+	}
+	if err := json.Unmarshal(attrs, &fragmentAttr); err != nil {
+		return aiCandidate{}, false
+	}
+	if fragmentAttr.Scope == nil || fragmentAttr.Kind == nil || fragmentAttr.Values == nil {
+		return aiCandidate{}, false
+	}
+	if *fragmentAttr.Kind != extractors.KindInngestAI {
+		return aiCandidate{}, false
+	}
+
+	return aiCandidate{scope: *fragmentAttr.Scope, raw: []byte(*fragmentAttr.Values)}, true
+}
+
 // computeAndAttachUsageMetadata walks the span tree, sums the size of all
 // non-usage metadata values, and attaches a synthetic "inngest.usage" metadata
 // entry to the root span. Any previously stored usage metadata entries are
@@ -934,6 +1003,53 @@ func walkMetadataSize(span *cqrs.OtelSpan, total *int) {
 	}
 	for _, child := range span.Children {
 		walkMetadataSize(child, total)
+	}
+}
+
+// computeAndAttachAISummaryMetadata attaches a synthetic run-scoped
+// "inngest.ai.summary" entry to the root span from a builder already seeded
+// with every counted inngest.ai entry in the run. Like inngest.usage, the
+// summary is recomputed on every read and never persisted; any stored
+// entries of that kind are stripped first so the computed value is
+// authoritative.
+//
+// The builder is seeded flat rather than by walking the tree so that usage
+// whose parent span is missing, dropped, or excluded from the tree still
+// counts.
+//
+// The summary covers only this run. Usage from invoked child runs is never
+// folded in, and a run with no in-run usage gets no summary at all.
+func computeAndAttachAISummaryMetadata(ctx context.Context, root *cqrs.OtelSpan, builder *extractors.AISummaryBuilder) {
+	removeStoredAISummary(root)
+
+	if builder.Empty() {
+		return
+	}
+	values, err := builder.Summary().Serialize()
+	if err != nil {
+		logger.StdlibLogger(ctx).Error("error serializing AI summary metadata", "error", err)
+		return
+	}
+
+	ts := root.EndTime
+	if ts.IsZero() {
+		ts = root.StartTime
+	}
+
+	root.Metadata = append(root.Metadata, &cqrs.SpanMetadata{
+		Scope:     enums.MetadataScopeRun,
+		Kind:      extractors.KindInngestAISummary,
+		Values:    values,
+		UpdatedAt: ts,
+	})
+}
+
+func removeStoredAISummary(span *cqrs.OtelSpan) {
+	span.Metadata = slices.DeleteFunc(span.Metadata, func(m *cqrs.SpanMetadata) bool {
+		return m.Kind == extractors.KindInngestAISummary
+	})
+	for _, child := range span.Children {
+		removeStoredAISummary(child)
 	}
 }
 

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -281,16 +281,11 @@ type spanRollupInfo struct {
 	// This is needed because parent_span_id in the DB is an OTEL span ID,
 	// but the span tree is keyed by dynamic_span_id.
 	otelToDynamic map[string]string
-	// aiCandidates collects every raw inngest.ai fragment emission, before
-	// rollup: the AI merge opcode is last-write-wins per key, so summing from
-	// rolled-up entries would silently drop all but the last emission that
-	// shares a dynamic span ID.
-	aiCandidates []aiCandidate
-}
-
-type aiCandidate struct {
-	scope metadata.Scope
-	raw   []byte
+	// aiEntries collects each rolled-up inngest.ai metadata entry, including
+	// entries whose parent span is missing from the tree. Rolled-up values are
+	// summed — never raw fragments — because the AI merge opcode makes a later
+	// emission a per-key update of the same entry, not a new call.
+	aiEntries []*cqrs.SpanMetadata
 }
 
 // fragmentAttributesJSON returns the attributes field of a span fragment as
@@ -504,18 +499,15 @@ fragmentLoop:
 	}
 
 	if info != nil && isMetadata {
-		for _, fragment := range fragments {
-			if candidate, ok := parseAICandidate(fragment); ok {
-				info.aiCandidates = append(info.aiCandidates, candidate)
+		rolled, err := rollupSpanMetadataFromFragments(ctx, fragments, parsedEndTime)
+		if err != nil {
+			logger.StdlibLogger(ctx).Error("error rolling up metadata span", "error", err)
+		} else {
+			if rolled.Kind == extractors.KindInngestAI {
+				info.aiEntries = append(info.aiEntries, rolled)
 			}
-		}
-
-		if parentSpanIDPtr != nil {
-			metadata, err := rollupSpanMetadataFromFragments(ctx, fragments, parsedEndTime)
-			if err != nil {
-				logger.StdlibLogger(ctx).Error("error rolling up metadata span", "error", err)
-			} else {
-				info.metadataByParent[*parentSpanIDPtr] = append(info.metadataByParent[*parentSpanIDPtr], metadata)
+			if parentSpanIDPtr != nil {
+				info.metadataByParent[*parentSpanIDPtr] = append(info.metadataByParent[*parentSpanIDPtr], rolled)
 			}
 		}
 	}
@@ -835,14 +827,14 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 	// extractors.RoundCost's granularity, absorbing float addition's order
 	// sensitivity, and every other field is order-independent.
 	aiUsage := extractors.NewAISummaryBuilder()
-	hasStepAI := slices.ContainsFunc(info.aiCandidates, func(c aiCandidate) bool {
-		return extractors.AIUsageStepScoped(c.scope)
+	hasStepAI := slices.ContainsFunc(info.aiEntries, func(md *cqrs.SpanMetadata) bool {
+		return extractors.AIUsageStepScoped(md.Scope)
 	})
-	for _, c := range info.aiCandidates {
-		if !extractors.AIUsageEntryCounted(c.scope, hasStepAI) {
+	for _, md := range info.aiEntries {
+		if !extractors.AIUsageEntryCounted(md.Scope, hasStepAI) {
 			continue
 		}
-		if err := aiUsage.AddCallJSON(c.raw); err != nil {
+		if err := aiUsage.AddCall(md.Values); err != nil {
 			logger.StdlibLogger(ctx).Warn(
 				"skipping malformed inngest.ai metadata entry",
 				"run_id", root.RunID.String(),
@@ -934,34 +926,6 @@ func rollupSpanMetadataFromFragments(ctx context.Context, fragments []map[string
 	return ret, nil
 }
 
-// parseAICandidate pulls the scope and raw values JSON from a single
-// inngest.ai fragment. Collection is best effort — fragments that fail to
-// parse are dropped here, and entries the summary builder can't parse are
-// skipped there — leaving the rollup's error handling untouched.
-func parseAICandidate(fragment map[string]any) (aiCandidate, bool) {
-	attrs, ok := fragmentAttributesJSON(fragment["attributes"])
-	if !ok {
-		return aiCandidate{}, false
-	}
-
-	var fragmentAttr struct {
-		Scope  *metadata.Scope `json:"_inngest.metadata.scope"`
-		Kind   *metadata.Kind  `json:"_inngest.metadata.kind"`
-		Values *string         `json:"_inngest.metadata.values"`
-	}
-	if err := json.Unmarshal(attrs, &fragmentAttr); err != nil {
-		return aiCandidate{}, false
-	}
-	if fragmentAttr.Scope == nil || fragmentAttr.Kind == nil || fragmentAttr.Values == nil {
-		return aiCandidate{}, false
-	}
-	if *fragmentAttr.Kind != extractors.KindInngestAI {
-		return aiCandidate{}, false
-	}
-
-	return aiCandidate{scope: *fragmentAttr.Scope, raw: []byte(*fragmentAttr.Values)}, true
-}
-
 // computeAndAttachUsageMetadata walks the span tree, sums the size of all
 // non-usage metadata values, and attaches a synthetic "inngest.usage" metadata
 // entry to the root span. Any previously stored usage metadata entries are
@@ -1009,9 +973,9 @@ func walkMetadataSize(span *cqrs.OtelSpan, total *int) {
 // computeAndAttachAISummaryMetadata attaches a synthetic run-scoped
 // "inngest.ai.summary" entry to the root span from a builder already seeded
 // with every counted inngest.ai entry in the run. Like inngest.usage, the
-// summary is recomputed on every read and never persisted; any stored
-// entries of that kind are stripped first so the computed value is
-// authoritative.
+// summary is recomputed on every read and never persisted. Unlike
+// inngest.usage there is no strip-before-attach pass: the kind allowlist
+// rejects writes of this kind, so no stored entry can exist to conflict.
 //
 // The builder is seeded flat rather than by walking the tree so that usage
 // whose parent span is missing, dropped, or excluded from the tree still
@@ -1020,8 +984,6 @@ func walkMetadataSize(span *cqrs.OtelSpan, total *int) {
 // The summary covers only this run. Usage from invoked child runs is never
 // folded in, and a run with no in-run usage gets no summary at all.
 func computeAndAttachAISummaryMetadata(ctx context.Context, root *cqrs.OtelSpan, builder *extractors.AISummaryBuilder) {
-	removeStoredAISummary(root)
-
 	if builder.Empty() {
 		return
 	}
@@ -1042,15 +1004,6 @@ func computeAndAttachAISummaryMetadata(ctx context.Context, root *cqrs.OtelSpan,
 		Values:    values,
 		UpdatedAt: ts,
 	})
-}
-
-func removeStoredAISummary(span *cqrs.OtelSpan) {
-	span.Metadata = slices.DeleteFunc(span.Metadata, func(m *cqrs.SpanMetadata) bool {
-		return m.Kind == extractors.KindInngestAISummary
-	})
-	for _, child := range span.Children {
-		removeStoredAISummary(child)
-	}
 }
 
 // extendedTraceKey is the map key used when indexing and reparenting orphaned

--- a/pkg/tracing/metadata/extractors/ai_summary.go
+++ b/pkg/tracing/metadata/extractors/ai_summary.go
@@ -164,11 +164,13 @@ func NewAISummaryBuilder() *AISummaryBuilder {
 }
 
 // aiUsageValues is the minimal projection of an inngest.ai entry needed to
-// aggregate usage. It deliberately does not reuse AIMetadata: that struct
-// types optional counts like cache_read_tokens as *int64, but producers can
-// emit them as floats, so unmarshalling the full struct fails and would drop
-// the entry's tokens entirely. Numerics are float64 here so both integer and
-// fractional encodings parse.
+// aggregate usage. It deliberately does not reuse AIMetadata: producers emit
+// values as arbitrary JSON and may encode counts like cache_read_tokens as
+// floats, which fail to unmarshal into *int64 and would drop the entry's
+// tokens entirely. Loosening AIMetadata's types would not help — it is a
+// producer-side struct that is never decoded from stored JSON, so this read
+// path must tolerate float encodings regardless. Numerics are float64 here
+// so both integer and fractional encodings parse.
 type aiUsageValues struct {
 	InputTokens         float64  `json:"input_tokens"`
 	OutputTokens        float64  `json:"output_tokens"`

--- a/pkg/tracing/metadata/extractors/ai_summary.go
+++ b/pkg/tracing/metadata/extractors/ai_summary.go
@@ -1,0 +1,258 @@
+package extractors
+
+import (
+	"cmp"
+	"encoding/json"
+	"maps"
+	"math"
+	"slices"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+)
+
+// costPrecision is the inverse granularity summary costs are rounded to:
+// 1e-8 dollars. Rounding at output makes the sum independent of the order
+// entries were folded in — float addition is not associative — except for
+// sums within a few ULPs of a decimal halfway boundary, which real per-token
+// rates never produce. Future cost representations must keep ≤1e-8
+// granularity or rounded values will visibly change.
+const costPrecision = 1e8
+
+// RoundCost canonicalizes a summed cost to costPrecision.
+func RoundCost(v float64) float64 {
+	return math.Round(v*costPrecision) / costPrecision
+}
+
+const (
+	// KindInngestAISummary is the run-scoped rollup of all AI usage within a
+	// run. It is synthesized every time a run's span tree is read and is never
+	// persisted, so it can never double-count itself. It must never be added
+	// to the allowedInngestKinds allowlist.
+	KindInngestAISummary metadata.Kind = "inngest.ai.summary"
+)
+
+// XXX: this package otherwise holds write-time extractors producing
+// []metadata.Structured, but AISummaryMetadata is a read-time aggregate that
+// is never written — it deliberately omits Op() and Scope(), so it cannot
+// implement metadata.Structured or be passed to tracing.CreateMetadataSpan.
+// It lives here because Cloud imports the counting rules; usage.go has the
+// same shape already.
+type AISummaryMetadata struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	TotalTokens  int64 `json:"total_tokens"`
+
+	// Absent when no call reported them; cache tokens are summed raw and never
+	// reconciled against InputTokens.
+	CacheReadTokens     *int64 `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens *int64 `json:"cache_creation_tokens,omitempty"`
+	ReasoningTokens     *int64 `json:"reasoning_tokens,omitempty"`
+
+	EstimatedCost *float64 `json:"estimated_cost,omitempty"`
+	Models        []string `json:"models,omitempty"`
+	Providers     []string `json:"providers,omitempty"`
+}
+
+func (ms AISummaryMetadata) Kind() metadata.Kind {
+	return KindInngestAISummary
+}
+
+func (ms AISummaryMetadata) Serialize() (metadata.Values, error) {
+	var rawMetadata metadata.Values
+	err := rawMetadata.FromStruct(ms)
+	if err != nil {
+		return nil, err
+	}
+
+	return rawMetadata, nil
+}
+
+func AISummaryFromValues(values metadata.Values) (AISummaryMetadata, error) {
+	var ms AISummaryMetadata
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return ms, err
+	}
+	err = json.Unmarshal(raw, &ms)
+	return ms, err
+}
+
+// AIUsageStepScoped reports whether an inngest.ai entry at the given scope is
+// executor-reported step usage. AIUsageEntryCounted needs to know whether a
+// run has any such entry: only then can an extended-trace entry be the second
+// report of a call already counted.
+func AIUsageStepScoped(scope metadata.Scope) bool {
+	return scope == enums.MetadataScopeStep || scope == enums.MetadataScopeStepAttempt
+}
+
+// AIUsageEntryCounted is the run-level definition of which inngest.ai entries
+// count toward the run's AI summary, shared by OSS and Cloud. Step and legacy
+// step-attempt entries are executor-reported usage and run-scoped entries are
+// how users report out-of-step usage, so those always count.
+//
+// extended_trace is conditional in both directions. On the SDK path every
+// OTel-derived LLM call made inside a step is reported twice with identical
+// tokens and cost — once at step scope by the SDK's metadata processor, once
+// at extended trace scope — so counting extended_trace unconditionally
+// reports 2x. But a blanket exclusion reads zero for gen_ai usage that never
+// reaches a counted scope at all: emitted outside any step, or from a source
+// with no metadata processor, where the OTLP endpoint is the only carrier.
+// Deciding per run — extended_trace counts only when the run reports no
+// step-scoped AI (runHasStepScopedAI, per AIUsageStepScoped) — closes that
+// gap without double-counting. The cost is that a mixed run — one step
+// reporting through the SDK, another making a raw OTel LLM call — still
+// undercounts; resolving that needs a per-step correlation key that only
+// extended-trace metadata spans carry.
+func AIUsageEntryCounted(scope metadata.Scope, runHasStepScopedAI bool) bool {
+	switch scope {
+	case enums.MetadataScopeStep, enums.MetadataScopeStepAttempt, enums.MetadataScopeRun:
+		return true
+	case enums.MetadataScopeExtendedTrace:
+		return !runHasStepScopedAI
+	default:
+		return false
+	}
+}
+
+// AISummaryBuilder accumulates inngest.ai metadata entries into a single
+// AISummaryMetadata. Every counted entry is summed, including entries from
+// retried attempts: spend on a retried step is real spend.
+type AISummaryBuilder struct {
+	sum     AISummaryMetadata
+	cost    float64
+	hasCost bool
+	// emissions counts AddCall folds. It exists only so Empty() stays
+	// meaningful — the summary deliberately exposes no call count, because the
+	// SDK sums a step's calls into one emission before reporting, so no
+	// emission count is a call count.
+	emissions int64
+	models    map[string]struct{}
+	providers map[string]struct{}
+	// Optional token counters, tracked separately from sum so a field no call
+	// reported stays absent rather than summing to zero.
+	cacheRead     optionalInt64
+	cacheCreation optionalInt64
+	reasoning     optionalInt64
+}
+
+// optionalInt64 accumulates a sum that is only emitted once at least one
+// contributor supplied a value.
+type optionalInt64 struct {
+	value int64
+	set   bool
+}
+
+func (o *optionalInt64) add(v int64) {
+	o.value += v
+	o.set = true
+}
+
+func (o optionalInt64) ptr() *int64 {
+	if !o.set {
+		return nil
+	}
+	v := o.value
+	return &v
+}
+
+func NewAISummaryBuilder() *AISummaryBuilder {
+	return &AISummaryBuilder{
+		models:    map[string]struct{}{},
+		providers: map[string]struct{}{},
+	}
+}
+
+// aiUsageValues is the minimal projection of an inngest.ai entry needed to
+// aggregate usage. It deliberately does not reuse AIMetadata: that struct
+// types optional counts like cache_read_tokens as *int64, but producers can
+// emit them as floats, so unmarshalling the full struct fails and would drop
+// the entry's tokens entirely. Numerics are float64 here so both integer and
+// fractional encodings parse.
+type aiUsageValues struct {
+	InputTokens         float64  `json:"input_tokens"`
+	OutputTokens        float64  `json:"output_tokens"`
+	TotalTokens         *float64 `json:"total_tokens"`
+	CacheReadTokens     *float64 `json:"cache_read_tokens"`
+	CacheCreationTokens *float64 `json:"cache_creation_tokens"`
+	ReasoningTokens     *float64 `json:"reasoning_tokens"`
+	EstimatedCost       *float64 `json:"estimated_cost"`
+	Provider            string   `json:"provider"`
+	RequestModel        string   `json:"request_model"`
+	ResponseModel       string   `json:"response_model"`
+}
+
+// AddCall folds one inngest.ai metadata entry's values into the summary.
+func (b *AISummaryBuilder) AddCall(values metadata.Values) error {
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return err
+	}
+	return b.AddCallJSON(raw)
+}
+
+// AddCallJSON folds one inngest.ai metadata entry's raw JSON values into the
+// summary.
+func (b *AISummaryBuilder) AddCallJSON(raw []byte) error {
+	var m aiUsageValues
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return err
+	}
+
+	b.sum.InputTokens += int64(m.InputTokens)
+	b.sum.OutputTokens += int64(m.OutputTokens)
+	if m.TotalTokens != nil {
+		b.sum.TotalTokens += int64(*m.TotalTokens)
+	} else {
+		b.sum.TotalTokens += int64(m.InputTokens) + int64(m.OutputTokens)
+	}
+	if m.CacheReadTokens != nil {
+		b.cacheRead.add(int64(*m.CacheReadTokens))
+	}
+	if m.CacheCreationTokens != nil {
+		b.cacheCreation.add(int64(*m.CacheCreationTokens))
+	}
+	if m.ReasoningTokens != nil {
+		b.reasoning.add(int64(*m.ReasoningTokens))
+	}
+	if m.EstimatedCost != nil {
+		b.cost += *m.EstimatedCost
+		b.hasCost = true
+	}
+	// Mirrors COALESCE(response_model, request_model), the label Cloud's AI
+	// dashboards group every model-scoped metric by. Recording both would
+	// surface request aliases that are never a dashboard category.
+	if model := cmp.Or(m.ResponseModel, m.RequestModel); model != "" {
+		b.models[model] = struct{}{}
+	}
+	if m.Provider != "" {
+		b.providers[m.Provider] = struct{}{}
+	}
+	b.emissions++
+
+	return nil
+}
+
+// Empty reports whether nothing has been accumulated. The partial flag is
+// deliberately ignored: an empty-but-partial summary still carries no usage.
+func (b *AISummaryBuilder) Empty() bool {
+	return b.emissions == 0 && !b.hasCost
+}
+
+func (b *AISummaryBuilder) Summary() AISummaryMetadata {
+	out := b.sum
+	out.CacheReadTokens = b.cacheRead.ptr()
+	out.CacheCreationTokens = b.cacheCreation.ptr()
+	out.ReasoningTokens = b.reasoning.ptr()
+	if b.hasCost {
+		cost := RoundCost(b.cost)
+		out.EstimatedCost = &cost
+	}
+	if len(b.models) > 0 {
+		out.Models = slices.Sorted(maps.Keys(b.models))
+	}
+	if len(b.providers) > 0 {
+		out.Providers = slices.Sorted(maps.Keys(b.providers))
+	}
+	return out
+}

--- a/pkg/tracing/metadata/kind.go
+++ b/pkg/tracing/metadata/kind.go
@@ -48,6 +48,10 @@ func (k Kind) Validate() error {
 // to prevent spoofing of internal metadata. The score kind is the bare
 // constant inngest.score; the user-supplied score name is a key in the values
 // map, not a kind suffix.
+//
+// Synthetic read-time kinds (inngest.usage, inngest.ai.summary) are computed
+// when a span tree is read and must never be allowlisted here: a client-
+// written entry of either kind would be spoofable and could double-count.
 var allowedInngestKinds = map[Kind]bool{
 	"inngest.ai":               true,
 	"inngest.http":             true,

--- a/pkg/tracing/metadata/kind.go
+++ b/pkg/tracing/metadata/kind.go
@@ -49,9 +49,10 @@ func (k Kind) Validate() error {
 // constant inngest.score; the user-supplied score name is a key in the values
 // map, not a kind suffix.
 //
-// Synthetic read-time kinds (inngest.usage, inngest.ai.summary) are computed
-// when a span tree is read and must never be allowlisted here: a client-
-// written entry of either kind would be spoofable and could double-count.
+// Synthetic read-time kinds (inngest.usage, inngest.ai.summary) stay off the
+// allowlist so no stored entry of either kind can exist: the AI summary read
+// path attaches its computed entry without stripping stored ones first and
+// relies on this rejection to stay the only entry of its kind.
 var allowedInngestKinds = map[Kind]bool{
 	"inngest.ai":               true,
 	"inngest.http":             true,


### PR DESCRIPTION
## Description

Adds a synthetic run-scoped `inngest.ai.summary` metadata kind aggregating `inngest.ai` usage across a run (tokens, cost, models, providers), computed at span-tree read time in the CQRS manager and never persisted. Step-scoped usage takes precedence over `extended_trace` duplicates.

Backend half of [EXE-2087](https://linear.app/inngest/issue/EXE-2087/ai-metdatatraces-aggregate-gen-aiusage-across-runs-and-child). Stacked under #4759 (UI); cloud counterpart: inngest/monorepo#8272.

## Release note

None (user-facing note on the UI PR).

## Migration note

None.
