### PR TITLE
feat(ui): show run AI usage summary

### DIFF
--- a/pkg/tracing/metadata/extractors/ai_summary.go
+++ b/pkg/tracing/metadata/extractors/ai_summary.go
@@ -24,6 +24,7 @@ func RoundCost(v float64) float64 {
 	return math.Round(v*costPrecision) / costPrecision
 }
 
+//tygo:generate
 const (
 	// KindInngestAISummary is the run-scoped rollup of all AI usage within a
 	// run. It is synthesized every time a run's span tree is read and is never
@@ -38,6 +39,8 @@ const (
 // implement metadata.Structured or be passed to tracing.CreateMetadataSpan.
 // It lives here because Cloud imports the counting rules; usage.go has the
 // same shape already.
+
+//tygo:generate
 type AISummaryMetadata struct {
 	InputTokens  int64 `json:"input_tokens"`
 	OutputTokens int64 `json:"output_tokens"`
@@ -91,19 +94,15 @@ func AIUsageStepScoped(scope metadata.Scope) bool {
 // step-attempt entries are executor-reported usage and run-scoped entries are
 // how users report out-of-step usage, so those always count.
 //
-// extended_trace is conditional in both directions. On the SDK path every
-// OTel-derived LLM call made inside a step is reported twice with identical
-// tokens and cost — once at step scope by the SDK's metadata processor, once
-// at extended trace scope — so counting extended_trace unconditionally
-// reports 2x. But a blanket exclusion reads zero for gen_ai usage that never
-// reaches a counted scope at all: emitted outside any step, or from a source
-// with no metadata processor, where the OTLP endpoint is the only carrier.
-// Deciding per run — extended_trace counts only when the run reports no
-// step-scoped AI (runHasStepScopedAI, per AIUsageStepScoped) — closes that
-// gap without double-counting. The cost is that a mixed run — one step
-// reporting through the SDK, another making a raw OTel LLM call — still
-// undercounts; resolving that needs a per-step correlation key that only
-// extended-trace metadata spans carry.
+// An OTel LLM call inside a step arrives twice with identical usage: summed
+// into a step-scoped entry by the SDK's metadata processor, and re-extracted
+// at extended_trace scope from the OTLP export. Counting extended_trace
+// unconditionally therefore reports 2x, but excluding it always reads zero
+// when it is the only carrier (calls outside any step, or sources with no
+// metadata processor). Counting it only when the run reports no step-scoped
+// AI closes that gap without double-counting. A mixed run, where one step
+// reports via the SDK and another via raw OTel, still undercounts; fixing
+// that needs the per-step correlation the read path currently discards.
 func AIUsageEntryCounted(scope metadata.Scope, runHasStepScopedAI bool) bool {
 	switch scope {
 	case enums.MetadataScopeStep, enums.MetadataScopeStepAttempt, enums.MetadataScopeRun:

--- a/pkg/tracing/metadata/types/types_gen.go
+++ b/pkg/tracing/metadata/types/types_gen.go
@@ -58,6 +58,32 @@ type AIMetadata struct {
 	Seed             *int64   `json:"seed,omitempty"`
 }
 
+// From ai_summary.go
+const (
+	// KindInngestAISummary is the run-scoped rollup of all AI usage within a
+	// run. It is synthesized every time a run's span tree is read and is never
+	// persisted, so it can never double-count itself. It must never be added
+	// to the allowedInngestKinds allowlist.
+	KindInngestAISummary = "inngest.ai.summary"
+)
+
+// From ai_summary.go
+type AISummaryMetadata struct {
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	TotalTokens  int64 `json:"total_tokens"`
+
+	// Absent when no call reported them; cache tokens are summed raw and never
+	// reconciled against InputTokens.
+	CacheReadTokens     *int64 `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens *int64 `json:"cache_creation_tokens,omitempty"`
+	ReasoningTokens     *int64 `json:"reasoning_tokens,omitempty"`
+
+	EstimatedCost *float64 `json:"estimated_cost,omitempty"`
+	Models        []string `json:"models,omitempty"`
+	Providers     []string `json:"providers,omitempty"`
+}
+
 // From experiment.go
 const (
 	KindInngestExperiment = "inngest.experiment"

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -14,6 +14,7 @@ packages:
       export type SpanMetadataKindInngestScore = typeof KindInngestScore;
       export type SpanMetadataKind =
         | typeof KindInngestAI
+        | typeof KindInngestAISummary
         | typeof KindInngestHTTP
         | typeof KindInngestHTTPTiming
         | typeof KindInngestResponseHeaders

--- a/ui/packages/components/src/RunDetailsV4/AIMetadata.test.tsx
+++ b/ui/packages/components/src/RunDetailsV4/AIMetadata.test.tsx
@@ -1,8 +1,19 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { AIMetadataNudge, traceHasAIMetadata } from './AIMetadata';
-import type { SpanMetadata, Trace } from './types';
+import { TooltipProvider } from '../Tooltip/Tooltip';
+import { AIMetadataNudge, AISummaryAttrs, traceHasAIMetadata } from './AIMetadata';
+import type { SpanMetadata, SpanMetadataInngestAISummary, Trace } from './types';
+
+// jsdom lacks ResizeObserver, which Pill uses for truncation detection.
+vi.stubGlobal(
+  'ResizeObserver',
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
 
 const booleanFlagMock = vi.hoisted(() => vi.fn());
 const pathCreatorMock = vi.hoisted(() => vi.fn());
@@ -84,6 +95,69 @@ describe('traceHasAIMetadata', () => {
     });
 
     expect(traceHasAIMetadata(trace)).toBe(false);
+  });
+});
+
+const aiSummaryMetadata: SpanMetadataInngestAISummary = {
+  scope: 'run',
+  kind: 'inngest.ai.summary',
+  updatedAt: '2026-01-01T00:00:05Z',
+  values: {
+    input_tokens: 1200,
+    output_tokens: 3400,
+    total_tokens: 4600,
+    estimated_cost: 0.004235,
+    models: ['claude-opus-4', 'gpt-4o-mini'],
+    providers: ['anthropic', 'openai'],
+  },
+};
+
+const renderSummary = (metadata: SpanMetadataInngestAISummary) =>
+  render(
+    <TooltipProvider>
+      <AISummaryAttrs metadata={metadata} />
+    </TooltipProvider>
+  );
+
+describe('AISummaryAttrs', () => {
+  it('renders formatted token totals, cost, models, and providers', () => {
+    renderSummary(aiSummaryMetadata);
+
+    expect(screen.getByText('AI Usage')).toBeTruthy();
+    expect(screen.getByText('4,600')).toBeTruthy();
+    expect(screen.getByText('1,200')).toBeTruthy();
+    expect(screen.getByText('3,400')).toBeTruthy();
+    expect(screen.getByText('$0.004235')).toBeTruthy();
+    // Pill renders its text twice: once visibly, once in a hidden measuring span.
+    expect(screen.getAllByText('claude-opus-4').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('gpt-4o-mini').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('anthropic').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('openai').length).toBeGreaterThan(0);
+  });
+
+  it('renders a zero-valued optional token count instead of omitting it', () => {
+    renderSummary({
+      ...aiSummaryMetadata,
+      values: { ...aiSummaryMetadata.values, cache_read_tokens: 0 },
+    });
+
+    expect(screen.getByText('Cache read tokens')).toBeTruthy();
+    expect(screen.getByText('0')).toBeTruthy();
+  });
+
+  it('omits rows for absent optional fields', () => {
+    renderSummary({
+      ...aiSummaryMetadata,
+      values: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+    });
+
+    expect(screen.getByText('Total tokens')).toBeTruthy();
+    expect(screen.queryByText('Cache read tokens')).toBeNull();
+    expect(screen.queryByText('Cache creation tokens')).toBeNull();
+    expect(screen.queryByText('Reasoning tokens')).toBeNull();
+    expect(screen.queryByText('Estimated cost')).toBeNull();
+    expect(screen.queryByText('Models')).toBeNull();
+    expect(screen.queryByText('Providers')).toBeNull();
   });
 });
 

--- a/ui/packages/components/src/RunDetailsV4/AIMetadata.tsx
+++ b/ui/packages/components/src/RunDetailsV4/AIMetadata.tsx
@@ -1,12 +1,15 @@
+import type { ReactNode } from 'react';
 import { RiSparkling2Line } from '@remixicon/react';
 
 import { Button } from '../Button/Button';
 import { InlineCode } from '../Code';
+import { ElementWrapper, TimeElement } from '../DetailsCard/Element';
+import { Pill } from '../Pill/Pill';
 import { useBooleanFlag } from '../SharedContext/useBooleanFlag';
 import { usePathCreator } from '../SharedContext/usePathCreator';
 import { KindInngestAI } from '../generated';
 import { traceWalk } from './runDetailsUtils';
-import type { Trace } from './types';
+import type { SpanMetadataInngestAISummary, Trace } from './types';
 
 const AI_METADATA_DOCS_URL =
   'https://www.inngest.com/docs/examples/ai-metadata-quickstart?ref=app-run-metadata';
@@ -32,6 +35,99 @@ export const traceHasAIMetadata = (trace: Trace | undefined): boolean => {
   });
 
   return found;
+};
+
+const formatTokenCount = (count: number): string => count.toLocaleString('en-US');
+
+// Costs are USD (see ModelPricing in the backend extractor). Extra fraction
+// digits keep sub-cent per-run costs from rounding to $0.00.
+const formatEstimatedCost = (cost: number): string =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+  }).format(cost);
+
+const pillList = (items: string[]) => (
+  <div className="flex flex-wrap gap-1">
+    {items.map((item) => (
+      <Pill key={item} appearance="outlined">
+        {item}
+      </Pill>
+    ))}
+  </div>
+);
+
+const aiSummaryRows = (
+  values: SpanMetadataInngestAISummary['values']
+): { label: string; value: ReactNode }[] => {
+  const rows: { label: string; value: ReactNode }[] = [
+    { label: 'Total tokens', value: formatTokenCount(values.total_tokens) },
+    { label: 'Input tokens', value: formatTokenCount(values.input_tokens) },
+    { label: 'Output tokens', value: formatTokenCount(values.output_tokens) },
+  ];
+
+  if (values.cache_read_tokens !== undefined) {
+    rows.push({ label: 'Cache read tokens', value: formatTokenCount(values.cache_read_tokens) });
+  }
+  if (values.cache_creation_tokens !== undefined) {
+    rows.push({
+      label: 'Cache creation tokens',
+      value: formatTokenCount(values.cache_creation_tokens),
+    });
+  }
+  if (values.reasoning_tokens !== undefined) {
+    rows.push({ label: 'Reasoning tokens', value: formatTokenCount(values.reasoning_tokens) });
+  }
+  if (values.estimated_cost !== undefined) {
+    rows.push({ label: 'Estimated cost', value: formatEstimatedCost(values.estimated_cost) });
+  }
+  if (values.models?.length) {
+    rows.push({ label: 'Models', value: pillList(values.models) });
+  }
+  if (values.providers?.length) {
+    rows.push({ label: 'Providers', value: pillList(values.providers) });
+  }
+
+  return rows;
+};
+
+/** Displays the run-level AI usage summary the backend aggregates from every AI call in the run. */
+export const AISummaryAttrs = ({ metadata }: { metadata: SpanMetadataInngestAISummary }) => {
+  const rows = aiSummaryRows(metadata.values);
+
+  return (
+    <div className="flex flex-col justify-start gap-2">
+      <div className="flex h-11 w-full flex-row items-center justify-between border-none px-4 pt-2">
+        <span className="text-basis flex items-center gap-2 text-sm font-medium">AI Usage</span>
+      </div>
+      <div className="flex flex-row flex-wrap items-center justify-start gap-x-10 gap-y-4 px-4">
+        <ElementWrapper label="Updated at">
+          <TimeElement date={new Date(metadata.updatedAt)} />
+        </ElementWrapper>
+      </div>
+      <div className="border-muted mt-2 flex max-h-full flex-col gap-2 overflow-hidden border-b pb-4">
+        <div className="text-muted bg-canvasSubtle sticky top-0 flex flex-row px-4 py-2 text-xs font-medium leading-tight">
+          <div className="w-48">Key</div>
+          <div className="">Value</div>
+        </div>
+        {rows.map(({ label, value }) => (
+          <div
+            key={`ai-summary-${label}`}
+            className="flex flex-row items-start overflow-hidden px-4 pb-2"
+          >
+            <div className="text-muted w-48 shrink-0 text-sm font-normal leading-tight">
+              {label}
+            </div>
+            <div className="text-basis min-w-0 whitespace-pre-wrap text-sm font-normal leading-tight [overflow-wrap:anywhere]">
+              {value}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export const AIMetadataNudge = () => {

--- a/ui/packages/components/src/RunDetailsV4/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TopInfo.tsx
@@ -23,13 +23,13 @@ import { usePrettyErrorBody, usePrettyJson } from '../hooks/usePrettyJson';
 import { IconCloudArrowDown } from '../icons/CloudArrowDown';
 import { getCronTriggerMetadata } from '../utils/cronTrigger';
 import { devServerURL, useDevServer } from '../utils/useDevServer';
-import { AIMetadataNudge, traceHasAIMetadata } from './AIMetadata';
+import { AIMetadataNudge, AISummaryAttrs, traceHasAIMetadata } from './AIMetadata';
 import { ErrorInfo } from './ErrorInfo';
 import { IO } from './IO';
 import { LinkedRuns } from './LinkedRuns';
 import { MetadataAttrs } from './MetadataAttrs';
 import { Tabs } from './Tabs';
-import { isScoreMetadata, type Trace } from './types';
+import { isAISummaryMetadata, isScoreMetadata, type Trace } from './types';
 
 type TopInfoProps = {
   slug?: string;
@@ -125,10 +125,12 @@ export const TopInfo = ({
   });
 
   const scoreMetadata = useMemo(() => collectScoreMetadata(trace), [trace]);
-  const nonScoreMetadata = trace?.metadata?.filter((md) => !isScoreMetadata(md)) ?? [];
+  const aiSummaryMetadata = trace?.metadata?.find(isAISummaryMetadata);
+  const nonScoreMetadata =
+    trace?.metadata?.filter((md) => !isScoreMetadata(md) && !isAISummaryMetadata(md)) ?? [];
   const hasAIMetadata = useMemo(() => traceHasAIMetadata(trace), [trace]);
   const showNudge = Boolean(trace?.endedAt) && !hasAIMetadata;
-  const hasMetadataTab = nonScoreMetadata.length > 0 || showNudge;
+  const hasMetadataTab = nonScoreMetadata.length > 0 || Boolean(aiSummaryMetadata) || showNudge;
 
   const prettyPayload = useMemo(() => {
     try {
@@ -372,7 +374,13 @@ export const TopInfo = ({
                     node: (
                       <MetadataAttrs
                         metadata={nonScoreMetadata}
-                        footer={showNudge ? <AIMetadataNudge /> : null}
+                        footer={
+                          aiSummaryMetadata ? (
+                            <AISummaryAttrs metadata={aiSummaryMetadata} />
+                          ) : showNudge ? (
+                            <AIMetadataNudge />
+                          ) : null
+                        }
                       />
                     ),
                   },

--- a/ui/packages/components/src/RunDetailsV4/types.ts
+++ b/ui/packages/components/src/RunDetailsV4/types.ts
@@ -1,6 +1,8 @@
 import {
+  KindInngestAISummary,
   KindInngestScore,
   type AIMetadata,
+  type AISummaryMetadata,
   type SpanMetadataKind as GeneratedSpanMetadataKind,
   type SpanMetadataKindInngestScore as GeneratedSpanMetadataKindInngestScore,
   type SpanMetadataKindUserland as GeneratedSpanMetadataKindUserland,
@@ -47,6 +49,7 @@ export type SpanMetadataScope = 'run' | 'step' | 'step_attempt' | 'extended_trac
 
 export type SpanMetadata =
   | SpanMetadataInngestAI
+  | SpanMetadataInngestAISummary
   | SpanMetadataInngestExperiment
   | SpanMetadataInngestHTTP
   | SpanMetadataInngestHTTPTiming
@@ -62,6 +65,15 @@ export type SpanMetadataInngestAI = {
   kind: 'inngest.ai';
   updatedAt: string;
   values: AIMetadata;
+};
+
+// The run-level AI usage rollup synthesized by the backend on every span-tree
+// read; it only ever appears on the root span.
+export type SpanMetadataInngestAISummary = {
+  scope: 'run';
+  kind: typeof KindInngestAISummary;
+  updatedAt: string;
+  values: AISummaryMetadata;
 };
 
 export type SpanMetadataInngestExperiment = {
@@ -243,4 +255,8 @@ export function isExperimentMetadata(md: SpanMetadata): md is SpanMetadataInnges
 
 export function isScoreMetadata(md: SpanMetadata): md is SpanMetadataInngestScore {
   return md.kind === KindInngestScore;
+}
+
+export function isAISummaryMetadata(md: SpanMetadata): md is SpanMetadataInngestAISummary {
+  return md.kind === KindInngestAISummary;
 }

--- a/ui/packages/components/src/generated/index.ts
+++ b/ui/packages/components/src/generated/index.ts
@@ -9,6 +9,7 @@ export type SpanMetadataKindUserland = `userland.${string}`;
 export type SpanMetadataKindInngestScore = typeof KindInngestScore;
 export type SpanMetadataKind =
   | typeof KindInngestAI
+  | typeof KindInngestAISummary
   | typeof KindInngestHTTP
   | typeof KindInngestHTTPTiming
   | typeof KindInngestResponseHeaders
@@ -76,6 +77,34 @@ export interface AIMetadata {
   frequency_penalty?: number /* float64 */;
   presence_penalty?: number /* float64 */;
   seed?: number /* int64 */;
+}
+/**
+ * From ai_summary.go
+ */
+/**
+ * KindInngestAISummary is the run-scoped rollup of all AI usage within a
+ * run. It is synthesized every time a run's span tree is read and is never
+ * persisted, so it can never double-count itself. It must never be added
+ * to the allowedInngestKinds allowlist.
+ */
+export const KindInngestAISummary = 'inngest.ai.summary';
+/**
+ * From ai_summary.go
+ */
+export interface AISummaryMetadata {
+  input_tokens: number /* int64 */;
+  output_tokens: number /* int64 */;
+  total_tokens: number /* int64 */;
+  /**
+   * Absent when no call reported them; cache tokens are summed raw and never
+   * reconciled against InputTokens.
+   */
+  cache_read_tokens?: number /* int64 */;
+  cache_creation_tokens?: number /* int64 */;
+  reasoning_tokens?: number /* int64 */;
+  estimated_cost?: number /* float64 */;
+  models?: string[];
+  providers?: string[];
 }
 /**
  * From experiment.go


### PR DESCRIPTION
## Description

Shows the run-level AI usage summary (tokens, cost, models/providers) in run details, plus the Go type + tygo plumbing that generates its TS types.

UI half of [EXE-2087](https://linear.app/inngest/issue/EXE-2087/ai-metdatatraces-aggregate-gen-aiusage-across-runs-and-child). Stacked on #4758; cloud counterpart: inngest/monorepo#8272.

<img width="4052" height="3446" alt="Inngest Server · 10 50am · 08-20" src="https://github.com/user-attachments/assets/7c603351-1d91-4008-983c-7ed22eda409e" />

## Release note

Run details now show a run-level AI usage summary (total tokens, cost, models used).

## Migration note

None.
