### PR TITLE
fix(queue): renew capacity leases before dispatch

### DIFF
--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -18,6 +18,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+const capacityLeaseRenewalGracePeriod = 2 * time.Second
+
 type PartitionConstraintConfig struct {
 	FunctionVersion int `json:"fv,omitempty,omitzero"`
 
@@ -403,7 +405,40 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 		}
 	)
 
-	switch hasValidCapacityLease(item, now) {
+	// A refilled item can wait in the ready queue long enough that its capacity
+	// lease no longer covers the first renewal interval. Refresh a still-active
+	// lease before dispatch so it cannot expire while the step is running but
+	// before ProcessItem's first renewal tick.
+	if item.CapacityLease != nil &&
+		!q.hasReusableCapacityLease(item, now) &&
+		item.CapacityLease.LeaseID.Timestamp().After(now) {
+		currentLease := item.CapacityLease
+		res, err := q.CapacityManager.ExtendLease(ctx, &constraintapi.CapacityExtendLeaseRequest{
+			AccountID:      *shadowPart.AccountID,
+			IdempotencyKey: currentLease.LeaseID.String(),
+			LeaseID:        currentLease.LeaseID,
+			Duration:       QueueLeaseDuration,
+			Source: constraintapi.LeaseSource{
+				Location:          constraintapi.CallerLocationItemLease,
+				Service:           constraintapi.ServiceExecutor,
+				RunProcessingMode: constraintapi.RunProcessingModeBackground,
+			},
+			LeaseIssuedAt: time.UnixMilli(currentLease.IssuedAtMS),
+		})
+		if err != nil {
+			return ItemLeaseConstraintCheckResult{}, fmt.Errorf("could not refresh capacity lease before processing: %w", err)
+		}
+		if res.LeaseID == nil {
+			return ItemLeaseConstraintCheckResult{}, fmt.Errorf("could not refresh capacity lease before processing: lease expired")
+		}
+
+		item.CapacityLease = &CapacityLease{
+			LeaseID:    *res.LeaseID,
+			IssuedAtMS: currentLease.IssuedAtMS,
+		}
+	}
+
+	switch q.hasReusableCapacityLease(item, now) {
 	case true:
 		// in this case, key queues claimed a bunch of constraints up front and we already have some
 		// capacity claimed.
@@ -554,8 +589,15 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 	}, nil
 }
 
-func hasValidCapacityLease(item *QueueItem, now time.Time) bool {
-	return item.CapacityLease != nil && item.CapacityLease.LeaseID.Timestamp().After(now.Add(2*time.Second))
+func (q *queueProcessor) hasReusableCapacityLease(item *QueueItem, now time.Time) bool {
+	if item.CapacityLease == nil {
+		return false
+	}
+
+	// Allow enough time for ProcessItem to reach its first renewal tick, plus
+	// the existing safety margin for scheduling and request latency.
+	minimumTTL := q.CapacityLeaseExtendInterval + capacityLeaseRenewalGracePeriod
+	return item.CapacityLease.LeaseID.Timestamp().After(now.Add(minimumTTL))
 }
 
 func (q *queueProcessor) semaphoreConstraintChecksDisabled(ctx context.Context, accountID uuid.UUID) bool {

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -215,6 +215,46 @@ func (q *queueProcessor) ProcessItem(
 		extendCapacityLeaseTick = q.Clock().NewTicker(q.CapacityLeaseExtendInterval)
 		defer extendCapacityLeaseTick.Stop()
 
+		// Cancel processing if the current capacity lease reaches its expiry
+		// before a renewal succeeds. The renewal request itself may be delayed or
+		// hang, so relying only on its eventual response can allow work to
+		// continue after the concurrency reservation has been scavenged.
+		go func() {
+			for {
+				currentCapacityLease := capacityLeaseID.get()
+				if currentCapacityLease == nil {
+					return
+				}
+
+				untilExpiry := currentCapacityLease.Timestamp().Sub(q.Clock().Now())
+				if untilExpiry > 0 {
+					expiryTimer := q.Clock().NewTimer(untilExpiry)
+					select {
+					case <-extendCapacityLeaseCtx.Done():
+						expiryTimer.Stop()
+						return
+					case <-expiryTimer.Chan():
+					}
+				}
+
+				if extendCapacityLeaseCtx.Err() != nil {
+					return
+				}
+
+				latestCapacityLease := capacityLeaseID.get()
+				if latestCapacityLease != nil && latestCapacityLease.Timestamp().After(q.Clock().Now()) {
+					// A renewal won the race with the previous lease's expiry.
+					continue
+				}
+
+				select {
+				case errCh <- AlwaysRetryError(fmt.Errorf("capacity lease expired while processing")):
+				case <-extendCapacityLeaseCtx.Done():
+				}
+				return
+			}
+		}()
+
 		go func() {
 			lastCapacityLeaseExtension := time.Now()
 			for {

--- a/pkg/execution/state/redis_state/constraints_test.go
+++ b/pkg/execution/state/redis_state/constraints_test.go
@@ -267,8 +267,7 @@ func TestItemLeaseConstraintCheck(t *testing.T) {
 		require.Equal(t, 0, len(cmLifecycles.ReleaseCalls))
 	})
 
-	// Tests that valid leases (>= 2s remaining) are NOT released and are reused as-is.
-	// The 2-second buffer is defined in constraints.go: hasValidLease := expiry.After(now.Add(2 * time.Second))
+	// Leases that cover a full renewal interval plus the safety margin are reused as-is.
 	t.Run("should not acquire lease with valid existing item lease", func(t *testing.T) {
 		reset()
 
@@ -290,7 +289,8 @@ func TestItemLeaseConstraintCheck(t *testing.T) {
 		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		// Simulate valid lease (10 seconds in future, well above the 2-second threshold)
+		// The one-second renewal interval plus the two-second safety margin is
+		// well below this lease's remaining TTL.
 		capacityLeaseID := ulid.MustNew(ulid.Timestamp(clock.Now().Add(10*time.Second)), rand.Reader)
 
 		qi.CapacityLease = &osqueue.CapacityLease{
@@ -375,10 +375,7 @@ func TestItemLeaseConstraintCheck(t *testing.T) {
 		require.Equal(t, originalLeaseID, cmLifecycles.ReleaseCalls[0].LeaseID)
 	})
 
-	// Tests that near-expiring leases (valid for < 2s) are also released and a new lease is acquired.
-	// This covers the edge case where the lease technically hasn't expired but won't be valid long enough.
-	// The 2-second buffer is defined in constraints.go: hasValidLease := expiry.After(now.Add(2 * time.Second))
-	t.Run("should release near-expiring lease (TTL < 2s) and acquire new one", func(t *testing.T) {
+	t.Run("should extend near-expiring lease before processing", func(t *testing.T) {
 		reset()
 
 		q, shard := newQueue(
@@ -411,10 +408,9 @@ func TestItemLeaseConstraintCheck(t *testing.T) {
 		originalLeaseID := res.CapacityLease.LeaseID
 		originalLeaseExpiry := originalLeaseID.Timestamp()
 
-		// Advance time so the lease has less than 2 seconds remaining
-		// (e.g., advance to 1 second before the lease ULID timestamp)
-		// Since ULID timestamps are based on creation time, we advance to 1 second before
-		// the original lease expiry to make it appear near-expiring
+		// Advance to one second before expiry. This is shorter than the configured
+		// renewal interval plus its safety margin, so the lease must be refreshed
+		// synchronously before the item is allowed to run.
 		timeToAdvance := originalLeaseExpiry.Sub(clock.Now()) - 1*time.Second
 		clock.Advance(timeToAdvance)
 		r.SetTime(clock.Now())
@@ -424,25 +420,53 @@ func TestItemLeaseConstraintCheck(t *testing.T) {
 		require.Less(t, ttlRemaining, 2*time.Second, "Lease should have less than 2 seconds remaining")
 		require.Greater(t, ttlRemaining, time.Duration(0), "Lease should still be technically valid (positive TTL)")
 
-		// Set the near-expiring lease on the item
 		qi.CapacityLease = res.CapacityLease
 
-		// Call again - should detect near-expiring lease, release it, and acquire a new one
 		res2, err := q.ItemLeaseConstraintCheck(ctx, &sp, &backlog, constraints, &qi, clock.Now())
 		require.NoError(t, err)
-
-		// Wait for async goroutines to complete (release happens via service.Go())
-		service.Wait()
-
 		require.NotNil(t, res2.CapacityLease)
+		require.NotEqual(t, originalLeaseID, res2.CapacityLease.LeaseID)
+		require.Equal(t, clock.Now().Add(osqueue.QueueLeaseDuration).UnixMilli(), res2.CapacityLease.LeaseID.Timestamp().UnixMilli())
+		require.Equal(t, res.CapacityLease.IssuedAtMS, res2.CapacityLease.IssuedAtMS)
 
-		// Expect 2 acquire calls total (initial + after near-expiry), and 1 release call
-		require.Equal(t, 2, len(cmLifecycles.AcquireCalls))
-		require.Equal(t, 0, len(cmLifecycles.ExtendCalls))
-		require.Equal(t, 1, len(cmLifecycles.ReleaseCalls))
+		// Refreshing the existing reservation avoids a release/reacquire gap in
+		// which another item could claim the concurrency slot.
+		require.Len(t, cmLifecycles.AcquireCalls, 1)
+		require.Len(t, cmLifecycles.ExtendCalls, 1)
+		require.Empty(t, cmLifecycles.ReleaseCalls)
+	})
 
-		// Verify the released lease ID matches the near-expiring lease
-		require.Equal(t, originalLeaseID, cmLifecycles.ReleaseCalls[0].LeaseID)
+	t.Run("should not process when near-expiring lease cannot be extended", func(t *testing.T) {
+		reset()
+
+		q, shard := newQueue(
+			t, rc,
+			osqueue.WithClock(clock),
+			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
+				return true
+			}),
+			osqueue.WithCapacityManager(cm),
+			osqueue.WithCapacityLeaseExtendInterval(time.Second),
+			osqueue.WithLogger(l),
+			osqueue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
+				return constraints
+			}),
+		)
+
+		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+		qi.CapacityLease = &osqueue.CapacityLease{
+			LeaseID:    ulid.MustNew(ulid.Timestamp(clock.Now().Add(2*time.Second)), rand.Reader),
+			IssuedAtMS: clock.Now().UnixMilli(),
+		}
+
+		sp := osqueue.ItemShadowPartition(ctx, qi)
+		backlog := osqueue.ItemBacklog(ctx, qi)
+		res, err := q.ItemLeaseConstraintCheck(ctx, &sp, &backlog, constraints, &qi, clock.Now())
+		require.ErrorContains(t, err, "could not refresh capacity lease before processing")
+		require.Nil(t, res.CapacityLease)
+		require.Empty(t, cmLifecycles.AcquireCalls)
+		require.Empty(t, cmLifecycles.ReleaseCalls)
 	})
 
 	t.Run("acquire lease from constraint api", func(t *testing.T) {

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -239,6 +239,105 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 		require.Equal(t, len(cmLifecycles.ReleaseCalls), 1)
 	})
 
+	t.Run("stops processing when capacity lease expires before renewal", func(t *testing.T) {
+		reset()
+
+		q, shard := newQueue(
+			t, rc,
+			osqueue.WithClock(clock),
+			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
+				return true
+			}),
+			osqueue.WithAcquireCapacityLeaseOnBacklogRefill(true),
+			osqueue.WithCapacityManager(cm),
+			osqueue.WithCapacityLeaseExtendInterval(10*time.Second),
+			osqueue.WithLogger(l),
+		)
+
+		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+		queueLeaseID, err := shard.Lease(ctx, qi, osqueue.QueueLeaseDuration, clock.Now())
+		require.NoError(t, err)
+		qi.LeaseID = queueLeaseID
+
+		resp, err := cm.Acquire(ctx, &constraintapi.CapacityAcquireRequest{
+			AccountID:            accountID,
+			EnvID:                envID,
+			IdempotencyKey:       qi.ID,
+			FunctionID:           fnID,
+			LeaseIdempotencyKeys: []string{qi.ID},
+			Amount:               1,
+			Configuration: constraintapi.ConstraintConfig{
+				FunctionVersion: 1,
+				Concurrency: constraintapi.ConcurrencyConfig{
+					FunctionConcurrency: 1,
+				},
+			},
+			Constraints: []constraintapi.ConstraintItem{{
+				Kind: constraintapi.ConstraintKindConcurrency,
+				Concurrency: &constraintapi.ConcurrencyConstraint{
+					Scope: enums.ConcurrencyScopeFn,
+				},
+			}},
+			CurrentTime:     clock.Now(),
+			Duration:        5 * time.Second,
+			MaximumLifetime: time.Minute,
+			Source: constraintapi.LeaseSource{
+				Service:           constraintapi.ServiceExecutor,
+				Location:          constraintapi.CallerLocationItemLease,
+				RunProcessingMode: constraintapi.RunProcessingModeBackground,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Leases, 1)
+
+		started := make(chan struct{})
+		cancelled := make(chan struct{})
+		done := make(chan error, 1)
+		go func() {
+			_, err := q.ProcessItem(ctx, osqueue.ProcessItem{
+				I: qi,
+				CapacityLease: &osqueue.CapacityLease{
+					LeaseID:    resp.Leases[0].LeaseID,
+					IssuedAtMS: clock.Now().UnixMilli(),
+				},
+			}, func(ctx context.Context, _ osqueue.RunInfo, _ osqueue.Item) (osqueue.RunResult, error) {
+				close(started)
+				<-ctx.Done()
+				close(cancelled)
+				return osqueue.RunResult{}, nil
+			})
+			done <- err
+		}()
+
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for item processing to start")
+		}
+
+		clock.Advance(6 * time.Second)
+		r.SetTime(clock.Now())
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("item continued processing after its capacity lease expired")
+		}
+		select {
+		case <-cancelled:
+		default:
+			t.Fatal("item context was not cancelled when its capacity lease expired")
+		}
+
+		service.Wait()
+		require.Empty(t, cmLifecycles.ExtendCalls)
+		loaded, err := shard.LoadQueueItem(ctx, qi.ID)
+		require.NoError(t, err)
+		require.Nil(t, loaded.LeaseID)
+	})
+
 	t.Run("with matching lease extension intervals", func(t *testing.T) {
 		reset()
 

--- a/tests/execution/queue/queue_concurrency_test.go
+++ b/tests/execution/queue/queue_concurrency_test.go
@@ -18,6 +18,7 @@ import (
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	"github.com/inngest/inngest/pkg/service"
 	"github.com/oklog/ulid/v2"
 	"github.com/redis/rueidis"
 	"github.com/stretchr/testify/require"
@@ -185,6 +186,197 @@ func TestQueuePartitionConcurrency(t *testing.T) {
 	diff := time.Since(start).Seconds()
 	require.Greater(t, int(diff), 10, "10 jobs should have taken at least 10 seconds")
 	require.Less(t, int(diff), 40, "10 jobs should have taken fewer than 40 seconds") // an extra 2x latency due to race checker
+}
+
+func TestKeyQueueConcurrencyOneDoesNotOverlapSteps(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClockAt(time.Now().Truncate(time.Second))
+	r.SetTime(clock.Now())
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	constraints := osqueue.PartitionConstraintConfig{
+		FunctionVersion: 1,
+		Concurrency: osqueue.PartitionConcurrency{
+			AccountConcurrency:  osqueue.NoConcurrencyLimit,
+			FunctionConcurrency: 1,
+		},
+	}
+	options := []osqueue.QueueOpt{
+		osqueue.WithClock(clock),
+		osqueue.WithNumWorkers(2),
+		osqueue.WithAllowKeyQueues(func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) bool {
+			return true
+		}),
+		osqueue.WithAcquireCapacityLeaseOnBacklogRefill(true),
+		osqueue.WithCapacityLeaseExtendInterval(osqueue.QueueLeaseDuration / 2),
+		osqueue.WithPartitionConstraintConfigGetter(func(context.Context, osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
+			return constraints
+		}),
+	}
+
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("test"),
+		constraintapi.WithClock(clock),
+	)
+	require.NoError(t, err)
+	options = append(options, osqueue.WithCapacityManager(cm))
+
+	shard := redis_state.NewQueueShard(
+		"test",
+		redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey),
+		options...,
+	)
+	registry, err := osqueue.NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+	q, err := osqueue.New(ctx, "test", registry, options...)
+	require.NoError(t, err)
+
+	makeItem := func(jobID string) osqueue.QueueItem {
+		return osqueue.QueueItem{
+			FunctionID:  fnID,
+			WorkspaceID: envID,
+			Data: osqueue.Item{
+				JobID:       &jobID,
+				WorkspaceID: envID,
+				Kind:        osqueue.KindEdge,
+				Identifier: state.Identifier{
+					AccountID:   accountID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
+					RunID:       ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader),
+				},
+			},
+		}
+	}
+
+	first, err := shard.EnqueueItem(ctx, makeItem("first"), clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+	_, err = shard.EnqueueItem(ctx, makeItem("second"), clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	backlog := osqueue.ItemBacklog(ctx, first)
+	shadowPartition := osqueue.ItemShadowPartition(ctx, first)
+	refillUntil := clock.Now().Add(time.Second)
+	refill, _, err := q.ProcessShadowPartitionBacklog(ctx, &shadowPartition, &backlog, refillUntil, constraints)
+	require.NoError(t, err)
+	require.Len(t, refill.RefilledItems, 1, "concurrency 1 should only refill one item")
+
+	// Leave the refilled capacity lease with less time remaining than one full
+	// renewal interval. Without a synchronous refresh before dispatch,
+	// ProcessItem would not attempt its first renewal until after expiry.
+	clock.Advance(osqueue.QueueLeaseDuration - 3*time.Second)
+	r.FastForward(osqueue.QueueLeaseDuration - 3*time.Second)
+	r.SetTime(clock.Now())
+	refilledItem, err := shard.LoadQueueItem(ctx, refill.RefilledItems[0])
+	require.NoError(t, err)
+	require.NotNil(t, refilledItem.CapacityLease)
+	require.Equal(t, 3*time.Second, refilledItem.CapacityLease.LeaseID.Timestamp().Sub(clock.Now()))
+
+	partition := osqueue.ItemPartition(ctx, first)
+	dispatchReady := func() *osqueue.ProcessItem {
+		items, err := shard.Peek(ctx, &partition, clock.Now().Add(time.Second), 10)
+		require.NoError(t, err)
+		if len(items) == 0 {
+			return nil
+		}
+
+		iterator := osqueue.ProcessorIterator{
+			Partition:  &partition,
+			Items:      items,
+			Queue:      q,
+			Dispatch:   dispatchToOSQueueWorkers(q.Workers()),
+			StaticTime: clock.Now(),
+		}
+		require.NoError(t, iterator.Iterate(ctx))
+
+		select {
+		case work := <-q.Workers():
+			return &work
+		default:
+			return nil
+		}
+	}
+
+	firstWork := dispatchReady()
+	require.NotNil(t, firstWork)
+
+	var active, maxActive atomic.Int32
+	started := make(chan struct{}, 2)
+	finish := make(chan struct{})
+	var finishOnce sync.Once
+	finishWork := func() {
+		finishOnce.Do(func() { close(finish) })
+	}
+	defer finishWork()
+	process := func(work osqueue.ProcessItem) <-chan error {
+		done := make(chan error, 1)
+		go func() {
+			_, err := q.ProcessItem(ctx, work, func(context.Context, osqueue.RunInfo, osqueue.Item) (osqueue.RunResult, error) {
+				running := active.Add(1)
+				for {
+					observed := maxActive.Load()
+					if running <= observed || maxActive.CompareAndSwap(observed, running) {
+						break
+					}
+				}
+				started <- struct{}{}
+				<-finish
+				active.Add(-1)
+				return osqueue.RunResult{}, nil
+			})
+			q.Semaphore().Release(1)
+			done <- err
+		}()
+		return done
+	}
+
+	firstDone := process(*firstWork)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.FailNow(t, "first item did not start")
+	}
+
+	// Advance past the original lease's expiry and scavenge it. The refreshed
+	// lease must continue holding the concurrency slot while the first callback
+	// is running.
+	clock.Advance(4 * time.Second)
+	r.FastForward(4 * time.Second)
+	r.SetTime(clock.Now())
+	_, err = cm.Scavenge(ctx)
+	require.NoError(t, err)
+
+	_, _, err = q.ProcessShadowPartitionBacklog(ctx, &shadowPartition, &backlog, clock.Now().Add(time.Second), constraints)
+	require.NoError(t, err)
+	secondWork := dispatchReady()
+	var secondDone <-chan error
+	if secondWork != nil {
+		secondDone = process(*secondWork)
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			require.FailNow(t, "second item was dispatched but did not start")
+		}
+	}
+
+	finishWork()
+	require.NoError(t, <-firstDone)
+	if secondDone != nil {
+		require.NoError(t, <-secondDone)
+	}
+	service.Wait()
+
+	require.LessOrEqual(t, maxActive.Load(), int32(1), "steps sharing concurrency 1 must never overlap")
 }
 
 type testLifecycleListener struct {


### PR DESCRIPTION
## Description

Prevent key-queue items from starting with a capacity lease that can expire before the first renewal tick.

Near-expiry leases are now renewed synchronously before item dispatch, using a reuse threshold based on the configured renewal interval plus a safety margin. If the renewal fails or returns no replacement lease, the item is not dispatched. Processing also watches the active lease expiry and cancels and requeues the item if renewal is not confirmed in time.

Adds a Redis-backed integration regression test for overlapping steps at concurrency one, plus focused coverage for pre-dispatch renewal failure and runtime expiry.

## Release note

Fixed an issue where steps using key queues could overlap despite a concurrency limit of one when a pre-acquired capacity lease expired before its first renewal.

## Migration note

None.