### PR TITLE
fix(queue): retry transient network errors in scan loops instead of exiting

### DIFF
--- a/pkg/execution/queue/scan.go
+++ b/pkg/execution/queue/scan.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -15,6 +17,49 @@ import (
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"golang.org/x/sync/errgroup"
 )
+
+// isTransientScanError reports whether a queue scan failure is a transient I/O
+// condition that should be retried with backoff rather than treated as fatal.
+//
+// The scan loops already retry context.DeadlineExceeded, which covers a
+// deadline the server sets itself. A deadline hit at the socket layer while
+// talking to the backing store surfaces as os.ErrDeadlineExceeded instead --
+// a distinct sentinel that prints as "i/o timeout" -- so it fell through to
+// the fatal path and tore down every service on a single blip from Redis or
+// Postgres. Connection resets, refused connections and transient resolver
+// failures reach the same loop the same way.
+//
+// None of these justify exiting the process: if the condition is transient the
+// next tick recovers, and if it is not, backing off in place is still strictly
+// better than a crash loop that drops queue leases and restarts from scratch.
+func isTransientScanError(err error) bool {
+	// A deadline the server set itself.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// A deadline hit at the socket layer.
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+	// Any network-layer failure talking to the backing store: timeouts,
+	// connection resets, refused connections, broken pipes.
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	// Transient resolver failures, e.g. "server misbehaving" from a DNS
+	// hiccup in the container network.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	// Anything else that self-reports as a timeout.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	return false
+}
 
 func (q *queueProcessor) executionScan(ctx context.Context, dispatch DispatchFunc) error {
 	l := logger.StdlibLogger(ctx).With(
@@ -53,8 +98,11 @@ LOOP:
 			}
 
 			if err = q.scan(ctx, dispatch); err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					l.Warn("deadline exceeded scanning partition pointers")
+				if isTransientScanError(err) {
+					l.Warn("transient error scanning partition pointers, retrying",
+						"error", err,
+						"backoff", backoff.String(),
+					)
 					<-time.After(backoff)
 
 					// Backoff doubles up to 3 seconds.
@@ -323,8 +371,11 @@ func (q *queueProcessor) shadowScan(ctx context.Context) error {
 			now := q.Clock().Now()
 			scanUntil := now.Truncate(time.Second).Add(ShadowPartitionLookahead)
 			if err := q.ScanShadowPartitions(ctx, scanUntil, q.qspc); err != nil {
-				if errors.Is(err, context.DeadlineExceeded) {
-					l.Warn("deadline exceeded scanning shadow partitions")
+				if isTransientScanError(err) {
+					l.Warn("transient error scanning shadow partitions, retrying",
+						"error", err,
+						"backoff", backoff.String(),
+					)
 					<-time.After(backoff)
 
 					// Backoff doubles up to 5 seconds

--- a/pkg/execution/queue/scan.go
+++ b/pkg/execution/queue/scan.go
@@ -47,11 +47,15 @@ func isTransientScanError(err error) bool {
 	if errors.As(err, &opErr) {
 		return true
 	}
-	// Transient resolver failures, e.g. "server misbehaving" from a DNS
-	// hiccup in the container network.
+	// Resolver failures, but only the ones that report themselves as transient
+	// -- e.g. SERVFAIL ("server misbehaving") from a DNS hiccup in the
+	// container network, which sets IsTemporary. A permanent NXDOMAIN from a
+	// misconfigured endpoint sets IsNotFound instead and must stay fatal:
+	// retrying it forever would leave the server up and healthy-looking while
+	// it can never reach its state store again.
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
-		return true
+		return dnsErr.IsTimeout || dnsErr.IsTemporary
 	}
 	// Anything else that self-reports as a timeout.
 	var netErr net.Error

--- a/pkg/execution/queue/scan_transient_test.go
+++ b/pkg/execution/queue/scan_transient_test.go
@@ -60,13 +60,43 @@ func TestIsTransientScanError(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "transient DNS failure",
+			// SERVFAIL from a resolver hiccup. This is the shape actually
+			// observed when a container network's DNS went bad for ~30 minutes.
+			name: "transient DNS failure (SERVFAIL sets IsTemporary)",
 			err: &net.DNSError{
 				Err:         "server misbehaving",
 				Name:        "example.redis.azure.net",
 				IsTemporary: true,
 			},
 			want: true,
+		},
+		{
+			name: "DNS timeout",
+			err: &net.DNSError{
+				Err:       "i/o timeout",
+				Name:      "example.redis.azure.net",
+				IsTimeout: true,
+			},
+			want: true,
+		},
+		// A permanent NXDOMAIN means the endpoint is misconfigured or gone.
+		// Retrying forever would keep the process up and passing health checks
+		// while it can never reach its state store, which hides the fault
+		// instead of surfacing it.
+		{
+			name: "permanent DNS not-found is NOT transient",
+			err: &net.DNSError{
+				Err:        "no such host",
+				Name:       "typo.redis.azure.net",
+				IsNotFound: true,
+			},
+			want: false,
+		},
+		{
+			name: "wrapped permanent DNS not-found is NOT transient",
+			err: fmt.Errorf("could not peek global partitions: %w",
+				&net.DNSError{Err: "no such host", Name: "typo.redis.azure.net", IsNotFound: true}),
+			want: false,
 		},
 		// Cancellation is a shutdown signal, not a transient fault: the loop
 		// must still exit so a real SIGTERM drains cleanly.

--- a/pkg/execution/queue/scan_transient_test.go
+++ b/pkg/execution/queue/scan_transient_test.go
@@ -1,0 +1,83 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsTransientScanError covers the failure modes that previously took the
+// whole server down. The production signature is a socket read deadline from
+// the Redis state store, wrapped by the scan call chain, which prints as:
+//
+//	error scanning continuations: error leasing partition: i/o timeout
+//
+// os.ErrDeadlineExceeded is a different sentinel than context.DeadlineExceeded,
+// so the original errors.Is check missed it and fell through to the fatal path.
+func TestIsTransientScanError(t *testing.T) {
+	// The exact shape the net package produces for a socket read deadline.
+	socketTimeout := &net.OpError{
+		Op:  "read",
+		Net: "tcp",
+		Err: os.ErrDeadlineExceeded,
+	}
+	require.Equal(t, "i/o timeout", os.ErrDeadlineExceeded.Error(),
+		"guard: the production log line is this sentinel's message")
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "socket read deadline, wrapped by the scan call chain",
+			err: fmt.Errorf("error scanning continuations: %w",
+				fmt.Errorf("error leasing partition: %w", socketTimeout)),
+			want: true,
+		},
+		{"bare socket read deadline", socketTimeout, true},
+		{"os.ErrDeadlineExceeded sentinel", os.ErrDeadlineExceeded, true},
+		{"context deadline still retried", context.DeadlineExceeded, true},
+		{
+			name: "wrapped context deadline",
+			err:  fmt.Errorf("could not peek global partitions: %w", context.DeadlineExceeded),
+			want: true,
+		},
+		{
+			name: "connection reset by peer",
+			err:  &net.OpError{Op: "read", Net: "tcp", Err: syscall.ECONNRESET},
+			want: true,
+		},
+		{
+			name: "connection refused",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: syscall.ECONNREFUSED},
+			want: true,
+		},
+		{
+			name: "transient DNS failure",
+			err: &net.DNSError{
+				Err:         "server misbehaving",
+				Name:        "example.redis.azure.net",
+				IsTemporary: true,
+			},
+			want: true,
+		},
+		// Cancellation is a shutdown signal, not a transient fault: the loop
+		// must still exit so a real SIGTERM drains cleanly.
+		{"context canceled is not transient", context.Canceled, false},
+		{"application error is not transient", errors.New("malformed partition"), false},
+		{"nil", nil, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isTransientScanError(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The queue scan loops retry `context.DeadlineExceeded` with backoff, but treat every other scan error as fatal — they `break LOOP` and return, which errors the executor service, and `service.StartAll` then cancels every other service and the process exits.

A read deadline hit at the **socket** layer while talking to the state store is not `context.DeadlineExceeded`. It's **`os.ErrDeadlineExceeded`** — a distinct sentinel, whose `Error()` is the string `i/o timeout`. So a single slow Redis read skips the retry branch it should have taken and terminates the whole server. Connection resets, refused connections and transient DNS failures reach the loop the same way.

```go
// pkg/execution/queue/scan.go
if err = q.scan(ctx); err != nil {
    if errors.Is(err, context.DeadlineExceeded) {
        // ... backoff, doubling to 5s ...
        continue
    }
    // On scan errors, halt the worker entirely.
    break LOOP     // -> service errored -> StartAll cancels everything -> exit
}
```

## Evidence

Seen repeatedly on a self-hosted deployment backed by Azure Managed Redis. A brief Redis blip produces:

```
service executor errored: error scanning partition: could not peek global
partitions: error peeking partition items: i/o timeout
```

...followed by exit code 1.

The part that isolates it: an application container **in the same environment, sharing the same Redis, hitting the same blip in the same seconds**, logs `ECONNRESET` / `ETIMEDOUT` / `getaddrinfo ENOTFOUND`, reconnects, and carries on with zero restarts. Only the Inngest process dies. That points at the scan loop's error classification rather than at Redis, the network, or configuration.

## Fix

Add `isTransientScanError` and use it in **both** `executionScan` and `shadowScan` (they had the same narrow check). It covers:

- `context.DeadlineExceeded` — unchanged behaviour
- `os.ErrDeadlineExceeded` — the socket-layer deadline that caused this
- `*net.OpError` — resets, refused connections, broken pipes
- `*net.DNSError` — transient resolver failures
- anything else reporting `net.Error.Timeout()`

`context.Canceled` is **deliberately excluded**, so shutdown still exits promptly and SIGTERM keeps draining cleanly.

The reasoning: exiting was never the better response to these. If the fault is transient, the next tick recovers. If it isn't, backing off in place still beats a crash loop that drops queue leases and restarts from scratch. The retry-with-backoff path already existed and was already correct — it was just matched too narrowly.

## Testing

New unit test over the real error shapes, including the exact production wrapping (`error scanning continuations: error leasing partition: i/o timeout`) and a guard that `context.Canceled` stays fatal. 11 cases.

End-to-end against `v1.33.0`, two containers on one Redis, Redis then paused to induce a real socket timeout:

| | Stock `v1.33.0` | Patched |
|---|---|---|
| During outage | `exited, exitcode=1` | `running, restarts=0` |
| Log | `service executor errored: … i/o timeout` | `WARN transient error … retrying, backoff 250ms → 500ms → 1s` |
| After Redis returns | (dead) | recovers, still zero restarts |

`go vet ./pkg/execution/queue/` clean on `main`.

## Notes

Happy to adjust the classification if you'd prefer it narrower (e.g. timeouts only, dropping `*net.OpError`) or to add a consecutive-failure cap before giving up — I kept it consistent with the existing unbounded `DeadlineExceeded` retry rather than introducing a new policy.