### PR TITLE
feat(sandbox): accept snapshot ID when creating sandboxes

### DIFF
--- a/proto/api/v2/sandbox.proto
+++ b/proto/api/v2/sandbox.proto
@@ -81,6 +81,7 @@ message CreateSandboxRequest {
   uint32 vcpu = 2;
   uint32 memory_mb = 3;
   map<string, string> environment = 4;
+  optional string snapshot_id = 5;
 }
 
 message ListSandboxesRequest {

--- a/proto/gen/api/v2/sandbox.pb.go
+++ b/proto/gen/api/v2/sandbox.pb.go
@@ -631,6 +631,7 @@ type CreateSandboxRequest struct {
 	Vcpu          uint32                 `protobuf:"varint,2,opt,name=vcpu,proto3" json:"vcpu,omitempty"`
 	MemoryMb      uint32                 `protobuf:"varint,3,opt,name=memory_mb,json=memoryMb,proto3" json:"memory_mb,omitempty"`
 	Environment   map[string]string      `protobuf:"bytes,4,rep,name=environment,proto3" json:"environment,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	SnapshotId    *string                `protobuf:"bytes,5,opt,name=snapshot_id,json=snapshotId,proto3,oneof" json:"snapshot_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -691,6 +692,13 @@ func (x *CreateSandboxRequest) GetEnvironment() map[string]string {
 		return x.Environment
 	}
 	return nil
+}
+
+func (x *CreateSandboxRequest) GetSnapshotId() string {
+	if x != nil && x.SnapshotId != nil {
+		return *x.SnapshotId
+	}
+	return ""
 }
 
 type ListSandboxesRequest struct {
@@ -2440,15 +2448,18 @@ const file_api_v2_sandbox_proto_rawDesc = "" +
 	"\x04data\x18\x01 \x01(\v2\x0f.api.v2.SandboxH\x00R\x04data\x88\x01\x01\x12@\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x1f.api.v2.SandboxResponseMetadataH\x01R\bmetadata\x88\x01\x01B\a\n" +
 	"\x05_dataB\v\n" +
-	"\t_metadata\"\xec\x01\n" +
+	"\t_metadata\"\xa2\x02\n" +
 	"\x14CreateSandboxRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
 	"\x04vcpu\x18\x02 \x01(\rR\x04vcpu\x12\x1b\n" +
 	"\tmemory_mb\x18\x03 \x01(\rR\bmemoryMb\x12O\n" +
-	"\venvironment\x18\x04 \x03(\v2-.api.v2.CreateSandboxRequest.EnvironmentEntryR\venvironment\x1a>\n" +
+	"\venvironment\x18\x04 \x03(\v2-.api.v2.CreateSandboxRequest.EnvironmentEntryR\venvironment\x12$\n" +
+	"\vsnapshot_id\x18\x05 \x01(\tH\x00R\n" +
+	"snapshotId\x88\x01\x01\x1a>\n" +
 	"\x10EnvironmentEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"c\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\x0e\n" +
+	"\f_snapshot_id\"c\n" +
 	"\x14ListSandboxesRequest\x12\x1b\n" +
 	"\x06cursor\x18\x01 \x01(\tH\x00R\x06cursor\x88\x01\x01\x12\x19\n" +
 	"\x05limit\x18\x02 \x01(\x05H\x01R\x05limit\x88\x01\x01B\t\n" +
@@ -2750,6 +2761,7 @@ func file_api_v2_sandbox_proto_init() {
 	file_api_v2_sandbox_proto_msgTypes[2].OneofWrappers = []any{}
 	file_api_v2_sandbox_proto_msgTypes[3].OneofWrappers = []any{}
 	file_api_v2_sandbox_proto_msgTypes[6].OneofWrappers = []any{}
+	file_api_v2_sandbox_proto_msgTypes[7].OneofWrappers = []any{}
 	file_api_v2_sandbox_proto_msgTypes[8].OneofWrappers = []any{}
 	file_api_v2_sandbox_proto_msgTypes[12].OneofWrappers = []any{}
 	file_api_v2_sandbox_proto_msgTypes[13].OneofWrappers = []any{}


### PR DESCRIPTION
## What changed

Adds an optional `snapshot_id` to the public `CreateSandboxRequest`. This lets SDK clients ask the Cloud API to create a sandbox from an existing snapshot.

The field is optional, so existing sandbox create requests are unchanged.

## Why

The snapshot SDK already sends the snapshot ID when cloning. The public API protobuf did not have a field for it, so the Cloud API could not receive or forward that value.

## Validation

- Generated Go protobuf updated from the source proto
- Used by the full local snapshot clone E2E in inngest/monorepo