### PR TITLE
fix(ui): removed events column from plan upgrade

### DIFF
--- a/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
+++ b/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
@@ -417,8 +417,6 @@ function InfraPlanDropdown({
               <span className="bg-canvasMuted rounded px-1.5 py-0.5 font-medium">
                 {selectedPlan.displaySku ?? selectedPlan.sku}
               </span>
-              <span>{selectedPlan.eventStream}</span>
-              <span className="text-disabled">·</span>
               <span>{selectedPlan.queueDepth} depth</span>
               <span className="text-disabled">·</span>
               <span>{selectedPlan.execConcurrency} concurrency</span>
@@ -434,7 +432,7 @@ function InfraPlanDropdown({
         </DropdownMenuTrigger>
         <DropdownMenuContent
           align="end"
-          className="w-[min(calc(100vw-2rem),640px)] overflow-hidden p-0"
+          className="w-[min(calc(100vw-2rem),420px)] overflow-hidden p-0"
         >
           <div className="border-subtle bg-canvasSubtle flex items-center gap-1 border-b p-2">
             <button
@@ -455,12 +453,11 @@ function InfraPlanDropdown({
           </div>
 
           <div className="overflow-x-auto">
-            <div className="min-w-[580px]">
-              <div className="bg-canvasSubtle text-muted grid grid-cols-[96px_140px_140px_160px_1fr] px-3 py-2 text-left text-[11px] font-medium uppercase">
+            <div className="min-w-[360px]">
+              <div className="bg-canvasSubtle text-muted grid grid-cols-[4.25rem_1fr_1fr_auto] gap-x-3 px-3 py-2 text-left text-[11px] font-medium uppercase">
                 <span>SKU</span>
-                <span>Events</span>
                 <span>Queue depth</span>
-                <span>Exec concurrency</span>
+                <span>Concurrency</span>
                 <span className="text-right">Price / mo</span>
               </div>
               {plans.map((plan) => {
@@ -487,7 +484,7 @@ function InfraPlanDropdown({
                 return (
                   <button
                     className={cn(
-                      'border-subtle text-basis grid w-full grid-cols-[96px_140px_140px_160px_1fr] items-center border-t px-3 py-2.5 text-left text-xs disabled:cursor-default disabled:opacity-100',
+                      'border-subtle text-basis grid w-full grid-cols-[4.25rem_1fr_1fr_auto] items-center gap-x-3 border-t px-3 py-2.5 text-left text-xs disabled:cursor-default disabled:opacity-100',
                       isCurrent && 'bg-canvasSubtle',
                       isActionable &&
                         'hover:bg-canvasSubtle focus:bg-canvasSubtle focus:outline-none',
@@ -509,7 +506,6 @@ function InfraPlanDropdown({
                         {plan.sku}
                       </span>
                     </span>
-                    <PlanMetric value={plan.eventStream} />
                     <PlanMetric value={plan.queueDepth} />
                     <PlanMetric value={plan.execConcurrency} />
                     <span className="flex min-w-0 items-center justify-end gap-2">

--- a/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
+++ b/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
@@ -454,7 +454,7 @@ function InfraPlanDropdown({
 
           <div className="overflow-x-auto">
             <div className="min-w-[360px]">
-              <div className="bg-canvasSubtle text-muted grid grid-cols-[4.25rem_1fr_1fr_auto] gap-x-3 px-3 py-2 text-left text-[11px] font-medium uppercase">
+              <div className="bg-canvasSubtle text-muted grid grid-cols-[4.25rem_1fr_1fr_6.75rem] gap-x-3 px-3 py-2 text-left text-[11px] font-medium uppercase">
                 <span>SKU</span>
                 <span>Queue depth</span>
                 <span>Concurrency</span>
@@ -484,7 +484,7 @@ function InfraPlanDropdown({
                 return (
                   <button
                     className={cn(
-                      'border-subtle text-basis grid w-full grid-cols-[4.25rem_1fr_1fr_auto] items-center gap-x-3 border-t px-3 py-2.5 text-left text-xs disabled:cursor-default disabled:opacity-100',
+                      'border-subtle text-basis grid w-full grid-cols-[4.25rem_1fr_1fr_6.75rem] items-center gap-x-3 border-t px-3 py-2.5 text-left text-xs disabled:cursor-default disabled:opacity-100',
                       isCurrent && 'bg-canvasSubtle',
                       isActionable &&
                         'hover:bg-canvasSubtle focus:bg-canvasSubtle focus:outline-none',


### PR DESCRIPTION
## Description

<img width="652" height="313" alt="image" src="https://github.com/user-attachments/assets/65d88c13-701c-4e9c-87a0-aa6dfae164b3" />

The events column was confusing users that this value is their included executions for the plan they choose. Removing it to avoid further confusion
<img width="456" height="426" alt="Screenshot 2026-08-23 at 2 45 15 PM" src="https://github.com/user-attachments/assets/e6bfa659-9bd8-4f54-b70d-eba3a4ed89e1" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
