### PR TITLE
fix(cli): honor explicit --json=false

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,22 @@ func init() {
 	}
 }
 
+func configureLogHandler(cmd *cli.Command, stdoutIsTerminal bool) {
+	if cmd.IsSet("json") {
+		if cmd.Bool("json") {
+			os.Setenv("LOG_HANDLER", "json")
+		} else {
+			os.Setenv("LOG_HANDLER", "dev")
+		}
+		return
+	}
+
+	if !stdoutIsTerminal {
+		// Always use JSON when not in a terminal
+		os.Setenv("LOG_HANDLER", "json")
+	}
+}
+
 // globalFlags are the flags that should be available on all commands
 var globalFlags = []cli.Flag{
 	&cli.BoolFlag{
@@ -58,11 +74,7 @@ func execute() {
 		)),
 		Version: inngestversion.Print(),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			// Set LOG_HANDLER environment variable based on --json flag
-			// This ensures the logger respects the JSON output setting
-			if cmd.Bool("json") {
-				os.Setenv("LOG_HANDLER", "json")
-			}
+			configureLogHandler(cmd, isatty.IsTerminal(os.Stdout.Fd()))
 
 			if os.Getenv("LOG_LEVEL") == "" {
 				// Set LOG_LEVEL environment variable so the logger picks it up
@@ -100,11 +112,6 @@ func execute() {
 			start.Command(),
 			alpha(),
 		},
-	}
-
-	if !isatty.IsTerminal(os.Stdout.Fd()) {
-		// Always use JSON when not in a terminal
-		os.Setenv("LOG_HANDLER", "json")
 	}
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestConfigureLogHandler(t *testing.T) {
+	tests := []struct {
+		name             string
+		args             []string
+		stdoutIsTerminal bool
+		initialHandler   string
+		wantHandler      string
+	}{
+		{
+			name:             "terminal uses existing handler by default",
+			stdoutIsTerminal: true,
+			initialHandler:   "text",
+			wantHandler:      "text",
+		},
+		{
+			name:             "non-terminal defaults to JSON",
+			stdoutIsTerminal: false,
+			initialHandler:   "dev",
+			wantHandler:      "json",
+		},
+		{
+			name:             "explicit true enables JSON in a terminal",
+			args:             []string{"--json=true"},
+			stdoutIsTerminal: true,
+			initialHandler:   "dev",
+			wantHandler:      "json",
+		},
+		{
+			name:             "explicit true enables JSON outside a terminal",
+			args:             []string{"--json"},
+			stdoutIsTerminal: false,
+			initialHandler:   "text",
+			wantHandler:      "json",
+		},
+		{
+			name:             "explicit false disables JSON in a terminal",
+			args:             []string{"--json=false"},
+			stdoutIsTerminal: true,
+			initialHandler:   "json",
+			wantHandler:      "dev",
+		},
+		{
+			name:             "explicit false disables JSON outside a terminal",
+			args:             []string{"--json=false"},
+			stdoutIsTerminal: false,
+			initialHandler:   "json",
+			wantHandler:      "dev",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("LOG_HANDLER", test.initialHandler)
+
+			var got string
+			captureHandler := func(context.Context, *cli.Command) error {
+				got = os.Getenv("LOG_HANDLER")
+				return nil
+			}
+			app := &cli.Command{
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "json"},
+				},
+				Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+					configureLogHandler(cmd, test.stdoutIsTerminal)
+					return ctx, nil
+				},
+				Commands: []*cli.Command{
+					{
+						Name:   "dev",
+						Action: captureHandler,
+					},
+				},
+			}
+
+			args := append([]string{"inngest"}, test.args...)
+			err := app.Run(t.Context(), append(args, "dev"))
+			require.NoError(t, err)
+			require.Equal(t, test.wantHandler, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4379

## Description

The CLI selected JSON logging for non-TTY stdout before parsing global flags.
As a result, `--json=false` could not override the automatic choice because
the existing pre-run hook only handled the true case.

Resolve the log handler after flag parsing and give an explicitly supplied
`--json` value precedence over TTY detection. Existing behavior remains the
same when the flag is omitted: non-TTY output defaults to JSON, while terminal
output keeps the configured/default human-readable handler.

The table-driven regression test exercises the root pre-run hook and a `dev`
subcommand for terminal and non-terminal output, explicit true and false
values, and the no-flag defaults.

## Release note

The CLI now honors `--json=false` when stdout is not a TTY.

## Migration note

None

## Tests

- `go test ./cmd -run '^TestConfigureLogHandler$' -count=1 -v`
- `go test ./cmd/... -count=1 -timeout=5m -p=4`
- `go vet ./cmd/...`
- `golangci-lint run ./cmd/... --verbose` (v2.11.4, 0 issues)
- `gofmt -l cmd/root.go cmd/root_test.go`
- `git diff --check`
