### PR TITLE
cloud(fix): wiring up the view functions button

### DIFF
--- a/ui/apps/dashboard/src/components/Apps/AppCardContent.tsx
+++ b/ui/apps/dashboard/src/components/Apps/AppCardContent.tsx
@@ -46,7 +46,16 @@ const getAppCardContent = ({
 
   const footerHeaderSecondaryCTA =
     !app.error && app.functionCount > 0 ? (
-      <Link size="small" to={pathCreator.functions({ envSlug: envSlug })}>
+      <Link
+        size="small"
+        to={pathCreator.functions({
+          envSlug: envSlug,
+          appIDs: [app.id],
+          // An archived app's functions are archived too, so the status filter
+          // has to match or the filtered view lands on an empty table.
+          archived: app.isArchived,
+        })}
+      >
         View functions
       </Link>
     ) : null;

--- a/ui/apps/dashboard/src/utils/urls.test.ts
+++ b/ui/apps/dashboard/src/utils/urls.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { pathCreator } from './urls';
+
+describe('pathCreator.functions', () => {
+  it('returns the unfiltered path when no apps are given', () => {
+    expect(pathCreator.functions({ envSlug: 'production' })).toBe(
+      '/env/production/functions',
+    );
+    expect(pathCreator.functions({ envSlug: 'production', appIDs: [] })).toBe(
+      '/env/production/functions',
+    );
+  });
+
+  it('encodes app IDs the way the functions table parses them', () => {
+    const path = pathCreator.functions({
+      envSlug: 'production',
+      appIDs: ['app-1', 'app-2'],
+    });
+
+    const filterApp = new URL(path, 'https://app.inngest.com').searchParams.get(
+      'filterApp',
+    );
+    expect(filterApp).not.toBeNull();
+    expect(JSON.parse(filterApp!)).toEqual(['app-1', 'app-2']);
+  });
+
+  it('sets the archived status filter for archived apps', () => {
+    const params = new URL(
+      pathCreator.functions({
+        envSlug: 'production',
+        appIDs: ['app-1'],
+        archived: true,
+      }),
+      'https://app.inngest.com',
+    ).searchParams;
+
+    expect(params.get('archived')).toBe('true');
+    expect(JSON.parse(params.get('filterApp')!)).toEqual(['app-1']);
+  });
+
+  it('omits the archived status filter for active apps', () => {
+    expect(
+      pathCreator.functions({
+        envSlug: 'production',
+        appIDs: ['app-1'],
+        archived: false,
+      }),
+    ).not.toContain('archived');
+  });
+});

--- a/ui/apps/dashboard/src/utils/urls.test.ts
+++ b/ui/apps/dashboard/src/utils/urls.test.ts
@@ -1,9 +1,22 @@
+import { defaultParseSearch } from '@tanstack/react-router';
 import { describe, expect, it } from 'vitest';
 
 import { pathCreator } from './urls';
 
+//
+// The functions table reads its filters with `useStringArraySearchParam` and
+// `useSearchParam`, which both require the router to hand them a *string*.
+// These tests round-trip through the router's own parser, because that parsing
+// step is what a hand-rolled URLSearchParams query gets wrong: it produces
+// `filterApp=["id"]`, which parses into an array and gets discarded.
+//
+const parse = (path: string) => {
+  const [, search = ''] = path.split('?');
+  return defaultParseSearch(search) as Record<string, unknown>;
+};
+
 describe('pathCreator.functions', () => {
-  it('returns the unfiltered path when no apps are given', () => {
+  it('returns the unfiltered path when no filters are given', () => {
     expect(pathCreator.functions({ envSlug: 'production' })).toBe(
       '/env/production/functions',
     );
@@ -12,34 +25,34 @@ describe('pathCreator.functions', () => {
     );
   });
 
-  it('encodes app IDs the way the functions table parses them', () => {
-    const path = pathCreator.functions({
-      envSlug: 'production',
-      appIDs: ['app-1', 'app-2'],
-    });
-
-    const filterApp = new URL(path, 'https://app.inngest.com').searchParams.get(
-      'filterApp',
+  it('encodes app IDs so the router yields the string the filter expects', () => {
+    const search = parse(
+      pathCreator.functions({
+        envSlug: 'production',
+        appIDs: ['app-1', 'app-2'],
+      }),
     );
-    expect(filterApp).not.toBeNull();
-    expect(JSON.parse(filterApp!)).toEqual(['app-1', 'app-2']);
+
+    // `useStringArraySearchParam` rejects anything but a string, then parses it.
+    expect(typeof search.filterApp).toBe('string');
+    expect(JSON.parse(search.filterApp as string)).toEqual(['app-1', 'app-2']);
   });
 
-  it('sets the archived status filter for archived apps', () => {
-    const params = new URL(
+  it('encodes the archived filter as the string the table compares against', () => {
+    const search = parse(
       pathCreator.functions({
         envSlug: 'production',
         appIDs: ['app-1'],
         archived: true,
       }),
-      'https://app.inngest.com',
-    ).searchParams;
+    );
 
-    expect(params.get('archived')).toBe('true');
-    expect(JSON.parse(params.get('filterApp')!)).toEqual(['app-1']);
+    // The table does `filteredStatus === 'true'`, so a boolean would read false.
+    expect(search.archived).toBe('true');
+    expect(typeof search.filterApp).toBe('string');
   });
 
-  it('omits the archived status filter for active apps', () => {
+  it('omits the archived filter for active apps', () => {
     expect(
       pathCreator.functions({
         envSlug: 'production',

--- a/ui/apps/dashboard/src/utils/urls.ts
+++ b/ui/apps/dashboard/src/utils/urls.ts
@@ -1,3 +1,5 @@
+import { defaultStringifySearch } from '@tanstack/react-router';
+
 export const WEBSITE_PRICING_URL = 'https://www.inngest.com/pricing';
 export const WEBSITE_CONTACT_URL = 'https://www.inngest.com/contact';
 export const DISCORD_URL = 'https://www.inngest.com/discord';
@@ -151,19 +153,24 @@ export const pathCreator = {
     archived?: boolean;
   }) {
     const path = `/env/${envSlug}/functions`;
-    const query = new URLSearchParams();
+    const search: Record<string, string> = {};
     if (appIDs?.length) {
       // The functions table reads its app filter from a JSON-encoded array of
       // app IDs, matching `useStringArraySearchParam('filterApp')`.
-      query.set('filterApp', JSON.stringify(appIDs));
+      search.filterApp = JSON.stringify(appIDs);
     }
     // The table defaults to active functions, so archived functions are only
     // visible when the status filter is explicitly set.
     if (archived) {
-      query.set('archived', 'true');
+      search.archived = 'true';
     }
 
-    return query.toString() ? `${path}?${query.toString()}` : path;
+    // Both filters read their params as strings. The router's serializer
+    // double-encodes JSON-looking strings so they survive parsing as strings,
+    // so build the query with it rather than by hand: URLSearchParams would
+    // emit `filterApp=["id"]`, which the router parses into an array and the
+    // filter hooks then discard.
+    return `${path}${defaultStringifySearch(search)}`;
   },
   function({
     envSlug,

--- a/ui/apps/dashboard/src/utils/urls.ts
+++ b/ui/apps/dashboard/src/utils/urls.ts
@@ -141,8 +141,29 @@ export const pathCreator = {
   envs() {
     return '/env';
   },
-  functions({ envSlug }: { envSlug: string }) {
-    return `/env/${envSlug}/functions`;
+  functions({
+    envSlug,
+    appIDs,
+    archived,
+  }: {
+    envSlug: string;
+    appIDs?: string[];
+    archived?: boolean;
+  }) {
+    const path = `/env/${envSlug}/functions`;
+    const query = new URLSearchParams();
+    if (appIDs?.length) {
+      // The functions table reads its app filter from a JSON-encoded array of
+      // app IDs, matching `useStringArraySearchParam('filterApp')`.
+      query.set('filterApp', JSON.stringify(appIDs));
+    }
+    // The table defaults to active functions, so archived functions are only
+    // visible when the status filter is explicitly set.
+    if (archived) {
+      query.set('archived', 'true');
+    }
+
+    return query.toString() ? `${path}?${query.toString()}` : path;
   },
   function({
     envSlug,


### PR DESCRIPTION
## Description

the view functions button on the app card now points to the filtered view of the function dashboard for the said app
<img width="890" height="248" alt="image" src="https://github.com/user-attachments/assets/224d7d50-d06d-4587-a2ca-96cd3606c27d" />
<img width="1488" height="613" alt="Screenshot 2026-08-20 at 19 19 58" src="https://github.com/user-attachments/assets/30f8aefc-3c39-43ab-bc7f-4704c0cedb47" />

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
