### PR TITLE
fix(connect): track reply delivery outcomes

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -1313,6 +1313,18 @@ func (c *connectionHandler) handleSdkReply(ctx context.Context, msg *connectpb.C
 
 	// Persist response in buffer, which is polled by executor.
 	err := c.svc.stateManager.SaveResponse(ctx, c.conn.EnvID, data.RequestId, data)
+	bufferOutcome := "success"
+	if errors.Is(err, state.ErrResponseAlreadyBuffered) {
+		bufferOutcome = "duplicate"
+	} else if err != nil {
+		bufferOutcome = "error"
+	}
+	bufferTags := c.svc.metricsTags()
+	bufferTags["outcome"] = bufferOutcome
+	metrics.IncrConnectGatewayResponseBufferWriteCounter(ctx, 1, metrics.CounterOpt{
+		PkgName: pkgName,
+		Tags:    bufferTags,
+	})
 	if err != nil && !errors.Is(err, state.ErrResponseAlreadyBuffered) {
 		return fmt.Errorf("could not save response: %w", err)
 	}

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -1324,12 +1324,32 @@ func (c *connectionHandler) handleSdkReply(ctx context.Context, msg *connectpb.C
 
 		switch {
 		case err == nil:
-			if _, err := grpcClient.Reply(ctx, &connectpb.ReplyRequest{Data: data}); err != nil {
+			result, err := grpcClient.Reply(ctx, &connectpb.ReplyRequest{Data: data})
+			if err != nil {
+				tags := c.svc.metricsTags()
+				tags["reason"] = "reply_error"
+				metrics.IncrConnectGatewayGRPCExecutorReplyFailureCounter(ctx, 1, metrics.CounterOpt{
+					PkgName: pkgName,
+					Tags:    tags,
+				})
 				l.Warn("could not fast-track response through grpc, executor will poll buffered response", "err", err)
+			} else if result == nil || !result.Success {
+				tags := c.svc.metricsTags()
+				tags["reason"] = "reply_rejected"
+				metrics.IncrConnectGatewayGRPCExecutorReplyFailureCounter(ctx, 1, metrics.CounterOpt{
+					PkgName: pkgName,
+					Tags:    tags,
+				})
 			}
 		case errors.Is(err, state.ErrExecutorNotFound):
 			l.Debug("executor not found in lease, reply was likely picked up by polling")
 		default:
+			tags := c.svc.metricsTags()
+			tags["reason"] = "client_creation"
+			metrics.IncrConnectGatewayGRPCExecutorReplyFailureCounter(ctx, 1, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags:    tags,
+			})
 			l.Warn("could not create grpc client for sdk reply, executor will poll buffered response", "err", err)
 		}
 	}

--- a/pkg/connect/grpc/proxy.go
+++ b/pkg/connect/grpc/proxy.go
@@ -164,12 +164,20 @@ func (i *grpcConnector) Proxy(ctx, traceCtx context.Context, opts ProxyOpts) (*c
 		// to have already sent a response and completed the request.
 		resp, err := i.stateManager.GetResponse(ctx, opts.EnvID, opts.Data.RequestId)
 		if err != nil {
+			metrics.IncrConnectProxyResponseBufferReadCounter(ctx, 1, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags:    map[string]any{"outcome": "error"},
+			})
 			span.RecordError(err)
 			l.ReportError(err, "could not check for buffered response")
 			return nil, fmt.Errorf("could not check for buffered response: %w", err)
 		}
 
 		if resp != nil {
+			metrics.IncrConnectProxyResponseBufferReadCounter(ctx, 1, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags:    map[string]any{"outcome": "hit"},
+			})
 			// We have a response already, return it
 			l.Debug("found buffered response")
 
@@ -239,12 +247,20 @@ func (i *grpcConnector) Proxy(ctx, traceCtx context.Context, opts ProxyOpts) (*c
 
 			resp, err := i.stateManager.GetResponse(ctx, opts.EnvID, opts.Data.RequestId)
 			if err != nil {
+				metrics.IncrConnectProxyResponseBufferReadCounter(ctx, 1, metrics.CounterOpt{
+					PkgName: pkgName,
+					Tags:    map[string]any{"outcome": "error"},
+				})
 				span.RecordError(err)
 				l.ReportError(err, "could not check for response")
 				continue
 			}
 
 			if resp != nil {
+				metrics.IncrConnectProxyResponseBufferReadCounter(ctx, 1, metrics.CounterOpt{
+					PkgName: pkgName,
+					Tags:    map[string]any{"outcome": "hit"},
+				})
 				span.AddEvent("ReplyReceivedPoll")
 
 				l.Debug("received response via polling")

--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -221,6 +221,15 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 
 	// Reliable path: Buffer the response to be picked up by the executor
 	err = cr.ConnectRequestStateManager.SaveResponse(ctx, res.EnvID, reqBody.RequestId, reqBody)
+	bufferOutcome := "success"
+	if errors.Is(err, state.ErrResponseAlreadyBuffered) {
+		bufferOutcome = "duplicate"
+	} else if err != nil {
+		bufferOutcome = "error"
+	}
+	metrics.IncrConnectGatewayResponseBufferWriteCounter(ctx, 1, metrics.CounterOpt{
+		Tags: map[string]any{"outcome": bufferOutcome},
+	})
 	if err != nil && !errors.Is(err, state.ErrResponseAlreadyBuffered) {
 		l.Error("could not buffer response", "err", err)
 		span.RecordError(err)

--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/connect/state"
 	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/codes"
@@ -243,10 +244,20 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 			grpcURL := net.JoinHostPort(executorIP, fmt.Sprintf("%d", cr.Opts.ConnectGRPCConfig.Executor.Port))
 			grpcClient, err := cr.grpcClientManager.GetOrCreateClient(notifyCtx, executorIP, grpcURL)
 			if err != nil {
+				metrics.IncrConnectGatewayGRPCExecutorReplyFailureCounter(notifyCtx, 1, metrics.CounterOpt{
+					Tags: map[string]any{"reason": "client_creation"},
+				})
 				l.Error("could not create grpc client", "url", grpcURL, "err", err)
 			} else {
 				result, err := grpcClient.Reply(notifyCtx, &connectpb.ReplyRequest{Data: reqBody})
-				if err != nil || !result.Success {
+				if err != nil || result == nil || !result.Success {
+					reason := "reply_rejected"
+					if err != nil {
+						reason = "reply_error"
+					}
+					metrics.IncrConnectGatewayGRPCExecutorReplyFailureCounter(notifyCtx, 1, metrics.CounterOpt{
+						Tags: map[string]any{"reason": reason},
+					})
 					l.Error("could not notify executor to flush connect message", "err", err)
 				}
 			}

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -358,6 +358,15 @@ func IncrConnectGatewayGRPCReplyCounter(ctx context.Context, value int64, opts C
 	})
 }
 
+func IncrConnectGatewayGRPCExecutorReplyFailureCounter(ctx context.Context, value int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, value, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "connect_gateway.grpc.executor_reply_failure_total",
+		Description: "Total number of failures sending replies from connect gateways to executors via gRPC",
+		Tags:        opts.Tags,
+	})
+}
+
 func IncrConnectGatewayGRPCClientFailureCounter(ctx context.Context, value int64, opts CounterOpt) {
 	RecordCounterMetric(ctx, value, CounterOpt{
 		PkgName:     opts.PkgName,

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -367,6 +367,24 @@ func IncrConnectGatewayGRPCExecutorReplyFailureCounter(ctx context.Context, valu
 	})
 }
 
+func IncrConnectGatewayResponseBufferWriteCounter(ctx context.Context, value int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, value, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "connect_gateway.response_buffer.write_total",
+		Description: "Total number of connect gateway response buffer writes",
+		Tags:        opts.Tags,
+	})
+}
+
+func IncrConnectProxyResponseBufferReadCounter(ctx context.Context, value int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, value, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "connect_proxy.response_buffer.read_total",
+		Description: "Total number of connect proxy response buffer hits and read errors",
+		Tags:        opts.Tags,
+	})
+}
+
 func IncrConnectGatewayGRPCClientFailureCounter(ctx context.Context, value int64, opts CounterOpt) {
 	RecordCounterMetric(ctx, value, CounterOpt{
 		PkgName:     opts.PkgName,


### PR DESCRIPTION
## Description

Add metrics for the Connect response delivery path from gateways to executors.

`connect_gateway.grpc.executor_reply_failure_total` distinguishes low-cardinality gRPC failure stages with a `reason` tag:

- `client_creation` when the executor gRPC client cannot be created or validated
- `reply_error` when the `Reply` RPC fails
- `reply_rejected` when the executor receives the RPC but can no longer deliver it to the subscriber

The response buffer fallback is tracked with:

- `connect_gateway.response_buffer.write_total{outcome=success|duplicate|error}`
- `connect_proxy.response_buffer.read_total{outcome=hit|error}`

Instrument both WebSocket Connect replies and the REST v0 flush path. Responses continue to be buffered before the best-effort gRPC notification, and existing delivery behavior is preserved.

Verification:

- `go test -count=1 -tags test -short ./pkg/connect ./pkg/connect/grpc ./pkg/connect/rest/v0 ./pkg/telemetry/metrics`
- `git diff --check`

## Release note

None.

## Migration note

None.