### PR TITLE
feat(auth): add CLI OAuth login

### DIFF
--- a/cmd/apiv2cli/cmd.go
+++ b/cmd/apiv2cli/cmd.go
@@ -19,6 +19,7 @@ import (
 	"time"
 	"unicode"
 
+	cliauth "github.com/inngest/inngest/cmd/internal/auth"
 	localconfig "github.com/inngest/inngest/cmd/internal/config"
 	"github.com/inngest/inngest/pkg/api"
 	"github.com/inngest/inngest/pkg/api/tel"
@@ -155,7 +156,7 @@ func commonFlags() []cli.Flag {
 		&cli.StringFlag{
 			Category: "Auth",
 			Name:     "env",
-			Usage:    "Environment name sent as X-Inngest-Env",
+			Usage:    "Environment name sent as X-Inngest-Env; defaults to production",
 			Sources:  cli.EnvVars("INNGEST_ENV"),
 		},
 		&cli.DurationFlag{
@@ -481,15 +482,17 @@ func buildRequest(ctx context.Context, cmd *cli.Command, ep endpoint) (*http.Req
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", "inngest-cli/"+version.Version)
 
-	if token, err := authToken(cmd); err != nil {
+	if token, err := authToken(ctx, cmd, baseURL); err != nil {
 		return nil, err
 	} else if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	if env := cmd.String("env"); env != "" {
-		req.Header.Set("X-Inngest-Env", env)
+	env := cmd.String("env")
+	if env == "" {
+		env = "production"
 	}
+	req.Header.Set("X-Inngest-Env", env)
 
 	if err := guardPlaintextAuth(req); err != nil {
 		return nil, err
@@ -890,11 +893,22 @@ func parseTimestamp(value string) (string, error) {
 	return value, nil
 }
 
-func authToken(cmd *cli.Command) (string, error) {
+func authToken(ctx context.Context, cmd *cli.Command, resource string) (string, error) {
 	if apiKey := cmd.String("api-key"); apiKey != "" {
 		return apiKey, nil
 	}
-	return cmd.String("signing-key"), nil
+	if signingKey := cmd.String("signing-key"); signingKey != "" {
+		return signingKey, nil
+	}
+	manager, err := cliauth.NewManager()
+	if err != nil {
+		return "", err
+	}
+	token, _, err := manager.AccessToken(ctx, resource)
+	if errors.Is(err, cliauth.ErrNotLoggedIn) {
+		return "", nil
+	}
+	return token, err
 }
 
 func addQueryValue(values url.Values, key string, value any) {

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -14,7 +14,9 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 
+	cliauth "github.com/inngest/inngest/cmd/internal/auth"
 	"github.com/inngest/inngest/pkg/api/v2/apiv2endpoint"
 	"github.com/inngest/inngest/pkg/inngest/version"
 	"github.com/stretchr/testify/require"
@@ -862,6 +864,51 @@ func TestCommandPrefersAPIKeyOverSigningKeyEnv(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "Bearer sk-inn-api-test", gotAuth)
+}
+
+func TestCommandUsesStoredOAuthForMatchingResource(t *testing.T) {
+	t.Setenv("INNGEST_API_KEY", "")
+	t.Setenv("INNGEST_SIGNING_KEY", "")
+	t.Setenv("INNGEST_CONFIG_DIR", t.TempDir())
+
+	var gotAuth string
+	var gotEnv string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotEnv = r.Header.Get("X-Inngest-Env")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{},"metadata":{}}`))
+	}))
+	defer server.Close()
+
+	store, err := cliauth.NewStore()
+	require.NoError(t, err)
+	require.NoError(t, store.Save(cliauth.Metadata{
+		Issuer:               server.URL,
+		Resource:             server.URL + "/v2",
+		ClientID:             cliauth.ClientID,
+		SessionID:            "session-id",
+		SessionExpiresAt:     time.Now().Add(time.Hour),
+		AccountID:            "account-id",
+		ResourceBoundaryMode: "all_envs",
+	}, cliauth.Credential{
+		AccessToken:  "inngest_at_stored",
+		RefreshToken: "inngest_rt_stored",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}, true))
+
+	cmd := Command()
+	cmd.Writer = &bytes.Buffer{}
+	err = cmd.Run(context.Background(), []string{
+		"api",
+		"health",
+		"--api-host", server.URL,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "Bearer inngest_at_stored", gotAuth)
+	require.Equal(t, "production", gotEnv)
 }
 
 func TestNormalizeAPIURL(t *testing.T) {

--- a/cmd/auth/cmd.go
+++ b/cmd/auth/cmd.go
@@ -1,0 +1,278 @@
+package authcmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	cliauth "github.com/inngest/inngest/cmd/internal/auth"
+	"github.com/urfave/cli/v3"
+	"golang.org/x/oauth2"
+)
+
+func LoginCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "login",
+		Usage: "Log in to Inngest Cloud",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "no-browser",
+				Usage: "Do not open the verification page",
+			},
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "Start a new login when already logged in",
+			},
+			&cli.BoolFlag{
+				Name:  "insecure-storage",
+				Usage: "Store credentials in a user-only file when no OS credential store is available",
+			},
+		},
+		Action: jsonAction(login),
+	}
+}
+
+func LogoutCommand() *cli.Command {
+	return &cli.Command{
+		Name:   "logout",
+		Usage:  "Log out of Inngest Cloud",
+		Action: jsonAction(logout),
+	}
+}
+
+func AuthCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "auth",
+		Usage: "Inspect CLI authentication",
+		Commands: []*cli.Command{
+			{
+				Name:   "status",
+				Usage:  "Show the current login",
+				Action: jsonAction(status),
+			},
+		},
+	}
+}
+
+func login(ctx context.Context, cmd *cli.Command) error {
+	manager, err := cliauth.NewManager()
+	if err != nil {
+		return err
+	}
+	previousMetadata, previousCredential, loadErr := manager.Store().Load()
+	if !cmd.Bool("force") {
+		if loadErr == nil {
+			accessToken, metadata, tokenErr := manager.AccessToken(ctx, previousMetadata.Resource)
+			if tokenErr == nil && manager.Validate(ctx, metadata, accessToken) == nil {
+				return writeStatus(cmd, metadata, true, "already_authenticated")
+			}
+		} else if !errors.Is(loadErr, cliauth.ErrNotLoggedIn) {
+			return loadErr
+		}
+	}
+
+	issuer, err := cliauth.Issuer()
+	if err != nil {
+		return err
+	}
+	resource := cliauth.Resource(issuer)
+	oauthConfig := cliauth.OAuthConfig(issuer)
+	ctx = manager.Context(ctx)
+	device, err := oauthConfig.DeviceAuth(ctx, oauth2.SetAuthURLParam("resource", resource))
+	if err != nil {
+		return fmt.Errorf("start device login: %w", err)
+	}
+	if err := writeVerification(cmd, device); err != nil {
+		return err
+	}
+	if !cmd.Bool("no-browser") {
+		verificationURL := device.VerificationURIComplete
+		if verificationURL == "" {
+			verificationURL = device.VerificationURI
+		}
+		_ = cliauth.OpenBrowser(verificationURL)
+	}
+	token, err := oauthConfig.DeviceAccessToken(ctx, device, oauth2.SetAuthURLParam("resource", resource))
+	if err != nil {
+		return fmt.Errorf("complete device login: %w", err)
+	}
+	metadata, credential, err := cliauth.MetadataFromToken(issuer, token)
+	if err != nil {
+		return err
+	}
+	if cmd.Bool("insecure-storage") && !cmd.Bool("json") {
+		_, _ = fmt.Fprintln(writer(cmd), "Warning: storing credentials in a plaintext user-only file. Use this only on a trusted machine or ephemeral environment.")
+	}
+	if err := manager.Store().Save(*metadata, *credential, cmd.Bool("insecure-storage")); err != nil {
+		if !cmd.Bool("insecure-storage") {
+			return fmt.Errorf("%w; retry with --insecure-storage only on a trusted machine", err)
+		}
+		return err
+	}
+	if loadErr == nil && previousMetadata.SessionID != metadata.SessionID {
+		if err := manager.Revoke(ctx, previousMetadata, previousCredential); err != nil {
+			if cmd.Bool("json") {
+				if writeErr := writeJSONLine(cmd, map[string]any{
+					"type":    "warning",
+					"message": "The previous session could not be revoked.",
+				}); writeErr != nil {
+					return writeErr
+				}
+			} else {
+				_, _ = fmt.Fprintln(writer(cmd), "Warning: the previous session could not be revoked. You can revoke it in the Dashboard.")
+			}
+		}
+	}
+	return writeStatus(cmd, metadata, true, "authenticated")
+}
+
+func logout(ctx context.Context, cmd *cli.Command) error {
+	manager, err := cliauth.NewManager()
+	if err != nil {
+		return err
+	}
+	metadata, credential, err := manager.Store().Load()
+	if errors.Is(err, cliauth.ErrNotLoggedIn) {
+		if cmd.Bool("json") {
+			return writeJSONLine(cmd, map[string]any{"type": "logout", "revoked": false})
+		}
+		_, err = fmt.Fprintln(writer(cmd), "Not logged in.")
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	if err := manager.Revoke(ctx, metadata, credential); err != nil {
+		return err
+	}
+	if err := manager.Store().Delete(metadata); err != nil {
+		return err
+	}
+	if cmd.Bool("json") {
+		return writeJSONLine(cmd, map[string]any{"type": "logout", "revoked": true})
+	}
+	_, err = fmt.Fprintln(writer(cmd), "Logged out.")
+	return err
+}
+
+func status(ctx context.Context, cmd *cli.Command) error {
+	manager, err := cliauth.NewManager()
+	if err != nil {
+		return err
+	}
+	metadata, _, err := manager.Store().Load()
+	if errors.Is(err, cliauth.ErrNotLoggedIn) {
+		if cmd.Bool("json") {
+			if err := writeJSONLine(cmd, map[string]any{"type": "auth_status", "authenticated": false}); err != nil {
+				return err
+			}
+			return &ReportedError{}
+		}
+		return cliauth.ErrNotLoggedIn
+	}
+	if err != nil {
+		return err
+	}
+	accessToken, metadata, err := manager.AccessToken(ctx, metadata.Resource)
+	if err != nil {
+		return err
+	}
+	if err := manager.Validate(ctx, metadata, accessToken); err != nil {
+		return err
+	}
+	return writeStatus(cmd, metadata, true, "auth_status")
+}
+
+func writeVerification(cmd *cli.Command, device *oauth2.DeviceAuthResponse) error {
+	if cmd.Bool("json") {
+		return writeJSONLine(cmd, map[string]any{
+			"type":                      "verification",
+			"user_code":                 device.UserCode,
+			"verification_uri":          device.VerificationURI,
+			"verification_uri_complete": device.VerificationURIComplete,
+			"expires_at":                device.Expiry.Format(time.RFC3339),
+			"interval_seconds":          device.Interval,
+		})
+	}
+	_, err := fmt.Fprintf(
+		writer(cmd),
+		"Open %s and enter code %s.\n",
+		device.VerificationURI,
+		device.UserCode,
+	)
+	return err
+}
+
+func writeStatus(cmd *cli.Command, metadata *cliauth.Metadata, authenticated bool, eventType string) error {
+	if cmd.Bool("json") {
+		return writeJSONLine(cmd, map[string]any{
+			"type":                   eventType,
+			"authenticated":          authenticated,
+			"account_id":             metadata.AccountID,
+			"account_name":           metadata.AccountName,
+			"resource":               metadata.Resource,
+			"resource_boundary_mode": metadata.ResourceBoundaryMode,
+			"workspace_id":           metadata.WorkspaceID,
+			"workspace_name":         metadata.WorkspaceName,
+			"session_expires_at":     metadata.SessionExpiresAt.Format(time.RFC3339),
+		})
+	}
+	boundary := "all environments"
+	if metadata.ResourceBoundaryMode == "single_env" {
+		boundary = metadata.WorkspaceName
+		if strings.TrimSpace(boundary) == "" && metadata.WorkspaceID != nil {
+			boundary = *metadata.WorkspaceID
+		}
+	}
+	account := strings.TrimSpace(metadata.AccountName)
+	if account == "" {
+		account = metadata.AccountID
+	}
+	_, err := fmt.Fprintf(
+		writer(cmd),
+		"Logged in to %s with access to %s. Session expires %s.\n",
+		account,
+		boundary,
+		metadata.SessionExpiresAt.Local().Format(time.RFC1123),
+	)
+	return err
+}
+
+func writeJSONLine(cmd *cli.Command, value any) error {
+	return json.NewEncoder(writer(cmd)).Encode(value)
+}
+
+func writer(cmd *cli.Command) io.Writer {
+	if cmd.Root().Writer != nil {
+		return cmd.Root().Writer
+	}
+	return os.Stdout
+}
+
+type ReportedError struct{}
+
+func (*ReportedError) Error() string {
+	return ""
+}
+
+func jsonAction(action cli.ActionFunc) cli.ActionFunc {
+	return func(ctx context.Context, cmd *cli.Command) error {
+		err := action(ctx, cmd)
+		if err == nil || !cmd.Bool("json") {
+			return err
+		}
+		var reported *ReportedError
+		if errors.As(err, &reported) {
+			return err
+		}
+		if writeErr := writeJSONLine(cmd, map[string]any{"type": "error", "message": err.Error()}); writeErr != nil {
+			return writeErr
+		}
+		return &ReportedError{}
+	}
+}

--- a/cmd/auth/cmd_test.go
+++ b/cmd/auth/cmd_test.go
@@ -1,0 +1,36 @@
+package authcmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+func TestJSONStatusIsOneLineAndFailsWhenLoggedOut(t *testing.T) {
+	t.Setenv("INNGEST_CONFIG_DIR", t.TempDir())
+	output := bytes.Buffer{}
+	command := &cli.Command{
+		Name:   "inngest",
+		Writer: &output,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "json"},
+		},
+		Commands: []*cli.Command{AuthCommand()},
+	}
+
+	err := command.Run(context.Background(), []string{"inngest", "--json", "auth", "status"})
+	var reported *ReportedError
+	require.True(t, errors.As(err, &reported))
+
+	lines := bytes.Split(bytes.TrimSpace(output.Bytes()), []byte("\n"))
+	require.Len(t, lines, 1)
+	result := map[string]any{}
+	require.NoError(t, json.Unmarshal(lines[0], &result))
+	require.Equal(t, "auth_status", result["type"])
+	require.Equal(t, false, result["authenticated"])
+}

--- a/cmd/internal/auth/browser.go
+++ b/cmd/internal/auth/browser.go
@@ -1,0 +1,26 @@
+package auth
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+)
+
+func OpenBrowser(url string) error {
+	var command *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		command = exec.Command("open", url)
+	case "windows":
+		command = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		command = exec.Command("xdg-open", url)
+	}
+	if err := command.Start(); err != nil {
+		return err
+	}
+	if command.Process == nil {
+		return errors.New("browser process did not start")
+	}
+	return command.Process.Release()
+}

--- a/cmd/internal/auth/client.go
+++ b/cmd/internal/auth/client.go
@@ -1,0 +1,281 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/inngest/inngest/pkg/api/v2/apiv2endpoint"
+	"golang.org/x/oauth2"
+)
+
+const (
+	ClientID      = "inngest-cli"
+	cloudIssuer   = "https://api.inngest.com"
+	refreshLeeway = 30 * time.Second
+	httpTimeout   = 30 * time.Second
+)
+
+type Manager struct {
+	store      *Store
+	httpClient *http.Client
+	now        func() time.Time
+}
+
+func NewManager() (*Manager, error) {
+	store, err := NewStore()
+	if err != nil {
+		return nil, err
+	}
+	return &Manager{
+		store:      store,
+		httpClient: &http.Client{Timeout: httpTimeout},
+		now:        time.Now,
+	}, nil
+}
+
+func (m *Manager) Store() *Store {
+	return m.store
+}
+
+func (m *Manager) Context(ctx context.Context) context.Context {
+	return context.WithValue(ctx, oauth2.HTTPClient, m.httpClient)
+}
+
+func OAuthConfig(issuer string) *oauth2.Config {
+	issuer = strings.TrimRight(issuer, "/")
+	return &oauth2.Config{
+		ClientID: ClientID,
+		Scopes:   DefaultScopes(),
+		Endpoint: oauth2.Endpoint{
+			DeviceAuthURL: issuer + "/oauth/device/code",
+			TokenURL:      issuer + "/oauth/token",
+			AuthStyle:     oauth2.AuthStyleInParams,
+		},
+	}
+}
+
+func Issuer() (string, error) {
+	raw := strings.TrimSpace(os.Getenv("INNGEST_API_HOST"))
+	if raw == "" {
+		return cloudIssuer, nil
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", errors.New("INNGEST_API_HOST must include a scheme and host")
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	path := strings.TrimRight(parsed.Path, "/")
+	for _, suffix := range []string{"/api/v2", "/v2", "/api"} {
+		if strings.HasSuffix(path, suffix) {
+			path = strings.TrimSuffix(path, suffix)
+			break
+		}
+	}
+	parsed.Path = path
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func Resource(issuer string) string {
+	return strings.TrimRight(issuer, "/") + "/v2"
+}
+
+func DefaultScopes() []string {
+	excluded := map[string]struct{}{
+		"api_keys":     {},
+		"event_keys":   {},
+		"partners":     {},
+		"signing_keys": {},
+	}
+	set := map[string]struct{}{}
+	for _, endpoint := range apiv2endpoint.Discover() {
+		parts := strings.Split(endpoint.AuthzPermission, ":")
+		if len(parts) != 3 || (parts[1] != "read" && parts[1] != "write") {
+			continue
+		}
+		if _, ok := excluded[parts[0]]; ok {
+			continue
+		}
+		set[parts[0]+":"+parts[1]+":*"] = struct{}{}
+	}
+	result := make([]string, 0, len(set))
+	for scope := range set {
+		result = append(result, scope)
+	}
+	slices.Sort(result)
+	return result
+}
+
+func (m *Manager) AccessToken(ctx context.Context, target string) (string, *Metadata, error) {
+	metadata, err := m.store.Metadata()
+	if err != nil {
+		return "", nil, err
+	}
+	if canonicalResource(target) != canonicalResource(metadata.Resource) {
+		return "", nil, ErrNotLoggedIn
+	}
+	_, credential, err := m.store.Load()
+	if err != nil {
+		return "", metadata, err
+	}
+	if !metadata.SessionExpiresAt.After(m.now()) {
+		return "", metadata, errors.New("OAuth session has expired; run `inngest login`")
+	}
+	if credential.Expiry.After(m.now().Add(refreshLeeway)) {
+		return credential.AccessToken, metadata, nil
+	}
+	token := &oauth2.Token{
+		AccessToken:  credential.AccessToken,
+		TokenType:    credential.TokenType,
+		RefreshToken: credential.RefreshToken,
+		Expiry:       credential.Expiry,
+	}
+	refreshed, err := OAuthConfig(metadata.Issuer).TokenSource(m.Context(ctx), token).Token()
+	if err != nil {
+		return "", metadata, fmt.Errorf("refresh OAuth session: %w", err)
+	}
+	credential = &Credential{
+		AccessToken:  refreshed.AccessToken,
+		RefreshToken: refreshed.RefreshToken,
+		TokenType:    refreshed.TokenType,
+		Expiry:       refreshed.Expiry,
+	}
+	updateMetadataFromToken(metadata, refreshed)
+	if err := m.store.Save(*metadata, *credential, metadata.Storage == storageFile); err != nil {
+		return "", metadata, err
+	}
+	return credential.AccessToken, metadata, nil
+}
+
+func (m *Manager) Validate(ctx context.Context, metadata *Metadata, accessToken string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(metadata.Resource, "/")+"/account", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return errors.New("OAuth session is no longer valid; run `inngest login`")
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return nil
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("validate OAuth session: %s", resp.Status)
+	}
+	return nil
+}
+
+func (m *Manager) Revoke(ctx context.Context, metadata *Metadata, credential *Credential) error {
+	values := url.Values{
+		"client_id":       {metadata.ClientID},
+		"token":           {credential.RefreshToken},
+		"token_type_hint": {"refresh_token"},
+	}
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		strings.TrimRight(metadata.Issuer, "/")+"/oauth/revoke",
+		strings.NewReader(values.Encode()),
+	)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("revoke OAuth session: %s", resp.Status)
+	}
+	return nil
+}
+
+func MetadataFromToken(issuer string, token *oauth2.Token) (*Metadata, *Credential, error) {
+	metadata := &Metadata{
+		Issuer:   issuer,
+		Resource: stringExtra(token, "resource"),
+		ClientID: ClientID,
+		Scopes:   strings.Fields(stringExtra(token, "scope")),
+	}
+	updateMetadataFromToken(metadata, token)
+	if metadata.Resource == "" || metadata.SessionID == "" || metadata.AccountID == "" || metadata.SessionExpiresAt.IsZero() {
+		return nil, nil, errors.New("authorization server returned incomplete session metadata")
+	}
+	credential := &Credential{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		TokenType:    token.TokenType,
+		Expiry:       token.Expiry,
+	}
+	return metadata, credential, nil
+}
+
+func updateMetadataFromToken(metadata *Metadata, token *oauth2.Token) {
+	if value := stringExtra(token, "session_id"); value != "" {
+		metadata.SessionID = value
+	}
+	if value := stringExtra(token, "session_expires_at"); value != "" {
+		if parsed, err := time.Parse(time.RFC3339Nano, value); err == nil {
+			metadata.SessionExpiresAt = parsed
+		}
+	}
+	if value := stringExtra(token, "account_id"); value != "" {
+		metadata.AccountID = value
+	}
+	if value := stringExtra(token, "account_name"); value != "" {
+		metadata.AccountName = value
+	}
+	if value := stringExtra(token, "resource_boundary_mode"); value != "" {
+		metadata.ResourceBoundaryMode = value
+	}
+	if value := stringExtra(token, "workspace_id"); value != "" {
+		metadata.WorkspaceID = &value
+	}
+	if value := stringExtra(token, "workspace_name"); value != "" {
+		metadata.WorkspaceName = value
+	}
+	if value := stringExtra(token, "scope"); value != "" {
+		metadata.Scopes = strings.Fields(value)
+	}
+	if value := stringExtra(token, "resource"); value != "" {
+		metadata.Resource = value
+	}
+}
+
+func stringExtra(token *oauth2.Token, key string) string {
+	value := token.Extra(key)
+	switch value := value.(type) {
+	case string:
+		return value
+	case fmt.Stringer:
+		return value.String()
+	default:
+		return ""
+	}
+}
+
+func canonicalResource(raw string) string {
+	parsed, err := url.Parse(strings.TrimRight(raw, "/"))
+	if err != nil {
+		return raw
+	}
+	if parsed.Path == "/api/v2" {
+		parsed.Path = "/v2"
+	}
+	return parsed.String()
+}

--- a/cmd/internal/auth/client_test.go
+++ b/cmd/internal/auth/client_test.go
@@ -1,0 +1,105 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultScopes(t *testing.T) {
+	require.Equal(t, []string{
+		"accounts:read:*",
+		"apps:read:*",
+		"apps:write:*",
+		"environments:read:*",
+		"environments:write:*",
+		"events:write:*",
+		"experiments:read:*",
+		"functions:read:*",
+		"functions:write:*",
+		"insights:read:*",
+		"runs:read:*",
+		"runs:write:*",
+		"sandboxes:read:*",
+		"sandboxes:write:*",
+		"sessions:read:*",
+		"webhooks:read:*",
+		"webhooks:write:*",
+	}, DefaultScopes())
+}
+
+func TestIssuer(t *testing.T) {
+	t.Setenv("INNGEST_API_HOST", "http://127.0.0.1:8090/api/v2")
+	issuer, err := Issuer()
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:8090", issuer)
+}
+
+func TestAccessTokenChecksResourceBeforeCredentialStore(t *testing.T) {
+	dir := t.TempDir()
+	store := newStore(dir, newMemoryKeyring())
+	metadata, _ := testSession("session-1")
+	metadata.Storage = storageKeyring
+	require.NoError(t, writeJSONFile(filepath.Join(dir, metadataFile), metadata, 0o600))
+	manager := &Manager{store: store, now: time.Now}
+
+	_, _, err := manager.AccessToken(context.Background(), "https://example.com/v2")
+	require.ErrorIs(t, err, ErrNotLoggedIn)
+}
+
+func TestValidateAcceptsAuthorizedAndPermissionDeniedResponses(t *testing.T) {
+	tests := map[string]struct {
+		status  int
+		wantErr bool
+	}{
+		"success":           {status: http.StatusOK},
+		"permission denied": {status: http.StatusForbidden},
+		"invalid token":     {status: http.StatusUnauthorized, wantErr: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(test.status)
+			}))
+			defer server.Close()
+			manager := &Manager{httpClient: server.Client()}
+
+			err := manager.Validate(context.Background(), &Metadata{Resource: server.URL}, "token")
+			require.Equal(t, test.wantErr, err != nil)
+		})
+	}
+}
+
+func TestCanonicalResourceSupportsCloudAndLocalV2Aliases(t *testing.T) {
+	tests := map[string]struct {
+		left  string
+		right string
+		equal bool
+	}{
+		"cloud": {
+			left:  "https://api.inngest.com/v2",
+			right: "https://api.inngest.com/v2/",
+			equal: true,
+		},
+		"local alias": {
+			left:  "http://localhost:8090/api/v2",
+			right: "http://localhost:8090/v2",
+			equal: true,
+		},
+		"different host": {
+			left:  "https://api.inngest.com/v2",
+			right: "https://example.com/v2",
+			equal: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.equal, canonicalResource(test.left) == canonicalResource(test.right))
+		})
+	}
+}

--- a/cmd/internal/auth/storage.go
+++ b/cmd/internal/auth/storage.go
@@ -1,0 +1,270 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/zalando/go-keyring"
+)
+
+const (
+	keyringService = "inngest-cli"
+	metadataFile   = "auth.json"
+	storageKeyring = "keyring"
+	storageFile    = "file"
+)
+
+var ErrNotLoggedIn = errors.New("not logged in")
+
+type Metadata struct {
+	Issuer               string    `json:"issuer"`
+	Resource             string    `json:"resource"`
+	ClientID             string    `json:"client_id"`
+	SessionID            string    `json:"session_id"`
+	SessionExpiresAt     time.Time `json:"session_expires_at"`
+	AccountID            string    `json:"account_id"`
+	AccountName          string    `json:"account_name"`
+	ResourceBoundaryMode string    `json:"resource_boundary_mode"`
+	WorkspaceID          *string   `json:"workspace_id,omitempty"`
+	WorkspaceName        string    `json:"workspace_name,omitempty"`
+	Scopes               []string  `json:"scopes"`
+	Storage              string    `json:"storage"`
+	UpdatedAt            time.Time `json:"updated_at"`
+}
+
+type Credential struct {
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token"`
+	TokenType    string    `json:"token_type"`
+	Expiry       time.Time `json:"expiry"`
+}
+
+type keyringStore interface {
+	Get(service, user string) (string, error)
+	Set(service, user, password string) error
+	Delete(service, user string) error
+}
+
+type systemKeyring struct{}
+
+func (systemKeyring) Get(service, user string) (string, error) {
+	return keyring.Get(service, user)
+}
+
+func (systemKeyring) Set(service, user, password string) error {
+	return keyring.Set(service, user, password)
+}
+
+func (systemKeyring) Delete(service, user string) error {
+	return keyring.Delete(service, user)
+}
+
+type Store struct {
+	dir     string
+	keyring keyringStore
+}
+
+func NewStore() (*Store, error) {
+	dir, err := configDir()
+	if err != nil {
+		return nil, err
+	}
+	return &Store{dir: dir, keyring: systemKeyring{}}, nil
+}
+
+func newStore(dir string, keyring keyringStore) *Store {
+	return &Store{dir: dir, keyring: keyring}
+}
+
+func (s *Store) Save(metadata Metadata, credential Credential, insecure bool) error {
+	if metadata.Resource == "" || metadata.SessionID == "" || credential.AccessToken == "" || credential.RefreshToken == "" {
+		return errors.New("OAuth credential is incomplete")
+	}
+	previous, _ := s.Metadata()
+	secret, err := json.Marshal(credential)
+	if err != nil {
+		return fmt.Errorf("encode OAuth credential: %w", err)
+	}
+	metadata.Storage = storageKeyring
+	if insecure {
+		metadata.Storage = storageFile
+		if err := writeJSONFile(s.credentialPath(&metadata), credential, 0o600); err != nil {
+			return fmt.Errorf("write OAuth credential: %w", err)
+		}
+	} else if err := s.keyring.Set(keyringService, keyringUser(&metadata), string(secret)); err != nil {
+		return fmt.Errorf("store OAuth credential in the OS credential store: %w", err)
+	}
+	metadata.UpdatedAt = time.Now().UTC()
+	if err := writeJSONFile(filepath.Join(s.dir, metadataFile), metadata, 0o600); err != nil {
+		_ = s.deleteCredential(&metadata)
+		return fmt.Errorf("write OAuth session metadata: %w", err)
+	}
+	if previous != nil && credentialLocation(previous) != credentialLocation(&metadata) {
+		_ = s.deleteCredential(previous)
+	}
+	return nil
+}
+
+func (s *Store) Metadata() (*Metadata, error) {
+	metadata := &Metadata{}
+	if err := readJSONFile(filepath.Join(s.dir, metadataFile), metadata, false); errors.Is(err, fs.ErrNotExist) {
+		return nil, ErrNotLoggedIn
+	} else if err != nil {
+		return nil, fmt.Errorf("read OAuth session metadata: %w", err)
+	}
+	return metadata, nil
+}
+
+func (s *Store) Load() (*Metadata, *Credential, error) {
+	metadata, err := s.Metadata()
+	if err != nil {
+		return nil, nil, err
+	}
+	credential := &Credential{}
+	switch metadata.Storage {
+	case storageKeyring:
+		secret, err := s.keyring.Get(keyringService, keyringUser(metadata))
+		if errors.Is(err, keyring.ErrNotFound) {
+			return nil, nil, ErrNotLoggedIn
+		}
+		if err != nil {
+			return nil, nil, fmt.Errorf("read OAuth credential from the OS credential store: %w", err)
+		}
+		if err := json.Unmarshal([]byte(secret), credential); err != nil {
+			return nil, nil, errors.New("stored OAuth credential is invalid")
+		}
+	case storageFile:
+		if err := readJSONFile(s.credentialPath(metadata), credential, true); errors.Is(err, fs.ErrNotExist) {
+			return nil, nil, ErrNotLoggedIn
+		} else if err != nil {
+			return nil, nil, fmt.Errorf("read OAuth credential file: %w", err)
+		}
+	default:
+		return nil, nil, errors.New("stored OAuth credential has an unknown storage type")
+	}
+	if credential.AccessToken == "" || credential.RefreshToken == "" {
+		return nil, nil, errors.New("stored OAuth credential is incomplete")
+	}
+	return metadata, credential, nil
+}
+
+func (s *Store) Delete(metadata *Metadata) error {
+	if metadata == nil {
+		loaded, err := s.Metadata()
+		if errors.Is(err, ErrNotLoggedIn) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		metadata = loaded
+	}
+	secretErr := s.deleteCredential(metadata)
+	metadataErr := os.Remove(filepath.Join(s.dir, metadataFile))
+	if errors.Is(metadataErr, fs.ErrNotExist) {
+		metadataErr = nil
+	}
+	return errors.Join(secretErr, metadataErr)
+}
+
+func configDir() (string, error) {
+	if dir := os.Getenv("INNGEST_CONFIG_DIR"); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("find home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "inngest"), nil
+}
+
+func keyringUser(metadata *Metadata) string {
+	return "oauth:" + credentialID(metadata)
+}
+
+func credentialID(metadata *Metadata) string {
+	hash := sha256.Sum256([]byte(metadata.Resource + "\x00" + metadata.SessionID))
+	return hex.EncodeToString(hash[:8])
+}
+
+func credentialLocation(metadata *Metadata) string {
+	return metadata.Storage + ":" + credentialID(metadata)
+}
+
+func (s *Store) credentialPath(metadata *Metadata) string {
+	return filepath.Join(s.dir, "oauth-credentials-"+credentialID(metadata)+".json")
+}
+
+func (s *Store) deleteCredential(metadata *Metadata) error {
+	switch metadata.Storage {
+	case storageKeyring:
+		err := s.keyring.Delete(keyringService, keyringUser(metadata))
+		if errors.Is(err, keyring.ErrNotFound) {
+			return nil
+		}
+		return err
+	case storageFile:
+		err := os.Remove(s.credentialPath(metadata))
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	default:
+		return nil
+	}
+}
+
+func writeJSONFile(path string, value any, mode fs.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".inngest-auth-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if err := tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(encoded); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func readJSONFile(path string, value any, requirePrivate bool) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if requirePrivate && runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+		return errors.New("credential file permissions must be 0600")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, value)
+}

--- a/cmd/internal/auth/storage_test.go
+++ b/cmd/internal/auth/storage_test.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+)
+
+type memoryKeyring struct {
+	values map[string]string
+}
+
+func newMemoryKeyring() *memoryKeyring {
+	return &memoryKeyring{values: map[string]string{}}
+}
+
+func (m *memoryKeyring) Get(service, user string) (string, error) {
+	value, ok := m.values[service+"\x00"+user]
+	if !ok {
+		return "", keyring.ErrNotFound
+	}
+	return value, nil
+}
+
+func (m *memoryKeyring) Set(service, user, password string) error {
+	m.values[service+"\x00"+user] = password
+	return nil
+}
+
+func (m *memoryKeyring) Delete(service, user string) error {
+	key := service + "\x00" + user
+	if _, ok := m.values[key]; !ok {
+		return keyring.ErrNotFound
+	}
+	delete(m.values, key)
+	return nil
+}
+
+func TestStoreKeyringKeepsSecretsOutOfMetadata(t *testing.T) {
+	store := newStore(t.TempDir(), newMemoryKeyring())
+	metadata, credential := testSession("session-1")
+
+	require.NoError(t, store.Save(metadata, credential, false))
+
+	storedMetadata, storedCredential, err := store.Load()
+	require.NoError(t, err)
+	require.Equal(t, metadata.SessionID, storedMetadata.SessionID)
+	require.Equal(t, credential, *storedCredential)
+
+	data, err := os.ReadFile(filepath.Join(store.dir, metadataFile))
+	require.NoError(t, err)
+	require.NotContains(t, string(data), credential.AccessToken)
+	require.NotContains(t, string(data), credential.RefreshToken)
+}
+
+func TestStoreReplacesCredentialAcrossBackends(t *testing.T) {
+	keyringStore := newMemoryKeyring()
+	store := newStore(t.TempDir(), keyringStore)
+	firstMetadata, firstCredential := testSession("session-1")
+	secondMetadata, secondCredential := testSession("session-2")
+
+	require.NoError(t, store.Save(firstMetadata, firstCredential, false))
+	firstUser := keyringUser(&firstMetadata)
+	require.Contains(t, keyringStore.values, keyringService+"\x00"+firstUser)
+
+	require.NoError(t, store.Save(secondMetadata, secondCredential, true))
+	require.NotContains(t, keyringStore.values, keyringService+"\x00"+firstUser)
+
+	storedMetadata, storedCredential, err := store.Load()
+	require.NoError(t, err)
+	require.Equal(t, storageFile, storedMetadata.Storage)
+	require.Equal(t, secondCredential, *storedCredential)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(store.credentialPath(storedMetadata))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+}
+
+func TestStoreRejectsReadableCredentialFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits")
+	}
+	store := newStore(t.TempDir(), newMemoryKeyring())
+	metadata, credential := testSession("session-1")
+	require.NoError(t, store.Save(metadata, credential, true))
+	require.NoError(t, os.Chmod(store.credentialPath(&metadata), 0o644))
+
+	_, _, err := store.Load()
+	require.ErrorContains(t, err, "permissions must be 0600")
+}
+
+func TestStoreDeleteWorksWhenCredentialIsMissing(t *testing.T) {
+	store := newStore(t.TempDir(), newMemoryKeyring())
+	metadata, credential := testSession("session-1")
+	require.NoError(t, store.Save(metadata, credential, true))
+	require.NoError(t, os.Remove(store.credentialPath(&metadata)))
+
+	require.NoError(t, store.Delete(nil))
+	_, err := store.Metadata()
+	require.ErrorIs(t, err, ErrNotLoggedIn)
+}
+
+func TestStoreRequiresCompleteSession(t *testing.T) {
+	store := newStore(t.TempDir(), newMemoryKeyring())
+	metadata, credential := testSession("")
+
+	err := store.Save(metadata, credential, false)
+	require.ErrorContains(t, err, "incomplete")
+}
+
+func testSession(sessionID string) (Metadata, Credential) {
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	return Metadata{
+			Issuer:           "https://api.inngest.com",
+			Resource:         "https://api.inngest.com/v2",
+			ClientID:         ClientID,
+			SessionID:        sessionID,
+			SessionExpiresAt: now.Add(30 * 24 * time.Hour),
+			AccountID:        "account-id",
+		}, Credential{
+			AccessToken:  "inngest_at_secret",
+			RefreshToken: "inngest_rt_secret",
+			TokenType:    "Bearer",
+			Expiry:       now.Add(time.Hour),
+		}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/inngest/inngest/cmd/apiv2cli"
+	authcmd "github.com/inngest/inngest/cmd/auth"
 	"github.com/inngest/inngest/cmd/devserver"
 	"github.com/inngest/inngest/cmd/start"
 	"github.com/inngest/inngest/cmd/version"
@@ -94,6 +96,9 @@ func execute() {
 
 		Flags: globalFlags,
 		Commands: []*cli.Command{
+			authcmd.LoginCommand(),
+			authcmd.LogoutCommand(),
+			authcmd.AuthCommand(),
 			apiv2cli.Command(),
 			devserver.Command(),
 			version.Command(),
@@ -108,6 +113,10 @@ func execute() {
 	}
 
 	if err := app.Run(context.Background(), os.Args); err != nil {
+		var reported *authcmd.ReportedError
+		if errors.As(err, &reported) {
+			os.Exit(1)
+		}
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/valyala/fastjson v1.6.4
 	github.com/vektah/gqlparser/v2 v2.5.15
 	github.com/xhit/go-str2duration/v2 v2.1.0
+	github.com/zalando/go-keyring v0.2.8
 	go.opentelemetry.io/collector/pdata v1.36.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
@@ -103,6 +104,7 @@ require (
 	gocloud.dev v0.40.0
 	gocloud.dev/pubsub/natspubsub v0.25.0
 	golang.org/x/mod v0.36.0
+	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sync v0.21.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
@@ -162,6 +164,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -175,6 +178,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -280,7 +284,6 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
 	golang.org/x/net v0.56.0 // indirect
-	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -318,6 +318,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -434,6 +436,8 @@ github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22
 github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -1036,6 +1040,8 @@ github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=

--- a/ui/apps/dashboard/src/components/APIKeys/CreateAPIKeyForm.tsx
+++ b/ui/apps/dashboard/src/components/APIKeys/CreateAPIKeyForm.tsx
@@ -15,7 +15,11 @@ import {
 import { useEnvironments } from '@/queries/environments';
 import { EnvironmentType } from '@/utils/environments';
 import { apiKeyErrorMessage } from './errorMessage';
-import { permissionResourceCopy } from './permissionResourceCopy';
+import {
+  PermissionPicker,
+  type PermissionGroup,
+  type PermissionLevel,
+} from './PermissionPicker';
 import { RevealKeyCard } from './RevealKeyCard';
 import { validateAPIKeyName } from './validation';
 
@@ -37,17 +41,10 @@ const Mutation = graphql(`
   }
 `);
 
-type PermissionGroup = {
-  resource: string;
-  read: string[];
-  write: string[];
-};
-
 type PermissionCatalogResult = {
   apiKeyPermissionCatalog: PermissionGroup[];
 };
 
-type PermissionLevel = 'none' | 'read' | 'write';
 type EnvOptionGroup = {
   label: string;
   opts: Option[];
@@ -114,21 +111,6 @@ const PermissionCatalogQuery: TypedDocumentNode<
     }
   }
 `;
-
-function permissionLevelButtonClass(isActive: boolean) {
-  const classes = [
-    'h-7 min-w-16 rounded-full px-3 text-sm outline-none transition-colors',
-    'disabled:text-disabled disabled:cursor-not-allowed',
-  ];
-  if (isActive) {
-    classes.push('bg-canvasBase border-muted text-basis border');
-  } else {
-    classes.push(
-      'text-muted hover:bg-canvasSubtle hover:text-basis border border-transparent',
-    );
-  }
-  return classes.join(' ');
-}
 
 function boundaryOptionName(optionID: BoundaryOptionID) {
   switch (optionID) {
@@ -570,63 +552,14 @@ export function CreateAPIKeyForm({
     );
   }
 
-  const permissionGroups = [...(catalogRes.data?.apiKeyPermissionCatalog ?? [])].sort((a, b) => {
-    return a.resource.localeCompare(b.resource)
-  })
+  const permissionGroups = catalogRes.data?.apiKeyPermissionCatalog ?? [];
   let permissionsContent = (
-    <div className="border-subtle rounded border">
-      {permissionGroups.map((group) => {
-        const level = permissionLevels[group.resource] ?? 'none';
-        const readDisabled = group.read.length === 0;
-        const writeDisabled = group.write.length === 0;
-        const copy = permissionResourceCopy(group.resource);
-
-        return (
-          <div
-            key={group.resource}
-            className="border-subtle grid grid-cols-1 gap-3 border-b p-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
-          >
-            <div className="flex min-w-0 flex-col">
-              <span className="text-basis truncate text-sm font-medium">
-                {copy.label}
-              </span>
-              {copy.description && (
-                <span className="text-subtle truncate text-xs">
-                  {copy.description}
-                </span>
-              )}
-            </div>
-
-            <div className="bg-canvasMuted grid h-8 grid-cols-3 rounded-full p-0.5">
-              <button
-                type="button"
-                className={permissionLevelButtonClass(level === 'none')}
-                onClick={() => setPermissionLevel(group.resource, 'none')}
-                disabled={isSubmitting}
-              >
-                None
-              </button>
-              <button
-                type="button"
-                className={permissionLevelButtonClass(level === 'read')}
-                onClick={() => setPermissionLevel(group.resource, 'read')}
-                disabled={isSubmitting || readDisabled}
-              >
-                Read
-              </button>
-              <button
-                type="button"
-                className={permissionLevelButtonClass(level === 'write')}
-                onClick={() => setPermissionLevel(group.resource, 'write')}
-                disabled={isSubmitting || writeDisabled}
-              >
-                Write
-              </button>
-            </div>
-          </div>
-        );
-      })}
-    </div>
+    <PermissionPicker
+      groups={permissionGroups}
+      levels={permissionLevels}
+      disabled={isSubmitting}
+      onChange={setPermissionLevel}
+    />
   );
   if (catalogRes.fetching && !catalogRes.data) {
     permissionsContent = (

--- a/ui/apps/dashboard/src/components/APIKeys/PermissionPicker.tsx
+++ b/ui/apps/dashboard/src/components/APIKeys/PermissionPicker.tsx
@@ -1,0 +1,110 @@
+import { permissionResourceCopy } from './permissionResourceCopy';
+
+export type PermissionGroup = {
+  resource: string;
+  read: string[];
+  write: string[];
+};
+
+export type PermissionLevel = 'none' | 'read' | 'write';
+
+type Props = {
+  groups: PermissionGroup[];
+  levels: Record<string, PermissionLevel>;
+  disabled?: boolean;
+  onChange: (resource: string, level: PermissionLevel) => void;
+};
+
+export function PermissionPicker({
+  groups,
+  levels,
+  disabled = false,
+  onChange,
+}: Props) {
+  const sortedGroups = [...groups].sort((a, b) =>
+    a.resource.localeCompare(b.resource),
+  );
+
+  return (
+    <div className="border-subtle rounded border">
+      {sortedGroups.map((group) => {
+        const level = levels[group.resource] ?? 'none';
+        const copy = permissionResourceCopy(group.resource);
+
+        return (
+          <div
+            key={group.resource}
+            className="border-subtle grid grid-cols-1 gap-3 border-b p-3 last:border-b-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+          >
+            <div className="flex min-w-0 flex-col">
+              <span className="text-basis truncate text-sm font-medium">
+                {copy.label}
+              </span>
+              {copy.description && (
+                <span className="text-subtle truncate text-xs">
+                  {copy.description}
+                </span>
+              )}
+            </div>
+
+            <div className="bg-canvasMuted grid h-8 grid-cols-3 rounded-full p-0.5">
+              <PermissionButton
+                active={level === 'none'}
+                disabled={disabled}
+                label="None"
+                onClick={() => onChange(group.resource, 'none')}
+              />
+              <PermissionButton
+                active={level === 'read'}
+                disabled={disabled || group.read.length === 0}
+                label="Read"
+                onClick={() => onChange(group.resource, 'read')}
+              />
+              <PermissionButton
+                active={level === 'write'}
+                disabled={disabled || group.write.length === 0}
+                label="Write"
+                onClick={() => onChange(group.resource, 'write')}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function PermissionButton({
+  active,
+  disabled,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  disabled: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  const classes = [
+    'h-7 min-w-16 rounded-full px-3 text-sm outline-none transition-colors',
+    'disabled:text-disabled disabled:cursor-not-allowed',
+  ];
+  if (active) {
+    classes.push('bg-canvasBase border-muted text-basis border');
+  } else {
+    classes.push(
+      'text-muted hover:bg-canvasSubtle hover:text-basis border border-transparent',
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={classes.join(' ')}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {label}
+    </button>
+  );
+}

--- a/ui/apps/dashboard/src/routeTree.gen.ts
+++ b/ui/apps/dashboard/src/routeTree.gen.ts
@@ -40,6 +40,7 @@ import { Route as AuthedEnvEnvSlugRouteRouteImport } from './routes/_authed/env/
 import { Route as AuthedSettingsIntegrationsIndexRouteImport } from './routes/_authed/settings/integrations/index'
 import { Route as AuthedSettingsCreateApiKeyIndexRouteImport } from './routes/_authed/settings/create-api-key/index'
 import { Route as AuthedSettingsApiKeysIndexRouteImport } from './routes/_authed/settings/api-keys/index'
+import { Route as AuthedOauthDeviceIndexRouteImport } from './routes/_authed/oauth/device/index'
 import { Route as AuthedMcpSetupIndexRouteImport } from './routes/_authed/mcp/setup/index'
 import { Route as AuthedIntentSetupAwsMarketplaceIndexRouteImport } from './routes/_authed/intent/setup-aws-marketplace/index'
 import { Route as AuthedIntentCreateWebhookIndexRouteImport } from './routes/_authed/intent/create-webhook/index'
@@ -276,6 +277,11 @@ const AuthedSettingsApiKeysIndexRoute =
     path: '/api-keys/',
     getParentRoute: () => AuthedSettingsRouteRoute,
   } as any)
+const AuthedOauthDeviceIndexRoute = AuthedOauthDeviceIndexRouteImport.update({
+  id: '/oauth/device/',
+  path: '/oauth/device/',
+  getParentRoute: () => AuthedRoute,
+} as any)
 const AuthedMcpSetupIndexRoute = AuthedMcpSetupIndexRouteImport.update({
   id: '/mcp/setup/',
   path: '/mcp/setup/',
@@ -764,6 +770,7 @@ export interface FileRoutesByFullPath {
   '/intent/create-webhook/': typeof AuthedIntentCreateWebhookIndexRoute
   '/intent/setup-aws-marketplace/': typeof AuthedIntentSetupAwsMarketplaceIndexRoute
   '/mcp/setup/': typeof AuthedMcpSetupIndexRoute
+  '/oauth/device/': typeof AuthedOauthDeviceIndexRoute
   '/settings/api-keys/': typeof AuthedSettingsApiKeysIndexRoute
   '/settings/create-api-key/': typeof AuthedSettingsCreateApiKeyIndexRoute
   '/settings/integrations/': typeof AuthedSettingsIntegrationsIndexRoute
@@ -866,6 +873,7 @@ export interface FileRoutesByTo {
   '/intent/create-webhook': typeof AuthedIntentCreateWebhookIndexRoute
   '/intent/setup-aws-marketplace': typeof AuthedIntentSetupAwsMarketplaceIndexRoute
   '/mcp/setup': typeof AuthedMcpSetupIndexRoute
+  '/oauth/device': typeof AuthedOauthDeviceIndexRoute
   '/settings/api-keys': typeof AuthedSettingsApiKeysIndexRoute
   '/settings/create-api-key': typeof AuthedSettingsCreateApiKeyIndexRoute
   '/settings/integrations': typeof AuthedSettingsIntegrationsIndexRoute
@@ -967,6 +975,7 @@ export interface FileRoutesById {
   '/_authed/intent/create-webhook/': typeof AuthedIntentCreateWebhookIndexRoute
   '/_authed/intent/setup-aws-marketplace/': typeof AuthedIntentSetupAwsMarketplaceIndexRoute
   '/_authed/mcp/setup/': typeof AuthedMcpSetupIndexRoute
+  '/_authed/oauth/device/': typeof AuthedOauthDeviceIndexRoute
   '/_authed/settings/api-keys/': typeof AuthedSettingsApiKeysIndexRoute
   '/_authed/settings/create-api-key/': typeof AuthedSettingsCreateApiKeyIndexRoute
   '/_authed/settings/integrations/': typeof AuthedSettingsIntegrationsIndexRoute
@@ -1076,6 +1085,7 @@ export interface FileRouteTypes {
     | '/intent/create-webhook/'
     | '/intent/setup-aws-marketplace/'
     | '/mcp/setup/'
+    | '/oauth/device/'
     | '/settings/api-keys/'
     | '/settings/create-api-key/'
     | '/settings/integrations/'
@@ -1178,6 +1188,7 @@ export interface FileRouteTypes {
     | '/intent/create-webhook'
     | '/intent/setup-aws-marketplace'
     | '/mcp/setup'
+    | '/oauth/device'
     | '/settings/api-keys'
     | '/settings/create-api-key'
     | '/settings/integrations'
@@ -1278,6 +1289,7 @@ export interface FileRouteTypes {
     | '/_authed/intent/create-webhook/'
     | '/_authed/intent/setup-aws-marketplace/'
     | '/_authed/mcp/setup/'
+    | '/_authed/oauth/device/'
     | '/_authed/settings/api-keys/'
     | '/_authed/settings/create-api-key/'
     | '/_authed/settings/integrations/'
@@ -1586,6 +1598,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/settings/api-keys/'
       preLoaderRoute: typeof AuthedSettingsApiKeysIndexRouteImport
       parentRoute: typeof AuthedSettingsRouteRoute
+    }
+    '/_authed/oauth/device/': {
+      id: '/_authed/oauth/device/'
+      path: '/oauth/device'
+      fullPath: '/oauth/device/'
+      preLoaderRoute: typeof AuthedOauthDeviceIndexRouteImport
+      parentRoute: typeof AuthedRoute
     }
     '/_authed/mcp/setup/': {
       id: '/_authed/mcp/setup/'
@@ -2504,6 +2523,7 @@ interface AuthedRouteChildren {
   AuthedEnvIndexRoute: typeof AuthedEnvIndexRoute
   AuthedIntegrationsVercelIndexRoute: typeof AuthedIntegrationsVercelIndexRoute
   AuthedMcpSetupIndexRoute: typeof AuthedMcpSetupIndexRoute
+  AuthedOauthDeviceIndexRoute: typeof AuthedOauthDeviceIndexRoute
   AuthedIntegrationsVercelCallbackIndexRoute: typeof AuthedIntegrationsVercelCallbackIndexRoute
   AuthedIntegrationsVercelCallbackSuccessIndexRoute: typeof AuthedIntegrationsVercelCallbackSuccessIndexRoute
 }
@@ -2517,6 +2537,7 @@ const AuthedRouteChildren: AuthedRouteChildren = {
   AuthedEnvIndexRoute: AuthedEnvIndexRoute,
   AuthedIntegrationsVercelIndexRoute: AuthedIntegrationsVercelIndexRoute,
   AuthedMcpSetupIndexRoute: AuthedMcpSetupIndexRoute,
+  AuthedOauthDeviceIndexRoute: AuthedOauthDeviceIndexRoute,
   AuthedIntegrationsVercelCallbackIndexRoute:
     AuthedIntegrationsVercelCallbackIndexRoute,
   AuthedIntegrationsVercelCallbackSuccessIndexRoute:

--- a/ui/apps/dashboard/src/routes/_authed/oauth/device/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/oauth/device/index.tsx
@@ -1,0 +1,407 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Alert } from '@inngest/components/Alert';
+import { Button } from '@inngest/components/Button';
+import { Input } from '@inngest/components/Forms/Input';
+import { Select, type Option } from '@inngest/components/Select/Select';
+import { useAuth } from '@clerk/tanstack-react-start';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+
+import {
+  PermissionPicker,
+  type PermissionGroup,
+  type PermissionLevel,
+} from '@/components/APIKeys/PermissionPicker';
+import { useEnvironments } from '@/queries/environments';
+import { EnvironmentType } from '@/utils/environments';
+
+type Search = {
+  request?: string;
+};
+
+type AuthorizationDetails = {
+  client_name: string;
+  account_id: string;
+  account_name: string;
+  requested_scopes: string[];
+  permission_groups: PermissionGroup[];
+};
+
+type Boundary = 'single_env' | 'all_envs';
+
+export const Route = createFileRoute('/_authed/oauth/device/')({
+  component: DeviceAuthorizationPage,
+  validateSearch: (search: Record<string, unknown>): Search => ({
+    request: typeof search.request === 'string' ? search.request : undefined,
+  }),
+});
+
+function DeviceAuthorizationPage() {
+  const search = Route.useSearch();
+  const navigate = useNavigate();
+  const { getToken } = useAuth();
+  const [{ data: environments }] = useEnvironments();
+  const [request, setRequest] = useState(search.request ?? '');
+  const [userCode, setUserCode] = useState('');
+  const [details, setDetails] = useState<AuthorizationDetails | null>(null);
+  const [permissionLevels, setPermissionLevels] = useState<
+    Record<string, PermissionLevel>
+  >({});
+  const [boundary, setBoundary] = useState<Boundary | null>(null);
+  const [workspace, setWorkspace] = useState<Option | null>(null);
+  const [durationDays, setDurationDays] = useState(30);
+  const [sessionName, setSessionName] = useState('Inngest CLI');
+  const [loading, setLoading] = useState(Boolean(search.request));
+  const [submitting, setSubmitting] = useState(false);
+  const [done, setDone] = useState<'approved' | 'denied' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const environmentOptions = useMemo(() => {
+    return (environments ?? [])
+      .filter(
+        (environment) =>
+          !environment.isArchived &&
+          environment.type !== EnvironmentType.BranchChild,
+      )
+      .map((environment) => ({ id: environment.id, name: environment.name }));
+  }, [environments]);
+
+  const selectedPermissions = useMemo(() => {
+    const selected = new Set<string>();
+    for (const group of details?.permission_groups ?? []) {
+      const level = permissionLevels[group.resource] ?? 'none';
+      if (level === 'read' || level === 'write') {
+        group.read.forEach((permission) => selected.add(permission));
+      }
+      if (level === 'write') {
+        group.write.forEach((permission) => selected.add(permission));
+      }
+    }
+    return Array.from(selected).sort();
+  }, [details?.permission_groups, permissionLevels]);
+
+  useEffect(() => {
+    if (!search.request) return;
+    setRequest(search.request);
+    setLoading(true);
+    setError(null);
+    void apiRequest<AuthorizationDetails>(
+      getToken,
+      `/oauth/device/authorization?request=${encodeURIComponent(
+        search.request,
+      )}`,
+    )
+      .then((response) => {
+        setDetails(response);
+        const requested = new Set(response.requested_scopes);
+        const levels: Record<string, PermissionLevel> = {};
+        for (const group of response.permission_groups) {
+          if (group.write.some((scope) => requested.has(scope))) {
+            levels[group.resource] = 'write';
+          } else if (group.read.some((scope) => requested.has(scope))) {
+            levels[group.resource] = 'read';
+          }
+        }
+        setPermissionLevels(levels);
+      })
+      .catch((err: unknown) => setError(errorMessage(err)))
+      .finally(() => setLoading(false));
+  }, [getToken, search.request]);
+
+  async function resolveCode() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await apiRequest<{ request: string }>(
+        getToken,
+        '/oauth/device/authorization/resolve',
+        { user_code: userCode },
+      );
+      await navigate({
+        to: '/oauth/device',
+        search: { request: response.request },
+      });
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function approve() {
+    if (!boundary) {
+      setError('Select an environment boundary.');
+      return;
+    }
+    if (boundary === 'single_env' && !workspace) {
+      setError('Select an environment.');
+      return;
+    }
+    if (selectedPermissions.length === 0) {
+      setError('Select at least one permission.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiRequest(getToken, '/oauth/device/authorization', {
+        request,
+        permission_grants: selectedPermissions,
+        resource_boundary_mode: boundary,
+        workspace_id: boundary === 'single_env' ? workspace?.id : null,
+        session_name: sessionName,
+        session_duration_days: durationDays,
+      });
+      setDone('approved');
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function deny() {
+    setSubmitting(true);
+    setError(null);
+    try {
+      await apiRequest(getToken, '/oauth/device/authorization/deny', {
+        request,
+      });
+      setDone('denied');
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (done) {
+    return (
+      <Page>
+        <h1 className="text-basis text-2xl">
+          {done === 'approved' ? 'Access approved' : 'Access denied'}
+        </h1>
+        <p className="text-subtle">
+          You can close this page and return to the CLI.
+        </p>
+      </Page>
+    );
+  }
+
+  if (!request) {
+    return (
+      <Page>
+        <h1 className="text-basis text-2xl">Connect the Inngest CLI</h1>
+        <p className="text-subtle">Enter the code shown by the CLI.</p>
+        <Input
+          id="device-code"
+          label="Code"
+          placeholder="ABCD-EFGH"
+          value={userCode}
+          onChange={(event) => setUserCode(event.target.value.toUpperCase())}
+          disabled={submitting}
+        />
+        {error && <Alert severity="error">{error}</Alert>}
+        <div className="flex justify-end">
+          <Button
+            kind="primary"
+            label="Continue"
+            onClick={resolveCode}
+            loading={submitting}
+            disabled={submitting || userCode.trim() === ''}
+          />
+        </div>
+      </Page>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Page>
+        <p className="text-subtle">Loading request...</p>
+      </Page>
+    );
+  }
+
+  if (!details) {
+    return (
+      <Page>
+        <h1 className="text-basis text-2xl">This request is not available</h1>
+        {error && <Alert severity="error">{error}</Alert>}
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      <div className="flex flex-col gap-1">
+        <h1 className="text-basis text-2xl">Connect {details.client_name}</h1>
+        <p className="text-subtle">
+          Grant access to {details.account_name}. You can revoke this session
+          later.
+        </p>
+      </div>
+
+      <Input
+        id="session-name"
+        label="Session name"
+        value={sessionName}
+        onChange={(event) => setSessionName(event.target.value)}
+        disabled={submitting}
+      />
+
+      <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+        <Select
+          label="Environment access"
+          value={
+            boundary
+              ? {
+                  id: boundary,
+                  name:
+                    boundary === 'single_env'
+                      ? 'One environment'
+                      : 'All environments',
+                }
+              : null
+          }
+          onChange={(option) => setBoundary(option.id as Boundary)}
+        >
+          <Select.Button>
+            {boundary === 'single_env'
+              ? 'One environment'
+              : boundary === 'all_envs'
+              ? 'All environments'
+              : 'Select access'}
+          </Select.Button>
+          <Select.Options>
+            <Select.Option
+              option={{ id: 'single_env', name: 'One environment' }}
+            >
+              One environment
+            </Select.Option>
+            <Select.Option
+              option={{ id: 'all_envs', name: 'All environments' }}
+            >
+              All environments, including production
+            </Select.Option>
+          </Select.Options>
+        </Select>
+
+        {boundary === 'single_env' && (
+          <Select label="Environment" value={workspace} onChange={setWorkspace}>
+            <Select.Button>
+              {workspace?.name ?? 'Select an environment'}
+            </Select.Button>
+            <Select.Options>
+              {environmentOptions.map((option) => (
+                <Select.Option key={option.id} option={option}>
+                  {option.name}
+                </Select.Option>
+              ))}
+            </Select.Options>
+          </Select>
+        )}
+
+        <Select
+          label="Expiration"
+          value={{
+            id: String(durationDays),
+            name: expirationName(durationDays),
+          }}
+          onChange={(option) => setDurationDays(Number(option.id))}
+        >
+          <Select.Button>{expirationName(durationDays)}</Select.Button>
+          <Select.Options>
+            {[7, 30, 90, 365].map((days) => (
+              <Select.Option
+                key={days}
+                option={{ id: String(days), name: expirationName(days) }}
+              >
+                {expirationName(days)}
+              </Select.Option>
+            ))}
+          </Select.Options>
+        </Select>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <label className="text-basis text-sm font-medium">Permissions</label>
+        <PermissionPicker
+          groups={details.permission_groups}
+          levels={permissionLevels}
+          disabled={submitting}
+          onChange={(resource, level) =>
+            setPermissionLevels((current) => ({
+              ...current,
+              [resource]: level,
+            }))
+          }
+        />
+      </div>
+
+      {error && <Alert severity="error">{error}</Alert>}
+
+      <div className="flex justify-end gap-2">
+        <Button
+          appearance="outlined"
+          kind="secondary"
+          label="Deny"
+          onClick={deny}
+          disabled={submitting}
+        />
+        <Button
+          kind="primary"
+          label="Approve"
+          onClick={approve}
+          loading={submitting}
+          disabled={submitting}
+        />
+      </div>
+    </Page>
+  );
+}
+
+function Page({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 py-8">
+      {children}
+    </div>
+  );
+}
+
+async function apiRequest<T = unknown>(
+  getToken: () => Promise<string | null>,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const token = await getToken();
+  const response = await fetch(new URL(path, import.meta.env.VITE_API_URL), {
+    method: body === undefined ? 'GET' : 'POST',
+    credentials: 'include',
+    headers: {
+      Accept: 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const payload = (await response.json()) as T & {
+    error?: string;
+    error_description?: string;
+  };
+  if (!response.ok) {
+    throw new Error(
+      payload.error_description ?? payload.error ?? 'Request failed.',
+    );
+  }
+  return payload;
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  return 'Request failed.';
+}
+
+function expirationName(days: number) {
+  if (days === 365) return '1 year';
+  return `${days} days`;
+}

--- a/vendor/github.com/danieljoos/wincred/.gitattributes
+++ b/vendor/github.com/danieljoos/wincred/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/vendor/github.com/danieljoos/wincred/.gitignore
+++ b/vendor/github.com/danieljoos/wincred/.gitignore
@@ -1,0 +1,25 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+
+coverage.txt

--- a/vendor/github.com/danieljoos/wincred/LICENSE
+++ b/vendor/github.com/danieljoos/wincred/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Daniel Joos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/danieljoos/wincred/README.md
+++ b/vendor/github.com/danieljoos/wincred/README.md
@@ -1,0 +1,145 @@
+wincred
+=======
+
+Go wrapper around the Windows Credential Manager API functions.
+
+[![GitHub release](https://img.shields.io/github/release/danieljoos/wincred.svg?style=flat-square)](https://github.com/danieljoos/wincred/releases/latest)
+[![Test Status](https://img.shields.io/github/actions/workflow/status/danieljoos/wincred/test.yml?label=test&logo=github&style=flat-square)](https://github.com/danieljoos/wincred/actions?query=workflow%3Atest)
+[![Go Report Card](https://goreportcard.com/badge/github.com/danieljoos/wincred)](https://goreportcard.com/report/github.com/danieljoos/wincred)
+[![Codecov](https://img.shields.io/codecov/c/github/danieljoos/wincred?logo=codecov&style=flat-square)](https://codecov.io/gh/danieljoos/wincred)
+[![PkgGoDev](https://img.shields.io/badge/go.dev-docs-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/github.com/danieljoos/wincred)
+
+Installation
+------------
+
+```Go
+go get github.com/danieljoos/wincred
+```
+
+
+Usage
+-----
+
+See the following examples:
+
+### Create and store a new generic credential object
+```Go
+package main
+
+import (
+    "fmt"
+    "github.com/danieljoos/wincred"
+)
+
+func main() {
+    cred := wincred.NewGenericCredential("myGoApplication")
+    cred.CredentialBlob = []byte("my secret")
+    err := cred.Write()
+    
+    if err != nil {
+        fmt.Println(err)
+    }
+} 
+```
+
+### Retrieve a credential object
+```Go
+package main
+
+import (
+    "fmt"
+    "github.com/danieljoos/wincred"
+)
+
+func main() {
+    cred, err := wincred.GetGenericCredential("myGoApplication")
+    if err == nil {
+        fmt.Println(string(cred.CredentialBlob))
+    }
+} 
+```
+
+### Remove a credential object
+```Go
+package main
+
+import (
+    "fmt"
+    "github.com/danieljoos/wincred"
+)
+
+func main() {
+    cred, err := wincred.GetGenericCredential("myGoApplication")
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    cred.Delete()
+} 
+```
+
+### List all available credentials
+```Go
+package main
+
+import (
+    "fmt"
+    "github.com/danieljoos/wincred"
+)
+
+func main() {
+    creds, err := wincred.List()
+    if err != nil {
+        fmt.Println(err)
+        return
+    }
+    for i := range(creds) {
+        fmt.Println(creds[i].TargetName)
+    }
+}
+```
+
+Hints
+-----
+
+### Encoding
+
+The credential objects simply store byte arrays without specific meaning or encoding.
+For sharing between different applications, it might make sense to apply an explicit string encoding - for example **UTF-16 LE** (used nearly everywhere in the Win32 API).
+
+```Go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/danieljoos/wincred"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+func main() {
+	cred := wincred.NewGenericCredential("myGoApplication")
+
+	encoder := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM).NewEncoder()
+	blob, _, err := transform.Bytes(encoder, []byte("mysecret"))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	cred.CredentialBlob = blob
+	err = cred.Write()
+
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+```
+
+### Limitations
+
+The size of a credential blob is limited to **2560 Bytes** by the Windows API.

--- a/vendor/github.com/danieljoos/wincred/conversion.go
+++ b/vendor/github.com/danieljoos/wincred/conversion.go
@@ -1,0 +1,110 @@
+// +build windows
+
+package wincred
+
+import (
+	"encoding/binary"
+	"reflect"
+	"time"
+	"unsafe"
+
+	syscall "golang.org/x/sys/windows"
+)
+
+// utf16ToByte creates a byte array from a given UTF 16 char array.
+func utf16ToByte(wstr []uint16) (result []byte) {
+	result = make([]byte, len(wstr)*2)
+	for i := range wstr {
+		binary.LittleEndian.PutUint16(result[(i*2):(i*2)+2], wstr[i])
+	}
+	return
+}
+
+// utf16FromString creates a UTF16 char array from a string.
+func utf16FromString(str string) []uint16 {
+	res, err := syscall.UTF16FromString(str)
+	if err != nil {
+		return []uint16{}
+	}
+	return res
+}
+
+// goBytes copies the given C byte array to a Go byte array (see `C.GoBytes`).
+// This function avoids having cgo as dependency.
+func goBytes(src *byte, len uint32) []byte {
+	if src == nil || len == 0 {
+		return []byte{}
+	}
+	rv := make([]byte, len)
+	copy(rv, *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(src)),
+		Len:  int(len),
+		Cap:  int(len),
+	})))
+	return rv
+}
+
+// Convert the given CREDENTIAL struct to a more usable structure
+func sysToCredential(cred *sysCREDENTIAL) (result *Credential) {
+	if cred == nil {
+		return nil
+	}
+	result = new(Credential)
+	result.Comment = syscall.UTF16PtrToString(cred.Comment)
+	result.TargetName = syscall.UTF16PtrToString(cred.TargetName)
+	result.TargetAlias = syscall.UTF16PtrToString(cred.TargetAlias)
+	result.UserName = syscall.UTF16PtrToString(cred.UserName)
+	result.LastWritten = time.Unix(0, cred.LastWritten.Nanoseconds())
+	result.Persist = CredentialPersistence(cred.Persist)
+	result.CredentialBlob = goBytes(cred.CredentialBlob, cred.CredentialBlobSize)
+	result.Attributes = make([]CredentialAttribute, cred.AttributeCount)
+	attrSlice := *(*[]sysCREDENTIAL_ATTRIBUTE)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: uintptr(unsafe.Pointer(cred.Attributes)),
+		Len:  int(cred.AttributeCount),
+		Cap:  int(cred.AttributeCount),
+	}))
+	for i, attr := range attrSlice {
+		resultAttr := &result.Attributes[i]
+		resultAttr.Keyword = syscall.UTF16PtrToString(attr.Keyword)
+		resultAttr.Value = goBytes(attr.Value, attr.ValueSize)
+	}
+	return result
+}
+
+// Convert the given Credential object back to a CREDENTIAL struct, which can be used for calling the
+// Windows APIs
+func sysFromCredential(cred *Credential) (result *sysCREDENTIAL) {
+	if cred == nil {
+		return nil
+	}
+	result = new(sysCREDENTIAL)
+	result.Flags = 0
+	result.Type = 0
+	result.TargetName, _ = syscall.UTF16PtrFromString(cred.TargetName)
+	result.Comment, _ = syscall.UTF16PtrFromString(cred.Comment)
+	result.LastWritten = syscall.NsecToFiletime(cred.LastWritten.UnixNano())
+	result.CredentialBlobSize = uint32(len(cred.CredentialBlob))
+	if len(cred.CredentialBlob) > 0 {
+		result.CredentialBlob = &cred.CredentialBlob[0]
+	}
+	result.Persist = uint32(cred.Persist)
+	result.AttributeCount = uint32(len(cred.Attributes))
+	attributes := make([]sysCREDENTIAL_ATTRIBUTE, len(cred.Attributes))
+	if len(attributes) > 0 {
+		result.Attributes = &attributes[0]
+	}
+	for i := range cred.Attributes {
+		inAttr := &cred.Attributes[i]
+		outAttr := &attributes[i]
+		outAttr.Keyword, _ = syscall.UTF16PtrFromString(inAttr.Keyword)
+		outAttr.Flags = 0
+		outAttr.ValueSize = uint32(len(inAttr.Value))
+		if len(inAttr.Value) > 0 {
+			outAttr.Value = &inAttr.Value[0]
+		}
+	}
+	result.TargetAlias, _ = syscall.UTF16PtrFromString(cred.TargetAlias)
+	result.UserName, _ = syscall.UTF16PtrFromString(cred.UserName)
+
+	return
+}

--- a/vendor/github.com/danieljoos/wincred/conversion_unsupported.go
+++ b/vendor/github.com/danieljoos/wincred/conversion_unsupported.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package wincred
+
+func utf16ToByte(...interface{}) []byte {
+	return nil
+}
+
+func utf16FromString(...interface{}) []uint16 {
+	return nil
+}

--- a/vendor/github.com/danieljoos/wincred/sys.go
+++ b/vendor/github.com/danieljoos/wincred/sys.go
@@ -1,0 +1,151 @@
+//go:build windows
+// +build windows
+
+package wincred
+
+import (
+	"reflect"
+	"runtime"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	modadvapi32            = windows.NewLazySystemDLL("advapi32.dll")
+	procCredRead           = modadvapi32.NewProc("CredReadW")
+	procCredWrite     proc = modadvapi32.NewProc("CredWriteW")
+	procCredDelete    proc = modadvapi32.NewProc("CredDeleteW")
+	procCredFree      proc = modadvapi32.NewProc("CredFree")
+	procCredEnumerate      = modadvapi32.NewProc("CredEnumerateW")
+)
+
+// Interface for syscall.Proc: helps testing
+type proc interface {
+	Call(a ...uintptr) (r1, r2 uintptr, lastErr error)
+}
+
+// https://docs.microsoft.com/en-us/windows/desktop/api/wincred/ns-wincred-_credentialw
+type sysCREDENTIAL struct {
+	Flags              uint32
+	Type               uint32
+	TargetName         *uint16
+	Comment            *uint16
+	LastWritten        windows.Filetime
+	CredentialBlobSize uint32
+	CredentialBlob     *byte
+	Persist            uint32
+	AttributeCount     uint32
+	Attributes         *sysCREDENTIAL_ATTRIBUTE
+	TargetAlias        *uint16
+	UserName           *uint16
+}
+
+// https://docs.microsoft.com/en-us/windows/desktop/api/wincred/ns-wincred-_credential_attributew
+type sysCREDENTIAL_ATTRIBUTE struct {
+	Keyword   *uint16
+	Flags     uint32
+	ValueSize uint32
+	Value     *byte
+}
+
+// https://docs.microsoft.com/en-us/windows/desktop/api/wincred/ns-wincred-_credentialw
+type sysCRED_TYPE uint32
+
+const (
+	sysCRED_TYPE_GENERIC                 sysCRED_TYPE = 0x1
+	sysCRED_TYPE_DOMAIN_PASSWORD         sysCRED_TYPE = 0x2
+	sysCRED_TYPE_DOMAIN_CERTIFICATE      sysCRED_TYPE = 0x3
+	sysCRED_TYPE_DOMAIN_VISIBLE_PASSWORD sysCRED_TYPE = 0x4
+	sysCRED_TYPE_GENERIC_CERTIFICATE     sysCRED_TYPE = 0x5
+	sysCRED_TYPE_DOMAIN_EXTENDED         sysCRED_TYPE = 0x6
+
+	// https://docs.microsoft.com/en-us/windows/desktop/Debug/system-error-codes
+	sysERROR_NOT_FOUND         = windows.Errno(1168)
+	sysERROR_INVALID_PARAMETER = windows.Errno(87)
+	sysERROR_BAD_USERNAME      = windows.Errno(2202)
+)
+
+// https://docs.microsoft.com/en-us/windows/desktop/api/wincred/nf-wincred-credreadw
+func sysCredRead(targetName string, typ sysCRED_TYPE) (*Credential, error) {
+	var pcred *sysCREDENTIAL
+	targetNamePtr, _ := windows.UTF16PtrFromString(targetName)
+	ret, _, err := syscall.SyscallN(
+		procCredRead.Addr(),
+		uintptr(unsafe.Pointer(targetNamePtr)),
+		uintptr(typ),
+		0,
+		uintptr(unsafe.Pointer(&pcred)),
+	)
+	if ret == 0 {
+		return nil, err
+	}
+	defer procCredFree.Call(uintptr(unsafe.Pointer(pcred)))
+
+	return sysToCredential(pcred), nil
+}
+
+// https://docs.microsoft.com/en-us/windows/desktop/api/wincred/nf-wincred-credwritew
+func sysCredWrite(cred *Credential, typ sysCRED_TYPE) error {
+	ncred := sysFromCredential(cred)
+	ncred.Type = uint32(typ)
+	ret, _, err := procCredWrite.Call(
+		uintptr(unsafe.Pointer(ncred)),
+		0,
+	)
+	// Make sure everything reachable from ncred stays alive through the call.
+	runtime.KeepAlive(ncred)
+	if ret == 0 {
+		return err
+	}
+
+	return nil
+}
+
+// https://docs.microsoft.com/en-us/windows/desktop/api/wincred/nf-wincred-creddeletew
+func sysCredDelete(cred *Credential, typ sysCRED_TYPE) error {
+	targetNamePtr, _ := windows.UTF16PtrFromString(cred.TargetName)
+	ret, _, err := procCredDelete.Call(
+		uintptr(unsafe.Pointer(targetNamePtr)),
+		uintptr(typ),
+		0,
+	)
+	if ret == 0 {
+		return err
+	}
+
+	return nil
+}
+
+// https://docs.microsoft.com/en-us/windows/desktop/api/wincred/nf-wincred-credenumeratew
+func sysCredEnumerate(filter string, all bool) ([]*Credential, error) {
+	var count int
+	var pcreds uintptr
+	var filterPtr *uint16
+	if !all {
+		filterPtr, _ = windows.UTF16PtrFromString(filter)
+	}
+	ret, _, err := syscall.SyscallN(
+		procCredEnumerate.Addr(),
+		uintptr(unsafe.Pointer(filterPtr)),
+		0,
+		uintptr(unsafe.Pointer(&count)),
+		uintptr(unsafe.Pointer(&pcreds)),
+	)
+	if ret == 0 {
+		return nil, err
+	}
+	defer procCredFree.Call(pcreds)
+	credsSlice := *(*[]*sysCREDENTIAL)(unsafe.Pointer(&reflect.SliceHeader{
+		Data: pcreds,
+		Len:  count,
+		Cap:  count,
+	}))
+	creds := make([]*Credential, count, count)
+	for i, cred := range credsSlice {
+		creds[i] = sysToCredential(cred)
+	}
+
+	return creds, nil
+}

--- a/vendor/github.com/danieljoos/wincred/sys_unsupported.go
+++ b/vendor/github.com/danieljoos/wincred/sys_unsupported.go
@@ -1,0 +1,38 @@
+//go:build !windows
+// +build !windows
+
+package wincred
+
+import (
+	"errors"
+	"syscall"
+)
+
+const (
+	sysCRED_TYPE_GENERIC                 = 0
+	sysCRED_TYPE_DOMAIN_PASSWORD         = 0
+	sysCRED_TYPE_DOMAIN_CERTIFICATE      = 0
+	sysCRED_TYPE_DOMAIN_VISIBLE_PASSWORD = 0
+	sysCRED_TYPE_GENERIC_CERTIFICATE     = 0
+	sysCRED_TYPE_DOMAIN_EXTENDED         = 0
+
+	sysERROR_NOT_FOUND         = syscall.Errno(1)
+	sysERROR_INVALID_PARAMETER = syscall.Errno(1)
+	sysERROR_BAD_USERNAME      = syscall.Errno(1)
+)
+
+func sysCredRead(...interface{}) (*Credential, error) {
+	return nil, errors.New("Operation not supported")
+}
+
+func sysCredWrite(...interface{}) error {
+	return errors.New("Operation not supported")
+}
+
+func sysCredDelete(...interface{}) error {
+	return errors.New("Operation not supported")
+}
+
+func sysCredEnumerate(...interface{}) ([]*Credential, error) {
+	return nil, errors.New("Operation not supported")
+}

--- a/vendor/github.com/danieljoos/wincred/types.go
+++ b/vendor/github.com/danieljoos/wincred/types.go
@@ -1,0 +1,69 @@
+package wincred
+
+import (
+	"time"
+)
+
+// CredentialPersistence describes one of three persistence modes of a credential.
+// A detailed description of the available modes can be found on
+// Docs: https://docs.microsoft.com/en-us/windows/desktop/api/wincred/ns-wincred-_credentialw
+type CredentialPersistence uint32
+
+const (
+	// PersistSession indicates that the credential only persists for the life
+	// of the current Windows login session. Such a credential is not visible in
+	// any other logon session, even from the same user.
+	PersistSession CredentialPersistence = 0x1
+
+	// PersistLocalMachine indicates that the credential persists for this and
+	// all subsequent logon sessions on this local machine/computer. It is
+	// however not visible for logon sessions of this user on a different
+	// machine.
+	PersistLocalMachine CredentialPersistence = 0x2
+
+	// PersistEnterprise indicates that the credential persists for this and all
+	// subsequent logon sessions for this user. It is also visible for logon
+	// sessions on different computers.
+	PersistEnterprise CredentialPersistence = 0x3
+)
+
+// CredentialAttribute represents an application-specific attribute of a credential.
+type CredentialAttribute struct {
+	Keyword string
+	Value   []byte
+}
+
+// Credential is the basic credential structure.
+// A credential is identified by its target name.
+// The actual credential secret is available in the CredentialBlob field.
+type Credential struct {
+	TargetName     string
+	Comment        string
+	LastWritten    time.Time
+	CredentialBlob []byte
+	Attributes     []CredentialAttribute
+	TargetAlias    string
+	UserName       string
+	Persist        CredentialPersistence
+}
+
+// GenericCredential holds a credential for generic usage.
+// It is typically defined and used by applications that need to manage user
+// secrets.
+//
+// More information about the available kinds of credentials of the Windows
+// Credential Management API can be found on Docs:
+// https://docs.microsoft.com/en-us/windows/desktop/SecAuthN/kinds-of-credentials
+type GenericCredential struct {
+	Credential
+}
+
+// DomainPassword holds a domain credential that is typically used by the
+// operating system for user logon.
+//
+// More information about the available kinds of credentials of the Windows
+// Credential Management API can be found on Docs:
+// https://docs.microsoft.com/en-us/windows/desktop/SecAuthN/kinds-of-credentials
+type DomainPassword struct {
+	Credential
+}

--- a/vendor/github.com/danieljoos/wincred/wincred.go
+++ b/vendor/github.com/danieljoos/wincred/wincred.go
@@ -1,0 +1,114 @@
+// Package wincred provides primitives for accessing the Windows Credentials Management API.
+// This includes functions for retrieval, listing and storage of credentials as well as Go structures for convenient access to the credential data.
+//
+// A more detailed description of Windows Credentials Management can be found on
+// Docs: https://docs.microsoft.com/en-us/windows/desktop/SecAuthN/credentials-management
+package wincred
+
+import "errors"
+
+const (
+	// ErrElementNotFound is the error that is returned if a requested element cannot be found.
+	// This error constant can be used to check if a credential could not be found.
+	ErrElementNotFound = sysERROR_NOT_FOUND
+
+	// ErrInvalidParameter is the error that is returned for invalid parameters.
+	// This error constant can be used to check if the given function parameters were invalid.
+	// For example when trying to create a new generic credential with an empty target name.
+	ErrInvalidParameter = sysERROR_INVALID_PARAMETER
+
+	// ErrBadUsername is returned when the credential's username is invalid.
+	ErrBadUsername = sysERROR_BAD_USERNAME
+)
+
+// GetGenericCredential fetches the generic credential with the given name from Windows credential manager.
+// It returns nil and an error if the credential could not be found or an error occurred.
+func GetGenericCredential(targetName string) (*GenericCredential, error) {
+	cred, err := sysCredRead(targetName, sysCRED_TYPE_GENERIC)
+	if cred != nil {
+		return &GenericCredential{Credential: *cred}, err
+	}
+	return nil, err
+}
+
+// NewGenericCredential creates a new generic credential object with the given name.
+// The persist mode of the newly created object is set to a default value that indicates local-machine-wide storage.
+// The credential object is NOT yet persisted to the Windows credential vault.
+func NewGenericCredential(targetName string) (result *GenericCredential) {
+	result = new(GenericCredential)
+	result.TargetName = targetName
+	result.Persist = PersistLocalMachine
+	return
+}
+
+// Write persists the generic credential object to Windows credential manager.
+func (t *GenericCredential) Write() (err error) {
+	err = sysCredWrite(&t.Credential, sysCRED_TYPE_GENERIC)
+	return
+}
+
+// Delete removes the credential object from Windows credential manager.
+func (t *GenericCredential) Delete() (err error) {
+	err = sysCredDelete(&t.Credential, sysCRED_TYPE_GENERIC)
+	return
+}
+
+// GetDomainPassword fetches the domain-password credential with the given target host name from Windows credential manager.
+// It returns nil and an error if the credential could not be found or an error occurred.
+func GetDomainPassword(targetName string) (*DomainPassword, error) {
+	cred, err := sysCredRead(targetName, sysCRED_TYPE_DOMAIN_PASSWORD)
+	if cred != nil {
+		return &DomainPassword{Credential: *cred}, err
+	}
+	return nil, err
+}
+
+// NewDomainPassword creates a new domain-password credential used for login to the given target host name.
+// The  persist mode of the newly created object is set to a default value that indicates local-machine-wide storage.
+// The credential object is NOT yet persisted to the Windows credential vault.
+func NewDomainPassword(targetName string) (result *DomainPassword) {
+	result = new(DomainPassword)
+	result.TargetName = targetName
+	result.Persist = PersistLocalMachine
+	return
+}
+
+// Write persists the domain-password credential to Windows credential manager.
+func (t *DomainPassword) Write() (err error) {
+	err = sysCredWrite(&t.Credential, sysCRED_TYPE_DOMAIN_PASSWORD)
+	return
+}
+
+// Delete removes the domain-password credential from Windows credential manager.
+func (t *DomainPassword) Delete() (err error) {
+	err = sysCredDelete(&t.Credential, sysCRED_TYPE_DOMAIN_PASSWORD)
+	return
+}
+
+// SetPassword sets the CredentialBlob field of a domain password credential to the given string.
+func (t *DomainPassword) SetPassword(pw string) {
+	t.CredentialBlob = utf16ToByte(utf16FromString(pw))
+}
+
+// List retrieves all credentials of the Credentials store.
+func List() ([]*Credential, error) {
+	creds, err := sysCredEnumerate("", true)
+	if err != nil && errors.Is(err, ErrElementNotFound) {
+		// Ignore ERROR_NOT_FOUND and return an empty list instead
+		creds = []*Credential{}
+		err = nil
+	}
+	return creds, err
+}
+
+// FilteredList retrieves the list of credentials from the Credentials store that match the given filter.
+// The filter string defines the prefix followed by an asterisk for the `TargetName` attribute of the credentials.
+func FilteredList(filter string) ([]*Credential, error) {
+	creds, err := sysCredEnumerate(filter, false)
+	if err != nil && errors.Is(err, ErrElementNotFound) {
+		// Ignore ERROR_NOT_FOUND and return an empty list instead
+		creds = []*Credential{}
+		err = nil
+	}
+	return creds, err
+}

--- a/vendor/github.com/godbus/dbus/v5/.cirrus.yml
+++ b/vendor/github.com/godbus/dbus/v5/.cirrus.yml
@@ -1,0 +1,11 @@
+# See https://cirrus-ci.org/guide/FreeBSD/
+freebsd_instance:
+  image_family: freebsd-14-3
+
+task:
+  name: Test on FreeBSD
+  install_script: pkg install -y go125 dbus
+  test_script: |
+    /usr/local/etc/rc.d/dbus onestart && \
+    eval `dbus-launch --sh-syntax` && \
+    go125 test -v ./...

--- a/vendor/github.com/godbus/dbus/v5/.golangci.yml
+++ b/vendor/github.com/godbus/dbus/v5/.golangci.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+linters:
+  enable:
+    - unconvert
+    - unparam
+  exclusions:
+    presets:
+      - std-error-handling
+
+formatters:
+  enable:
+    - gofumpt

--- a/vendor/github.com/godbus/dbus/v5/CONTRIBUTING.md
+++ b/vendor/github.com/godbus/dbus/v5/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# How to Contribute
+
+## Getting Started
+
+- Fork the repository on GitHub
+- Read the [README](README.markdown) for build and test instructions
+- Play with the project, submit bugs, submit patches!
+
+## Contribution Flow
+
+This is a rough outline of what a contributor's workflow looks like:
+
+- Create a topic branch from where you want to base your work (usually master).
+- Make commits of logical units.
+- Make sure your commit messages are in the proper format (see below).
+- Push your changes to a topic branch in your fork of the repository.
+- Make sure the tests pass, and add any new tests as appropriate.
+- Submit a pull request to the original repository.
+
+Thanks for your contributions!
+
+### Format of the Commit Message
+
+We follow a rough convention for commit messages that is designed to answer two
+questions: what changed and why. The subject line should feature the what and
+the body of the commit should describe the why.
+
+```
+scripts: add the test-cluster command
+
+this uses tmux to setup a test cluster that you can easily kill and
+start for debugging.
+
+Fixes #38
+```
+
+The format can be described more formally as follows:
+
+```
+<subsystem>: <what changed>
+<BLANK LINE>
+<why this change was made>
+<BLANK LINE>
+<footer>
+```
+
+The first line is the subject and should be no longer than 70 characters, the
+second line is always blank, and other lines should be wrapped at 80 characters.
+This allows the message to be easier to read on GitHub as well as in various
+git tools.

--- a/vendor/github.com/godbus/dbus/v5/LICENSE
+++ b/vendor/github.com/godbus/dbus/v5/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2013, Georg Reinke (<guelfey at gmail dot com>), Google
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/godbus/dbus/v5/MAINTAINERS
+++ b/vendor/github.com/godbus/dbus/v5/MAINTAINERS
@@ -1,0 +1,3 @@
+Brandon Philips <brandon@ifup.org> (@philips)
+Brian Waldon <brian@waldon.cc> (@bcwaldon)
+John Southworth <jsouthwo@brocade.com> (@jsouthworth)

--- a/vendor/github.com/godbus/dbus/v5/README.md
+++ b/vendor/github.com/godbus/dbus/v5/README.md
@@ -1,0 +1,47 @@
+![Build Status](https://github.com/godbus/dbus/workflows/Go/badge.svg)
+
+dbus
+----
+
+dbus is a simple library that implements native Go client bindings for the
+D-Bus message bus system.
+
+### Features
+
+* Complete native implementation of the D-Bus message protocol
+* Go-like API (channels for signals / asynchronous method calls, Goroutine-safe connections)
+* Subpackages that help with the introspection / property interfaces
+
+### Installation
+
+This packages requires Go 1.20 or later. It can be installed by running the command below:
+
+```
+go get github.com/godbus/dbus/v5
+```
+
+### Usage
+
+The complete package documentation and some simple examples are available at
+[pkg.go.dev](https://pkg.go.dev/github.com/godbus/dbus/v5). Also, the
+[_examples](https://github.com/godbus/dbus/tree/master/_examples) directory
+gives a short overview over the basic usage. 
+
+#### Projects using godbus
+- [fyne](https://github.com/fyne-io/fyne) a cross platform GUI in Go inspired by Material Design.
+- [fynedesk](https://github.com/fyne-io/fynedesk) a full desktop environment for Linux/Unix using Fyne.
+- [go-bluetooth](https://github.com/muka/go-bluetooth) provides a bluetooth client over bluez dbus API.
+- [iwd](https://github.com/shibumi/iwd) go bindings for the internet wireless daemon "iwd".
+- [notify](https://github.com/esiqveland/notify) provides desktop notifications over dbus into a library.
+- [playerbm](https://github.com/altdesktop/playerbm) a bookmark utility for media players.
+- [rpic](https://github.com/stephenhu/rpic) lightweight web app and RESTful API for managing a Raspberry Pi
+
+Please note that the API is considered unstable for now and may change without
+further notice.
+
+### License
+
+go.dbus is available under the Simplified BSD License; see LICENSE for the full
+text.
+
+Nearly all of the credit for this library goes to github.com/guelfey/go.dbus.

--- a/vendor/github.com/godbus/dbus/v5/SECURITY.md
+++ b/vendor/github.com/godbus/dbus/v5/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/godbus/dbus/security/advisories/new).
+
+This project is maintained by a team of volunteers on a reasonable-effort basis. As such, vulnerabilities will be disclosed in a best effort base.

--- a/vendor/github.com/godbus/dbus/v5/auth.go
+++ b/vendor/github.com/godbus/dbus/v5/auth.go
@@ -1,0 +1,257 @@
+package dbus
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strconv"
+)
+
+// AuthStatus represents the Status of an authentication mechanism.
+type AuthStatus byte
+
+const (
+	// AuthOk signals that authentication is finished; the next command
+	// from the server should be an OK.
+	AuthOk AuthStatus = iota
+
+	// AuthContinue signals that additional data is needed; the next command
+	// from the server should be a DATA.
+	AuthContinue
+
+	// AuthError signals an error; the server sent invalid data or some
+	// other unexpected thing happened and the current authentication
+	// process should be aborted.
+	AuthError
+)
+
+type authState byte
+
+const (
+	waitingForData authState = iota
+	waitingForOk
+	waitingForReject
+)
+
+// Auth defines the behaviour of an authentication mechanism.
+type Auth interface {
+	// Return the name of the mechanism, the argument to the first AUTH command
+	// and the next status.
+	FirstData() (name, resp []byte, status AuthStatus)
+
+	// Process the given DATA command, and return the argument to the DATA
+	// command and the next status. If len(resp) == 0, no DATA command is sent.
+	HandleData(data []byte) (resp []byte, status AuthStatus)
+}
+
+// Auth authenticates the connection, trying the given list of authentication
+// mechanisms (in that order). If nil is passed, the EXTERNAL and
+// DBUS_COOKIE_SHA1 mechanisms are tried for the current user. For private
+// connections, this method must be called before sending any messages to the
+// bus. Auth must not be called on shared connections.
+func (conn *Conn) Auth(methods []Auth) error {
+	if methods == nil {
+		uid := strconv.Itoa(os.Geteuid())
+		methods = getDefaultAuthMethods(uid)
+	}
+	in := bufio.NewReader(conn.transport)
+	err := conn.SendNullByte()
+	if err != nil {
+		return err
+	}
+	err = authWriteLine(conn.transport, []byte("AUTH"))
+	if err != nil {
+		return err
+	}
+	s, err := authReadLine(in)
+	if err != nil {
+		return err
+	}
+	if len(s) < 2 || !bytes.Equal(s[0], []byte("REJECTED")) {
+		return errors.New("dbus: authentication protocol error")
+	}
+	s = s[1:]
+	for _, v := range s {
+		for _, m := range methods {
+			if name, _, status := m.FirstData(); bytes.Equal(v, name) {
+				var ok bool
+				err = authWriteLine(conn.transport, []byte("AUTH"), v)
+				if err != nil {
+					return err
+				}
+				switch status {
+				case AuthOk:
+					ok, err = conn.tryAuth(m, waitingForOk, in)
+				case AuthContinue:
+					ok, err = conn.tryAuth(m, waitingForData, in)
+				default:
+					panic("dbus: invalid authentication status")
+				}
+				if err != nil {
+					return err
+				}
+				if ok {
+					if conn.transport.SupportsUnixFDs() {
+						err = authWriteLine(conn, []byte("NEGOTIATE_UNIX_FD"))
+						if err != nil {
+							return err
+						}
+						line, err := authReadLine(in)
+						if err != nil {
+							return err
+						}
+						switch {
+						case bytes.Equal(line[0], []byte("AGREE_UNIX_FD")):
+							conn.EnableUnixFDs()
+							conn.unixFD = true
+						case bytes.Equal(line[0], []byte("ERROR")):
+						default:
+							return errors.New("dbus: authentication protocol error")
+						}
+					}
+					err = authWriteLine(conn.transport, []byte("BEGIN"))
+					if err != nil {
+						return err
+					}
+					go conn.inWorker()
+					return nil
+				}
+			}
+		}
+	}
+	return errors.New("dbus: authentication failed")
+}
+
+// tryAuth tries to authenticate with m as the mechanism, using state as the
+// initial authState and in for reading input. It returns (true, nil) on
+// success, (false, nil) on a REJECTED and (false, someErr) if some other
+// error occurred.
+func (conn *Conn) tryAuth(m Auth, state authState, in *bufio.Reader) (bool, error) {
+	for {
+		s, err := authReadLine(in)
+		if err != nil {
+			return false, err
+		}
+		switch {
+		case state == waitingForData && string(s[0]) == "DATA":
+			if len(s) != 2 {
+				err = authWriteLine(conn.transport, []byte("ERROR"))
+				if err != nil {
+					return false, err
+				}
+				continue
+			}
+			data, status := m.HandleData(s[1])
+			switch status {
+			case AuthOk, AuthContinue:
+				if len(data) != 0 {
+					err = authWriteLine(conn.transport, []byte("DATA"), data)
+					if err != nil {
+						return false, err
+					}
+				}
+				if status == AuthOk {
+					state = waitingForOk
+				}
+			case AuthError:
+				err = authWriteLine(conn.transport, []byte("ERROR"))
+				if err != nil {
+					return false, err
+				}
+			}
+		case state == waitingForData && string(s[0]) == "REJECTED":
+			return false, nil
+		case state == waitingForData && string(s[0]) == "ERROR":
+			err = authWriteLine(conn.transport, []byte("CANCEL"))
+			if err != nil {
+				return false, err
+			}
+			state = waitingForReject
+		case state == waitingForData && string(s[0]) == "OK":
+			if len(s) != 2 {
+				err = authWriteLine(conn.transport, []byte("CANCEL"))
+				if err != nil {
+					return false, err
+				}
+				state = waitingForReject
+			} else {
+				conn.uuid = string(s[1])
+				return true, nil
+			}
+		case state == waitingForData:
+			err = authWriteLine(conn.transport, []byte("ERROR"))
+			if err != nil {
+				return false, err
+			}
+		case state == waitingForOk && string(s[0]) == "OK":
+			if len(s) != 2 {
+				err = authWriteLine(conn.transport, []byte("CANCEL"))
+				if err != nil {
+					return false, err
+				}
+				state = waitingForReject
+			} else {
+				conn.uuid = string(s[1])
+				return true, nil
+			}
+		case state == waitingForOk && string(s[0]) == "DATA":
+			err = authWriteLine(conn.transport, []byte("DATA"))
+			if err != nil {
+				return false, nil
+			}
+		case state == waitingForOk && string(s[0]) == "REJECTED":
+			return false, nil
+		case state == waitingForOk && string(s[0]) == "ERROR":
+			err = authWriteLine(conn.transport, []byte("CANCEL"))
+			if err != nil {
+				return false, err
+			}
+			state = waitingForReject
+		case state == waitingForOk:
+			err = authWriteLine(conn.transport, []byte("ERROR"))
+			if err != nil {
+				return false, err
+			}
+		case state == waitingForReject && string(s[0]) == "REJECTED":
+			return false, nil
+		case state == waitingForReject:
+			return false, errors.New("dbus: authentication protocol error")
+		default:
+			panic("dbus: invalid auth state")
+		}
+	}
+}
+
+// authReadLine reads a line and separates it into its fields.
+func authReadLine(in *bufio.Reader) ([][]byte, error) {
+	data, err := in.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+	data = bytes.TrimSuffix(data, []byte("\r\n"))
+	return bytes.Split(data, []byte{' '}), nil
+}
+
+// authWriteLine writes the given line in the authentication protocol format
+// (elements of data separated by a " " and terminated by "\r\n").
+func authWriteLine(out io.Writer, data ...[]byte) error {
+	buf := make([]byte, 0)
+	for i, v := range data {
+		buf = append(buf, v...)
+		if i != len(data)-1 {
+			buf = append(buf, ' ')
+		}
+	}
+	buf = append(buf, '\r')
+	buf = append(buf, '\n')
+	n, err := out.Write(buf)
+	if err != nil {
+		return err
+	}
+	if n != len(buf) {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/auth_anonymous.go
+++ b/vendor/github.com/godbus/dbus/v5/auth_anonymous.go
@@ -1,0 +1,16 @@
+package dbus
+
+// AuthAnonymous returns an Auth that uses the ANONYMOUS mechanism.
+func AuthAnonymous() Auth {
+	return &authAnonymous{}
+}
+
+type authAnonymous struct{}
+
+func (a *authAnonymous) FirstData() (name, resp []byte, status AuthStatus) {
+	return []byte("ANONYMOUS"), nil, AuthOk
+}
+
+func (a *authAnonymous) HandleData(data []byte) (resp []byte, status AuthStatus) {
+	return nil, AuthError
+}

--- a/vendor/github.com/godbus/dbus/v5/auth_default_other.go
+++ b/vendor/github.com/godbus/dbus/v5/auth_default_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package dbus
+
+func getDefaultAuthMethods(user string) []Auth {
+	return []Auth{AuthExternal(user)}
+}

--- a/vendor/github.com/godbus/dbus/v5/auth_default_windows.go
+++ b/vendor/github.com/godbus/dbus/v5/auth_default_windows.go
@@ -1,0 +1,5 @@
+package dbus
+
+func getDefaultAuthMethods(user string) []Auth {
+	return []Auth{AuthCookieSha1(user, getHomeDir())}
+}

--- a/vendor/github.com/godbus/dbus/v5/auth_external.go
+++ b/vendor/github.com/godbus/dbus/v5/auth_external.go
@@ -1,0 +1,26 @@
+package dbus
+
+import (
+	"encoding/hex"
+)
+
+// AuthExternal returns an Auth that authenticates as the given user with the
+// EXTERNAL mechanism.
+func AuthExternal(user string) Auth {
+	return authExternal{user}
+}
+
+// AuthExternal implements the EXTERNAL authentication mechanism.
+type authExternal struct {
+	user string
+}
+
+func (a authExternal) FirstData() ([]byte, []byte, AuthStatus) {
+	b := make([]byte, 2*len(a.user))
+	hex.Encode(b, []byte(a.user))
+	return []byte("EXTERNAL"), b, AuthOk
+}
+
+func (a authExternal) HandleData(b []byte) ([]byte, AuthStatus) {
+	return nil, AuthError
+}

--- a/vendor/github.com/godbus/dbus/v5/auth_sha1_windows.go
+++ b/vendor/github.com/godbus/dbus/v5/auth_sha1_windows.go
@@ -1,0 +1,109 @@
+package dbus
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/hex"
+	"os"
+)
+
+// AuthCookieSha1 returns an Auth that authenticates as the given user with the
+// DBUS_COOKIE_SHA1 mechanism. The home parameter should specify the home
+// directory of the user.
+func AuthCookieSha1(user, home string) Auth {
+	return authCookieSha1{user, home}
+}
+
+type authCookieSha1 struct {
+	user, home string
+}
+
+func (a authCookieSha1) FirstData() ([]byte, []byte, AuthStatus) {
+	b := make([]byte, 2*len(a.user))
+	hex.Encode(b, []byte(a.user))
+	return []byte("DBUS_COOKIE_SHA1"), b, AuthContinue
+}
+
+func (a authCookieSha1) HandleData(data []byte) ([]byte, AuthStatus) {
+	challenge := make([]byte, len(data)/2)
+	_, err := hex.Decode(challenge, data)
+	if err != nil {
+		return nil, AuthError
+	}
+	b := bytes.Split(challenge, []byte{' '})
+	if len(b) != 3 {
+		return nil, AuthError
+	}
+	context := b[0]
+	id := b[1]
+	svchallenge := b[2]
+	cookie := a.getCookie(context, id)
+	if cookie == nil {
+		return nil, AuthError
+	}
+	clchallenge := a.generateChallenge()
+	if clchallenge == nil {
+		return nil, AuthError
+	}
+	hash := sha1.New()
+	hash.Write(bytes.Join([][]byte{svchallenge, clchallenge, cookie}, []byte{':'}))
+	hexhash := make([]byte, 2*hash.Size())
+	hex.Encode(hexhash, hash.Sum(nil))
+	data = append(clchallenge, ' ')
+	data = append(data, hexhash...)
+	resp := make([]byte, 2*len(data))
+	hex.Encode(resp, data)
+	return resp, AuthOk
+}
+
+// getCookie searches for the cookie identified by id in context and returns
+// the cookie content or nil. (Since HandleData can't return a specific error,
+// but only whether an error occurred, this function also doesn't bother to
+// return an error.)
+func (a authCookieSha1) getCookie(context, id []byte) []byte {
+	file, err := os.Open(a.home + "/.dbus-keyrings/" + string(context))
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+	rd := bufio.NewReader(file)
+	for {
+		line, err := rd.ReadBytes('\n')
+		if err != nil {
+			return nil
+		}
+		line = line[:len(line)-1]
+		b := bytes.Split(line, []byte{' '})
+		if len(b) != 3 {
+			return nil
+		}
+		if bytes.Equal(b[0], id) {
+			return b[2]
+		}
+	}
+}
+
+// generateChallenge returns a random, hex-encoded challenge, or nil on error
+// (see above).
+func (a authCookieSha1) generateChallenge() []byte {
+	b := make([]byte, 16)
+	n, err := rand.Read(b)
+	if err != nil {
+		return nil
+	}
+	if n != 16 {
+		return nil
+	}
+	enc := make([]byte, 32)
+	hex.Encode(enc, b)
+	return enc
+}
+
+func getHomeDir() string {
+	if dir, err := os.UserHomeDir(); err == nil {
+		return dir
+	}
+	return "/"
+}

--- a/vendor/github.com/godbus/dbus/v5/call.go
+++ b/vendor/github.com/godbus/dbus/v5/call.go
@@ -1,0 +1,66 @@
+package dbus
+
+import (
+	"context"
+)
+
+// Call represents a pending or completed method call.
+type Call struct {
+	Destination string
+	Path        ObjectPath
+	Method      string
+	Args        []any
+
+	// Strobes when the call is complete.
+	Done chan *Call
+
+	// After completion, the error status. If this is non-nil, it may be an
+	// error message from the peer (with Error as its type) or some other error.
+	Err error
+
+	// Holds the response once the call is done.
+	Body []any
+
+	// ResponseSequence stores the sequence number of the DBus message containing
+	// the call response (or error). This can be compared to the sequence number
+	// of other call responses and signals on this connection to determine their
+	// relative ordering on the underlying DBus connection.
+	// For errors, ResponseSequence is populated only if the error came from a
+	// DBusMessage that was received or if there was an error receiving. In case of
+	// failure to make the call, ResponseSequence will be NoSequence.
+	ResponseSequence Sequence
+
+	// tracks context and canceler
+	ctx         context.Context
+	ctxCanceler context.CancelFunc
+}
+
+func (c *Call) Context() context.Context {
+	if c.ctx == nil {
+		return context.Background()
+	}
+
+	return c.ctx
+}
+
+func (c *Call) ContextCancel() {
+	if c.ctxCanceler != nil {
+		c.ctxCanceler()
+	}
+}
+
+// Store stores the body of the reply into the provided pointers. It returns
+// an error if the signatures of the body and retvalues don't match, or if
+// the error status is not nil.
+func (c *Call) Store(retvalues ...any) error {
+	if c.Err != nil {
+		return c.Err
+	}
+
+	return Store(c.Body, retvalues...)
+}
+
+func (c *Call) done() {
+	c.Done <- c
+	c.ContextCancel()
+}

--- a/vendor/github.com/godbus/dbus/v5/conn.go
+++ b/vendor/github.com/godbus/dbus/v5/conn.go
@@ -1,0 +1,1009 @@
+package dbus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	systemBus     *Conn
+	systemBusLck  sync.Mutex
+	sessionBus    *Conn
+	sessionBusLck sync.Mutex
+)
+
+// ErrClosed is the error returned by calls on a closed connection.
+var ErrClosed = errors.New("dbus: connection closed by user")
+
+// Conn represents a connection to a message bus (usually, the system or
+// session bus).
+//
+// Connections are either shared or private. Shared connections
+// are shared between calls to the functions that return them. As a result,
+// the methods Close, Auth and Hello must not be called on them.
+//
+// Multiple goroutines may invoke methods on a connection simultaneously.
+type Conn struct {
+	transport
+
+	ctx       context.Context
+	cancelCtx context.CancelFunc
+
+	closeOnce sync.Once
+	closeErr  error
+
+	busObj BusObject
+	unixFD bool
+	uuid   string
+
+	handler       Handler
+	signalHandler SignalHandler
+	serialGen     SerialGenerator
+	inInt         Interceptor
+	outInt        Interceptor
+	auth          []Auth
+
+	names      *nameTracker
+	calls      *callTracker
+	outHandler *outputHandler
+
+	eavesdropped    chan<- *Message
+	eavesdroppedLck sync.Mutex
+}
+
+// SessionBus returns a shared connection to the session bus, connecting to it
+// if not already done.
+func SessionBus() (conn *Conn, err error) {
+	sessionBusLck.Lock()
+	defer sessionBusLck.Unlock()
+	if sessionBus != nil &&
+		sessionBus.Connected() {
+		return sessionBus, nil
+	}
+	defer func() {
+		if conn != nil {
+			sessionBus = conn
+		}
+	}()
+	conn, err = ConnectSessionBus()
+	return
+}
+
+func getSessionBusAddress(autolaunch bool) (string, error) {
+	if address := os.Getenv("DBUS_SESSION_BUS_ADDRESS"); address != "" && address != "autolaunch:" {
+		return address, nil
+	} else if address := tryDiscoverDbusSessionBusAddress(); address != "" {
+		os.Setenv("DBUS_SESSION_BUS_ADDRESS", address)
+		return address, nil
+	}
+	if !autolaunch {
+		return "", errors.New("dbus: couldn't determine address of session bus")
+	}
+	return getSessionBusPlatformAddress()
+}
+
+// SessionBusPrivate returns a new private connection to the session bus.
+func SessionBusPrivate(opts ...ConnOption) (*Conn, error) {
+	address, err := getSessionBusAddress(true)
+	if err != nil {
+		return nil, err
+	}
+
+	return Dial(address, opts...)
+}
+
+// SessionBusPrivateNoAutoStartup returns a new private connection to the session bus.  If
+// the session bus is not already open, do not attempt to launch it.
+func SessionBusPrivateNoAutoStartup(opts ...ConnOption) (*Conn, error) {
+	address, err := getSessionBusAddress(false)
+	if err != nil {
+		return nil, err
+	}
+
+	return Dial(address, opts...)
+}
+
+// SessionBusPrivateHandler returns a new private connection to the session bus.
+//
+// Deprecated: use SessionBusPrivate with options instead.
+func SessionBusPrivateHandler(handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return SessionBusPrivate(WithHandler(handler), WithSignalHandler(signalHandler))
+}
+
+// SystemBus returns a shared connection to the system bus, connecting to it if
+// not already done.
+func SystemBus() (conn *Conn, err error) {
+	systemBusLck.Lock()
+	defer systemBusLck.Unlock()
+	if systemBus != nil &&
+		systemBus.Connected() {
+		return systemBus, nil
+	}
+	defer func() {
+		if conn != nil {
+			systemBus = conn
+		}
+	}()
+	conn, err = ConnectSystemBus()
+	return
+}
+
+// ConnectSessionBus connects to the session bus.
+func ConnectSessionBus(opts ...ConnOption) (*Conn, error) {
+	address, err := getSessionBusAddress(true)
+	if err != nil {
+		return nil, err
+	}
+	return Connect(address, opts...)
+}
+
+// ConnectSystemBus connects to the system bus.
+func ConnectSystemBus(opts ...ConnOption) (*Conn, error) {
+	return Connect(getSystemBusPlatformAddress(), opts...)
+}
+
+// Connect connects to the given address.
+//
+// Returned connection is ready to use and doesn't require calling
+// Auth and Hello methods to make it usable.
+func Connect(address string, opts ...ConnOption) (*Conn, error) {
+	conn, err := Dial(address, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err = conn.Auth(conn.auth); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err = conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// SystemBusPrivate returns a new private connection to the system bus.
+// Note: this connection is not ready to use. One must perform Auth and Hello
+// on the connection before it is usable.
+func SystemBusPrivate(opts ...ConnOption) (*Conn, error) {
+	return Dial(getSystemBusPlatformAddress(), opts...)
+}
+
+// SystemBusPrivateHandler returns a new private connection to the system bus, using the provided handlers.
+//
+// Deprecated: use SystemBusPrivate with options instead.
+func SystemBusPrivateHandler(handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return SystemBusPrivate(WithHandler(handler), WithSignalHandler(signalHandler))
+}
+
+// Dial establishes a new private connection to the message bus specified by address.
+func Dial(address string, opts ...ConnOption) (*Conn, error) {
+	tr, err := getTransport(address)
+	if err != nil {
+		return nil, err
+	}
+	return newConn(tr, opts...)
+}
+
+// DialHandler establishes a new private connection to the message bus specified by address, using the supplied handlers.
+//
+// Deprecated: use Dial with options instead.
+func DialHandler(address string, handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return Dial(address, WithHandler(handler), WithSignalHandler(signalHandler))
+}
+
+// ConnOption is a connection option.
+type ConnOption func(conn *Conn) error
+
+// WithHandler overrides the default handler.
+func WithHandler(handler Handler) ConnOption {
+	return func(conn *Conn) error {
+		conn.handler = handler
+		return nil
+	}
+}
+
+// WithSignalHandler overrides the default signal handler.
+func WithSignalHandler(handler SignalHandler) ConnOption {
+	return func(conn *Conn) error {
+		conn.signalHandler = handler
+		return nil
+	}
+}
+
+// WithSerialGenerator overrides the default signals generator.
+func WithSerialGenerator(gen SerialGenerator) ConnOption {
+	return func(conn *Conn) error {
+		conn.serialGen = gen
+		return nil
+	}
+}
+
+// WithAuth sets authentication methods for the auth conversation.
+func WithAuth(methods ...Auth) ConnOption {
+	return func(conn *Conn) error {
+		conn.auth = methods
+		return nil
+	}
+}
+
+// Interceptor intercepts incoming and outgoing messages.
+type Interceptor func(msg *Message)
+
+// WithIncomingInterceptor sets the given interceptor for incoming messages.
+func WithIncomingInterceptor(interceptor Interceptor) ConnOption {
+	return func(conn *Conn) error {
+		conn.inInt = interceptor
+		return nil
+	}
+}
+
+// WithOutgoingInterceptor sets the given interceptor for outgoing messages.
+func WithOutgoingInterceptor(interceptor Interceptor) ConnOption {
+	return func(conn *Conn) error {
+		conn.outInt = interceptor
+		return nil
+	}
+}
+
+// WithContext overrides  the default context for the connection.
+func WithContext(ctx context.Context) ConnOption {
+	return func(conn *Conn) error {
+		conn.ctx = ctx
+		return nil
+	}
+}
+
+// NewConn creates a new private *Conn from an already established connection.
+func NewConn(conn io.ReadWriteCloser, opts ...ConnOption) (*Conn, error) {
+	return newConn(genericTransport{conn}, opts...)
+}
+
+// NewConnHandler creates a new private *Conn from an already established connection, using the supplied handlers.
+//
+// Deprecated: use NewConn with options instead.
+func NewConnHandler(conn io.ReadWriteCloser, handler Handler, signalHandler SignalHandler) (*Conn, error) {
+	return NewConn(genericTransport{conn}, WithHandler(handler), WithSignalHandler(signalHandler))
+}
+
+// newConn creates a new *Conn from a transport.
+func newConn(tr transport, opts ...ConnOption) (*Conn, error) {
+	conn := new(Conn)
+	conn.transport = tr
+	for _, opt := range opts {
+		if err := opt(conn); err != nil {
+			return nil, err
+		}
+	}
+	if conn.ctx == nil {
+		conn.ctx = context.Background()
+	}
+	conn.ctx, conn.cancelCtx = context.WithCancel(conn.ctx)
+
+	conn.calls = newCallTracker()
+	if conn.handler == nil {
+		conn.handler = NewDefaultHandler()
+	}
+	if conn.signalHandler == nil {
+		conn.signalHandler = NewDefaultSignalHandler()
+	}
+	if conn.serialGen == nil {
+		conn.serialGen = newSerialGenerator()
+	}
+	conn.outHandler = &outputHandler{conn: conn}
+	conn.names = newNameTracker()
+	conn.busObj = conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+
+	go func() {
+		<-conn.ctx.Done()
+		conn.Close()
+	}()
+	return conn, nil
+}
+
+// BusObject returns the object owned by the bus daemon which handles
+// administrative requests.
+func (conn *Conn) BusObject() BusObject {
+	return conn.busObj
+}
+
+// Close closes the connection. Any blocked operations will return with errors
+// and the channels passed to Eavesdrop and Signal are closed. This method must
+// not be called on shared connections.
+func (conn *Conn) Close() error {
+	conn.closeOnce.Do(func() {
+		conn.outHandler.close()
+		if term, ok := conn.signalHandler.(Terminator); ok {
+			term.Terminate()
+		}
+
+		if term, ok := conn.handler.(Terminator); ok {
+			term.Terminate()
+		}
+
+		conn.eavesdroppedLck.Lock()
+		if conn.eavesdropped != nil {
+			close(conn.eavesdropped)
+		}
+		conn.eavesdroppedLck.Unlock()
+
+		conn.cancelCtx()
+
+		conn.closeErr = conn.transport.Close()
+	})
+	return conn.closeErr
+}
+
+// Context returns the context associated with the connection.  The
+// context will be cancelled when the connection is closed.
+func (conn *Conn) Context() context.Context {
+	return conn.ctx
+}
+
+// Connected returns whether conn is connected
+func (conn *Conn) Connected() bool {
+	return conn.ctx.Err() == nil
+}
+
+// Eavesdrop causes conn to send all incoming messages to the given channel
+// without further processing. Method replies, errors and signals will not be
+// sent to the appropriate channels and method calls will not be handled. If nil
+// is passed, the normal behaviour is restored.
+//
+// The caller has to make sure that ch is sufficiently buffered;
+// if a message arrives when a write to ch is not possible, the message is
+// discarded.
+func (conn *Conn) Eavesdrop(ch chan<- *Message) {
+	conn.eavesdroppedLck.Lock()
+	conn.eavesdropped = ch
+	conn.eavesdroppedLck.Unlock()
+}
+
+// getSerial returns an unused serial.
+func (conn *Conn) getSerial() uint32 {
+	return conn.serialGen.GetSerial()
+}
+
+// Hello sends the initial org.freedesktop.DBus.Hello call. This method must be
+// called after authentication, but before sending any other messages to the
+// bus. Hello must not be called for shared connections.
+func (conn *Conn) Hello() error {
+	var s string
+	err := conn.busObj.Call("org.freedesktop.DBus.Hello", 0).Store(&s)
+	if err != nil {
+		return err
+	}
+	conn.names.acquireUniqueConnectionName(s)
+	return nil
+}
+
+// inWorker runs in an own goroutine, reading incoming messages from the
+// transport and dispatching them appropriately.
+func (conn *Conn) inWorker() {
+	sequenceGen := newSequenceGenerator()
+	for {
+		msg, err := conn.ReadMessage()
+		if err != nil {
+			if _, ok := err.(InvalidMessageError); !ok {
+				// Some read error occurred (usually EOF); we can't really do
+				// anything but to shut down all stuff and returns errors to all
+				// pending replies.
+				conn.Close()
+				conn.calls.finalizeAllWithError(sequenceGen, err)
+				return
+			}
+			// invalid messages are ignored
+			continue
+		}
+		conn.eavesdroppedLck.Lock()
+		if conn.eavesdropped != nil {
+			select {
+			case conn.eavesdropped <- msg:
+			default:
+			}
+			conn.eavesdroppedLck.Unlock()
+			continue
+		}
+		conn.eavesdroppedLck.Unlock()
+		dest, _ := msg.Headers[FieldDestination].value.(string)
+		found := dest == "" ||
+			!conn.names.uniqueNameIsKnown() ||
+			conn.names.isKnownName(dest)
+		if !found {
+			// Eavesdropped a message, but no channel for it is registered.
+			// Ignore it.
+			continue
+		}
+
+		if conn.inInt != nil {
+			conn.inInt(msg)
+		}
+		sequence := sequenceGen.next()
+		switch msg.Type {
+		case TypeError:
+			conn.serialGen.RetireSerial(conn.calls.handleDBusError(sequence, msg))
+		case TypeMethodReply:
+			conn.serialGen.RetireSerial(conn.calls.handleReply(sequence, msg))
+		case TypeSignal:
+			conn.handleSignal(sequence, msg)
+		case TypeMethodCall:
+			go conn.handleCall(msg)
+		}
+
+	}
+}
+
+func (conn *Conn) handleSignal(sequence Sequence, msg *Message) {
+	iface := msg.Headers[FieldInterface].value.(string)
+	member := msg.Headers[FieldMember].value.(string)
+	// as per http://dbus.freedesktop.org/doc/dbus-specification.html ,
+	// sender is optional for signals.
+	sender, _ := msg.Headers[FieldSender].value.(string)
+	if iface == "org.freedesktop.DBus" && sender == "org.freedesktop.DBus" {
+		switch member {
+		case "NameLost":
+			// If we lost the name on the bus, remove it from our
+			// tracking list.
+			name, ok := msg.Body[0].(string)
+			if !ok {
+				panic("Unable to read the lost name")
+			}
+			conn.names.loseName(name)
+		case "NameAcquired":
+			// If we acquired the name on the bus, add it to our
+			// tracking list.
+			name, ok := msg.Body[0].(string)
+			if !ok {
+				panic("Unable to read the acquired name")
+			}
+			conn.names.acquireName(name)
+		}
+	}
+	signal := &Signal{
+		Sender:   sender,
+		Path:     msg.Headers[FieldPath].value.(ObjectPath),
+		Name:     iface + "." + member,
+		Body:     msg.Body,
+		Sequence: sequence,
+	}
+	conn.signalHandler.DeliverSignal(iface, member, signal)
+}
+
+// Names returns the list of all names that are currently owned by this
+// connection. The slice is always at least one element long, the first element
+// being the unique name of the connection.
+func (conn *Conn) Names() []string {
+	return conn.names.listKnownNames()
+}
+
+// Object returns the object identified by the given destination name and path.
+func (conn *Conn) Object(dest string, path ObjectPath) BusObject {
+	return &Object{conn, dest, path}
+}
+
+func (conn *Conn) sendMessageAndIfClosed(msg *Message, ifClosed func()) error {
+	if msg.serial == 0 {
+		msg.serial = conn.getSerial()
+	}
+	if conn.outInt != nil {
+		conn.outInt(msg)
+	}
+	err := conn.outHandler.sendAndIfClosed(msg, ifClosed)
+	if err != nil {
+		conn.handleSendError(msg, err)
+	} else if msg.Type != TypeMethodCall {
+		conn.serialGen.RetireSerial(msg.serial)
+	}
+	return err
+}
+
+func isEncodingError(err error) bool {
+	switch err.(type) {
+	case FormatError:
+		return true
+	case InvalidMessageError:
+		return true
+	}
+	return false
+}
+
+func (conn *Conn) handleSendError(msg *Message, err error) {
+	switch msg.Type {
+	case TypeMethodCall:
+		conn.calls.handleSendError(msg, err)
+	case TypeMethodReply:
+		if isEncodingError(err) {
+			// Make sure that the caller gets some kind of error response if
+			// the application code tried to respond, but the resulting message
+			// was malformed in the end
+			returnedErr := fmt.Errorf("destination tried to respond with invalid message (%w)", err)
+			conn.sendError(returnedErr, msg.Headers[FieldDestination].value.(string), msg.Headers[FieldReplySerial].value.(uint32))
+		}
+	}
+	conn.serialGen.RetireSerial(msg.serial)
+}
+
+// Send sends the given message to the message bus. You usually don't need to
+// use this; use the higher-level equivalents (Call / Go, Emit and Export)
+// instead. If msg is a method call and NoReplyExpected is not set, a non-nil
+// call is returned and the same value is sent to ch (which must be buffered)
+// once the call is complete. Otherwise, ch is ignored and a Call structure is
+// returned of which only the Err member is valid.
+func (conn *Conn) Send(msg *Message, ch chan *Call) *Call {
+	return conn.send(context.Background(), msg, ch)
+}
+
+// SendWithContext acts like Send but takes a context
+func (conn *Conn) SendWithContext(ctx context.Context, msg *Message, ch chan *Call) *Call {
+	return conn.send(ctx, msg, ch)
+}
+
+func (conn *Conn) send(ctx context.Context, msg *Message, ch chan *Call) *Call {
+	if ctx == nil {
+		panic("nil context")
+	}
+	if ch == nil {
+		ch = make(chan *Call, 1)
+	} else if cap(ch) == 0 {
+		panic("dbus: unbuffered channel passed to (*Conn).Send")
+	}
+
+	var call *Call
+	ctx, canceler := context.WithCancel(ctx)
+	msg.serial = conn.getSerial()
+	if msg.Type == TypeMethodCall && msg.Flags&FlagNoReplyExpected == 0 {
+		call = new(Call)
+		call.Destination, _ = msg.Headers[FieldDestination].value.(string)
+		call.Path, _ = msg.Headers[FieldPath].value.(ObjectPath)
+		iface, _ := msg.Headers[FieldInterface].value.(string)
+		member, _ := msg.Headers[FieldMember].value.(string)
+		call.Method = iface + "." + member
+		call.Args = msg.Body
+		call.Done = ch
+		call.ctx = ctx
+		call.ctxCanceler = canceler
+		conn.calls.track(msg.serial, call)
+		if ctx.Err() != nil {
+			// short path: don't even send the message if context already cancelled
+			conn.calls.handleSendError(msg, ctx.Err())
+			return call
+		}
+		go func() {
+			<-ctx.Done()
+			conn.calls.handleSendError(msg, ctx.Err())
+		}()
+		// error is handled in handleSendError
+		_ = conn.sendMessageAndIfClosed(msg, func() {
+			conn.calls.handleSendError(msg, ErrClosed)
+			canceler()
+		})
+	} else {
+		canceler()
+		call = &Call{Err: nil, Done: ch}
+		ch <- call
+		// error is handled in handleSendError
+		_ = conn.sendMessageAndIfClosed(msg, func() {
+			call = &Call{Err: ErrClosed}
+		})
+	}
+	return call
+}
+
+// sendError creates an error message corresponding to the parameters and sends
+// it to conn.out.
+func (conn *Conn) sendError(err error, dest string, serial uint32) {
+	var e *Error
+	switch em := err.(type) {
+	case Error:
+		e = &em
+	case *Error:
+		e = em
+	case DBusError:
+		name, body := em.DBusError()
+		e = NewError(name, body)
+	default:
+		e = MakeFailedError(err)
+	}
+	msg := new(Message)
+	msg.Type = TypeError
+	msg.Headers = make(map[HeaderField]Variant)
+	if dest != "" {
+		msg.Headers[FieldDestination] = MakeVariant(dest)
+	}
+	msg.Headers[FieldErrorName] = MakeVariant(e.Name)
+	msg.Headers[FieldReplySerial] = MakeVariant(serial)
+	msg.Body = e.Body
+	if len(e.Body) > 0 {
+		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(e.Body...))
+	}
+	// not much we can do to handle a possible error here
+	_ = conn.sendMessageAndIfClosed(msg, nil)
+}
+
+// sendReply creates a method reply message corresponding to the parameters and
+// sends it to conn.out.
+func (conn *Conn) sendReply(dest string, serial uint32, values ...any) {
+	msg := new(Message)
+	msg.Type = TypeMethodReply
+	msg.Headers = make(map[HeaderField]Variant)
+	if dest != "" {
+		msg.Headers[FieldDestination] = MakeVariant(dest)
+	}
+	msg.Headers[FieldReplySerial] = MakeVariant(serial)
+	msg.Body = values
+	if len(values) > 0 {
+		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(values...))
+	}
+	// not much we can do to handle a possible error here
+	_ = conn.sendMessageAndIfClosed(msg, nil)
+}
+
+// AddMatchSignal registers the given match rule to receive broadcast
+// signals based on their contents.
+func (conn *Conn) AddMatchSignal(options ...MatchOption) error {
+	return conn.AddMatchSignalContext(context.Background(), options...)
+}
+
+// AddMatchSignalContext acts like AddMatchSignal but takes a context.
+func (conn *Conn) AddMatchSignalContext(ctx context.Context, options ...MatchOption) error {
+	options = append([]MatchOption{withMatchTypeSignal()}, options...)
+	return conn.busObj.CallWithContext(
+		ctx,
+		"org.freedesktop.DBus.AddMatch", 0,
+		formatMatchOptions(options),
+	).Store()
+}
+
+// RemoveMatchSignal removes the first rule that matches previously registered with AddMatchSignal.
+func (conn *Conn) RemoveMatchSignal(options ...MatchOption) error {
+	return conn.RemoveMatchSignalContext(context.Background(), options...)
+}
+
+// RemoveMatchSignalContext acts like RemoveMatchSignal but takes a context.
+func (conn *Conn) RemoveMatchSignalContext(ctx context.Context, options ...MatchOption) error {
+	options = append([]MatchOption{withMatchTypeSignal()}, options...)
+	return conn.busObj.CallWithContext(
+		ctx,
+		"org.freedesktop.DBus.RemoveMatch", 0,
+		formatMatchOptions(options),
+	).Store()
+}
+
+// Signal registers the given channel to be passed all received signal messages.
+//
+// Multiple of these channels can be registered at the same time. The channel is
+// closed if the Conn is closed; it should not be closed by the caller before
+// RemoveSignal was called on it.
+//
+// These channels are "overwritten" by Eavesdrop; i.e., if there currently is a
+// channel for eavesdropped messages, this channel receives all signals, and
+// none of the channels passed to Signal will receive any signals.
+//
+// Panics if the signal handler is not a `SignalRegistrar`.
+func (conn *Conn) Signal(ch chan<- *Signal) {
+	handler, ok := conn.signalHandler.(SignalRegistrar)
+	if !ok {
+		panic("cannot use this method with a non SignalRegistrar handler")
+	}
+	handler.AddSignal(ch)
+}
+
+// RemoveSignal removes the given channel from the list of the registered channels.
+//
+// Panics if the signal handler is not a `SignalRegistrar`.
+func (conn *Conn) RemoveSignal(ch chan<- *Signal) {
+	handler, ok := conn.signalHandler.(SignalRegistrar)
+	if !ok {
+		panic("cannot use this method with a non SignalRegistrar handler")
+	}
+	handler.RemoveSignal(ch)
+}
+
+// SupportsUnixFDs returns whether the underlying transport supports passing of
+// unix file descriptors. If this is false, method calls containing unix file
+// descriptors will return an error and emitted signals containing them will
+// not be sent.
+func (conn *Conn) SupportsUnixFDs() bool {
+	return conn.unixFD
+}
+
+// Error represents a D-Bus message of type Error.
+type Error struct {
+	Name string
+	Body []any
+}
+
+func NewError(name string, body []any) *Error {
+	return &Error{name, body}
+}
+
+func (e Error) Error() string {
+	if len(e.Body) >= 1 {
+		s, ok := e.Body[0].(string)
+		if ok {
+			return s
+		}
+	}
+	return e.Name
+}
+
+// Signal represents a D-Bus message of type Signal. The name member is given in
+// "interface.member" notation, e.g. org.freedesktop.D-Bus.NameLost.
+type Signal struct {
+	Sender   string
+	Path     ObjectPath
+	Name     string
+	Body     []any
+	Sequence Sequence
+}
+
+// transport is a D-Bus transport.
+type transport interface {
+	// Read and Write raw data (for example, for the authentication protocol).
+	io.ReadWriteCloser
+
+	// Send the initial null byte used for the EXTERNAL mechanism.
+	SendNullByte() error
+
+	// Returns whether this transport supports passing Unix FDs.
+	SupportsUnixFDs() bool
+
+	// Signal the transport that Unix FD passing is enabled for this connection.
+	EnableUnixFDs()
+
+	// Read / send a message, handling things like Unix FDs.
+	ReadMessage() (*Message, error)
+	SendMessage(*Message) error
+}
+
+var transports = make(map[string]func(string) (transport, error))
+
+func getTransport(address string) (transport, error) {
+	var err error
+	var t transport
+
+	addresses := strings.Split(address, ";")
+	for _, v := range addresses {
+		i := strings.IndexRune(v, ':')
+		if i == -1 {
+			err = errors.New("dbus: invalid bus address (no transport)")
+			continue
+		}
+		f := transports[v[:i]]
+		if f == nil {
+			err = errors.New("dbus: invalid bus address (invalid or unsupported transport)")
+			continue
+		}
+		t, err = f(v[i+1:])
+		if err == nil {
+			return t, nil
+		}
+	}
+	return nil, err
+}
+
+// getKey gets a key from a the list of keys. Returns "" on error / not found...
+func getKey(s, key string) string {
+	keyEq := key + "="
+	for _, kv := range strings.Split(s, ",") {
+		if v, ok := strings.CutPrefix(kv, keyEq); ok {
+			val, err := UnescapeBusAddressValue(v)
+			if err != nil {
+				// No way to return an error.
+				return ""
+			}
+			return val
+		}
+	}
+	return ""
+}
+
+type outputHandler struct {
+	conn    *Conn
+	sendLck sync.Mutex
+	closed  struct {
+		isClosed bool
+		lck      sync.RWMutex
+	}
+}
+
+func (h *outputHandler) sendAndIfClosed(msg *Message, ifClosed func()) error {
+	h.closed.lck.RLock()
+	defer h.closed.lck.RUnlock()
+	if h.closed.isClosed {
+		if ifClosed != nil {
+			ifClosed()
+		}
+		return nil
+	}
+	h.sendLck.Lock()
+	defer h.sendLck.Unlock()
+	return h.conn.SendMessage(msg)
+}
+
+func (h *outputHandler) close() {
+	h.closed.lck.Lock()
+	defer h.closed.lck.Unlock()
+	h.closed.isClosed = true
+}
+
+type serialGenerator struct {
+	lck        sync.Mutex
+	nextSerial uint32
+	serialUsed map[uint32]bool
+}
+
+func newSerialGenerator() *serialGenerator {
+	return &serialGenerator{
+		serialUsed: map[uint32]bool{0: true},
+		nextSerial: 1,
+	}
+}
+
+func (gen *serialGenerator) GetSerial() uint32 {
+	gen.lck.Lock()
+	defer gen.lck.Unlock()
+	n := gen.nextSerial
+	for gen.serialUsed[n] {
+		n++
+	}
+	gen.serialUsed[n] = true
+	gen.nextSerial = n + 1
+	return n
+}
+
+func (gen *serialGenerator) RetireSerial(serial uint32) {
+	gen.lck.Lock()
+	defer gen.lck.Unlock()
+	delete(gen.serialUsed, serial)
+}
+
+type nameTracker struct {
+	lck    sync.RWMutex
+	unique string
+	names  map[string]struct{}
+}
+
+func newNameTracker() *nameTracker {
+	return &nameTracker{names: map[string]struct{}{}}
+}
+
+func (tracker *nameTracker) acquireUniqueConnectionName(name string) {
+	tracker.lck.Lock()
+	defer tracker.lck.Unlock()
+	tracker.unique = name
+}
+
+func (tracker *nameTracker) acquireName(name string) {
+	tracker.lck.Lock()
+	defer tracker.lck.Unlock()
+	tracker.names[name] = struct{}{}
+}
+
+func (tracker *nameTracker) loseName(name string) {
+	tracker.lck.Lock()
+	defer tracker.lck.Unlock()
+	delete(tracker.names, name)
+}
+
+func (tracker *nameTracker) uniqueNameIsKnown() bool {
+	tracker.lck.RLock()
+	defer tracker.lck.RUnlock()
+	return tracker.unique != ""
+}
+
+func (tracker *nameTracker) isKnownName(name string) bool {
+	tracker.lck.RLock()
+	defer tracker.lck.RUnlock()
+	_, ok := tracker.names[name]
+	return ok || name == tracker.unique
+}
+
+func (tracker *nameTracker) listKnownNames() []string {
+	tracker.lck.RLock()
+	defer tracker.lck.RUnlock()
+	out := make([]string, 0, len(tracker.names)+1)
+	out = append(out, tracker.unique)
+	for k := range tracker.names {
+		out = append(out, k)
+	}
+	return out
+}
+
+type callTracker struct {
+	calls map[uint32]*Call
+	lck   sync.RWMutex
+}
+
+func newCallTracker() *callTracker {
+	return &callTracker{calls: map[uint32]*Call{}}
+}
+
+func (tracker *callTracker) track(sn uint32, call *Call) {
+	tracker.lck.Lock()
+	tracker.calls[sn] = call
+	tracker.lck.Unlock()
+}
+
+func (tracker *callTracker) handleReply(sequence Sequence, msg *Message) uint32 {
+	serial := msg.Headers[FieldReplySerial].value.(uint32)
+	tracker.lck.RLock()
+	_, ok := tracker.calls[serial]
+	tracker.lck.RUnlock()
+	if ok {
+		tracker.finalizeWithBody(serial, sequence, msg.Body)
+	}
+	return serial
+}
+
+func (tracker *callTracker) handleDBusError(sequence Sequence, msg *Message) uint32 {
+	serial := msg.Headers[FieldReplySerial].value.(uint32)
+	tracker.lck.RLock()
+	_, ok := tracker.calls[serial]
+	tracker.lck.RUnlock()
+	if ok {
+		name, _ := msg.Headers[FieldErrorName].value.(string)
+		tracker.finalizeWithError(serial, sequence, Error{name, msg.Body})
+	}
+	return serial
+}
+
+func (tracker *callTracker) handleSendError(msg *Message, err error) {
+	if err == nil {
+		return
+	}
+	tracker.lck.RLock()
+	_, ok := tracker.calls[msg.serial]
+	tracker.lck.RUnlock()
+	if ok {
+		tracker.finalizeWithError(msg.serial, NoSequence, err)
+	}
+}
+
+func (tracker *callTracker) finalizeWithBody(sn uint32, sequence Sequence, body []any) {
+	tracker.lck.Lock()
+	c, ok := tracker.calls[sn]
+	if ok {
+		delete(tracker.calls, sn)
+	}
+	tracker.lck.Unlock()
+	if ok {
+		c.Body = body
+		c.ResponseSequence = sequence
+		c.done()
+	}
+}
+
+func (tracker *callTracker) finalizeWithError(sn uint32, sequence Sequence, err error) {
+	tracker.lck.Lock()
+	c, ok := tracker.calls[sn]
+	if ok {
+		delete(tracker.calls, sn)
+	}
+	tracker.lck.Unlock()
+	if ok {
+		c.Err = err
+		c.ResponseSequence = sequence
+		c.done()
+	}
+}
+
+func (tracker *callTracker) finalizeAllWithError(sequenceGen *sequenceGenerator, err error) {
+	tracker.lck.Lock()
+	closedCalls := make([]*Call, 0, len(tracker.calls))
+	for sn := range tracker.calls {
+		closedCalls = append(closedCalls, tracker.calls[sn])
+	}
+	tracker.calls = map[uint32]*Call{}
+	tracker.lck.Unlock()
+	for _, call := range closedCalls {
+		call.Err = err
+		call.ResponseSequence = sequenceGen.next()
+		call.done()
+	}
+}

--- a/vendor/github.com/godbus/dbus/v5/conn_darwin.go
+++ b/vendor/github.com/godbus/dbus/v5/conn_darwin.go
@@ -1,0 +1,36 @@
+package dbus
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+const defaultSystemBusAddress = "unix:path=/opt/local/var/run/dbus/system_bus_socket"
+
+func getSessionBusPlatformAddress() (string, error) {
+	cmd := exec.Command("launchctl", "getenv", "DBUS_LAUNCHD_SESSION_BUS_SOCKET")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	if len(b) == 0 {
+		return "", errors.New("dbus: couldn't determine address of session bus")
+	}
+
+	return "unix:path=" + string(b[:len(b)-1]), nil
+}
+
+func getSystemBusPlatformAddress() string {
+	address := os.Getenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET")
+	if address != "" {
+		return fmt.Sprintf("unix:path=%s", address)
+	}
+	return defaultSystemBusAddress
+}
+
+func tryDiscoverDbusSessionBusAddress() string {
+	return ""
+}

--- a/vendor/github.com/godbus/dbus/v5/conn_other.go
+++ b/vendor/github.com/godbus/dbus/v5/conn_other.go
@@ -1,0 +1,83 @@
+//go:build !darwin
+
+package dbus
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"strings"
+)
+
+var execCommand = exec.Command
+
+func getSessionBusPlatformAddress() (string, error) {
+	cmd := execCommand("dbus-launch")
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	i := bytes.IndexByte(b, '=')
+	j := bytes.IndexByte(b, '\n')
+
+	if i == -1 || j == -1 || i > j {
+		return "", errors.New("dbus: couldn't determine address of session bus")
+	}
+
+	env, addr := string(b[0:i]), string(b[i+1:j])
+	os.Setenv(env, addr)
+
+	return addr, nil
+}
+
+// tryDiscoverDbusSessionBusAddress tries to discover an existing dbus session
+// and return the value of its DBUS_SESSION_BUS_ADDRESS.
+// It tries different techniques employed by different operating systems,
+// returning the first valid address it finds, or an empty string.
+//
+//   - /run/user/<uid>/bus           if this exists, it *is* the bus socket. present on
+//     Ubuntu 18.04
+//   - /run/user/<uid>/dbus-session: if this exists, it can be parsed for the bus
+//     address. present on Ubuntu 16.04
+//
+// See https://dbus.freedesktop.org/doc/dbus-launch.1.html
+func tryDiscoverDbusSessionBusAddress() string {
+	if runtimeDirectory, err := getRuntimeDirectory(); err == nil {
+
+		if runUserBusFile := path.Join(runtimeDirectory, "bus"); fileExists(runUserBusFile) {
+			// if /run/user/<uid>/bus exists, that file itself
+			// *is* the unix socket, so return its path
+			return fmt.Sprintf("unix:path=%s", EscapeBusAddressValue(runUserBusFile))
+		}
+		if runUserSessionDbusFile := path.Join(runtimeDirectory, "dbus-session"); fileExists(runUserSessionDbusFile) {
+			// if /run/user/<uid>/dbus-session exists, it's a
+			// text file // containing the address of the socket, e.g.:
+			// DBUS_SESSION_BUS_ADDRESS=unix:abstract=/tmp/dbus-E1c73yNqrG
+
+			if f, err := os.ReadFile(runUserSessionDbusFile); err == nil {
+				if addr, ok := strings.CutPrefix(string(f), "DBUS_SESSION_BUS_ADDRESS="); ok {
+					return strings.TrimRight(addr, "\n\r")
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func getRuntimeDirectory() (string, error) {
+	if currentUser, err := user.Current(); err != nil {
+		return "", err
+	} else {
+		return fmt.Sprintf("/run/user/%s", currentUser.Uid), nil
+	}
+}
+
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return !os.IsNotExist(err)
+}

--- a/vendor/github.com/godbus/dbus/v5/conn_unix.go
+++ b/vendor/github.com/godbus/dbus/v5/conn_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows && !solaris && !darwin
+
+package dbus
+
+import (
+	"net"
+	"os"
+)
+
+const defaultSystemBusAddress = "unix:path=/var/run/dbus/system_bus_socket"
+
+func getSystemBusPlatformAddress() string {
+	address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
+	if address != "" {
+		return address
+	}
+	return defaultSystemBusAddress
+}
+
+// DialUnix establishes a new private connection to the message bus specified by UnixConn.
+func DialUnix(conn *net.UnixConn, opts ...ConnOption) (*Conn, error) {
+	tr := newUnixTransportFromConn(conn)
+	return newConn(tr, opts...)
+}
+
+func ConnectUnix(uconn *net.UnixConn, opts ...ConnOption) (*Conn, error) {
+	conn, err := DialUnix(uconn, opts...)
+	if err != nil {
+		return nil, err
+	}
+	if err = conn.Auth(conn.auth); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	if err = conn.Hello(); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}

--- a/vendor/github.com/godbus/dbus/v5/conn_windows.go
+++ b/vendor/github.com/godbus/dbus/v5/conn_windows.go
@@ -1,0 +1,13 @@
+package dbus
+
+import "os"
+
+const defaultSystemBusAddress = "tcp:host=127.0.0.1,port=12434"
+
+func getSystemBusPlatformAddress() string {
+	address := os.Getenv("DBUS_SYSTEM_BUS_ADDRESS")
+	if address != "" {
+		return address
+	}
+	return defaultSystemBusAddress
+}

--- a/vendor/github.com/godbus/dbus/v5/dbus.go
+++ b/vendor/github.com/godbus/dbus/v5/dbus.go
@@ -1,0 +1,427 @@
+package dbus
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var (
+	byteType        = reflect.TypeOf(byte(0))
+	boolType        = reflect.TypeOf(false)
+	int16Type       = reflect.TypeOf(int16(0))
+	uint16Type      = reflect.TypeOf(uint16(0))
+	int32Type       = reflect.TypeOf(int32(0))
+	uint32Type      = reflect.TypeOf(uint32(0))
+	int64Type       = reflect.TypeOf(int64(0))
+	uint64Type      = reflect.TypeOf(uint64(0))
+	float64Type     = reflect.TypeOf(float64(0))
+	stringType      = reflect.TypeOf("")
+	signatureType   = reflect.TypeOf(Signature{""})
+	objectPathType  = reflect.TypeOf(ObjectPath(""))
+	variantType     = reflect.TypeOf(Variant{Signature{""}, nil})
+	interfacesType  = reflect.TypeOf([]any{})
+	interfaceType   = reflect.TypeOf((*any)(nil)).Elem()
+	unixFDType      = reflect.TypeOf(UnixFD(0))
+	unixFDIndexType = reflect.TypeOf(UnixFDIndex(0))
+	errType         = reflect.TypeOf((*error)(nil)).Elem()
+)
+
+// An InvalidTypeError signals that a value which cannot be represented in the
+// D-Bus wire format was passed to a function.
+type InvalidTypeError struct {
+	Type reflect.Type
+}
+
+func (e InvalidTypeError) Error() string {
+	return "dbus: invalid type " + e.Type.String()
+}
+
+// Store copies the values contained in src to dest, which must be a slice of
+// pointers. It converts slices of interfaces from src to corresponding structs
+// in dest. An error is returned if the lengths of src and dest or the types of
+// their elements don't match.
+func Store(src []any, dest ...any) error {
+	if len(src) != len(dest) {
+		return errors.New("dbus.Store: length mismatch")
+	}
+
+	for i := range src {
+		if err := storeInterfaces(src[i], dest[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func storeInterfaces(src, dest any) error {
+	return store(reflect.ValueOf(dest), reflect.ValueOf(src))
+}
+
+func store(dest, src reflect.Value) error {
+	if dest.Kind() == reflect.Ptr {
+		if dest.IsNil() {
+			dest.Set(reflect.New(dest.Type().Elem()))
+		}
+		return store(dest.Elem(), src)
+	}
+	switch src.Kind() {
+	case reflect.Slice:
+		return storeSlice(dest, src)
+	case reflect.Map:
+		return storeMap(dest, src)
+	default:
+		return storeBase(dest, src)
+	}
+}
+
+func storeBase(dest, src reflect.Value) error {
+	return setDest(dest, src)
+}
+
+func setDest(dest, src reflect.Value) error {
+	if !isVariant(src.Type()) && isVariant(dest.Type()) {
+		// special conversion for dbus.Variant
+		dest.Set(reflect.ValueOf(MakeVariant(src.Interface())))
+		return nil
+	}
+	if isVariant(src.Type()) && !isVariant(dest.Type()) {
+		src = getVariantValue(src)
+		return store(dest, src)
+	}
+	if !src.Type().ConvertibleTo(dest.Type()) {
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: cannot convert %s to %s",
+			src.Type(), dest.Type())
+	}
+	dest.Set(src.Convert(dest.Type()))
+	return nil
+}
+
+func kindsAreCompatible(dest, src reflect.Type) bool {
+	switch {
+	case isVariant(dest):
+		return true
+	case dest.Kind() == reflect.Interface:
+		return true
+	default:
+		return dest.Kind() == src.Kind()
+	}
+}
+
+func isConvertibleTo(dest, src reflect.Type) bool {
+	switch {
+	case isVariant(dest):
+		return true
+	case dest.Kind() == reflect.Interface:
+		return true
+	case dest.Kind() == reflect.Slice:
+		return src.Kind() == reflect.Slice &&
+			isConvertibleTo(dest.Elem(), src.Elem())
+	case dest.Kind() == reflect.Ptr:
+		dest = dest.Elem()
+		return isConvertibleTo(dest, src)
+	case dest.Kind() == reflect.Struct:
+		return src == interfacesType || dest.Kind() == src.Kind()
+	default:
+		return src.ConvertibleTo(dest)
+	}
+}
+
+func storeMap(dest, src reflect.Value) error {
+	switch {
+	case !kindsAreCompatible(dest.Type(), src.Type()):
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"map: cannot store a value of %s into %s",
+			src.Type(), dest.Type())
+	case isVariant(dest.Type()):
+		return storeMapIntoVariant(dest, src)
+	case dest.Kind() == reflect.Interface:
+		return storeMapIntoInterface(dest, src)
+	case isConvertibleTo(dest.Type().Key(), src.Type().Key()) &&
+		isConvertibleTo(dest.Type().Elem(), src.Type().Elem()):
+		return storeMapIntoMap(dest, src)
+	default:
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"map: cannot convert a value of %s into %s",
+			src.Type(), dest.Type())
+	}
+}
+
+func storeMapIntoVariant(dest, src reflect.Value) error {
+	dv := reflect.MakeMap(src.Type())
+	err := store(dv, src)
+	if err != nil {
+		return err
+	}
+	return storeBase(dest, dv)
+}
+
+func storeMapIntoInterface(dest, src reflect.Value) error {
+	var dv reflect.Value
+	if isVariant(src.Type().Elem()) {
+		// Convert variants to interface{} recursively when converting
+		// to interface{}
+		dv = reflect.MakeMap(
+			reflect.MapOf(src.Type().Key(), interfaceType))
+	} else {
+		dv = reflect.MakeMap(src.Type())
+	}
+	err := store(dv, src)
+	if err != nil {
+		return err
+	}
+	return storeBase(dest, dv)
+}
+
+func storeMapIntoMap(dest, src reflect.Value) error {
+	if dest.IsNil() {
+		dest.Set(reflect.MakeMap(dest.Type()))
+	}
+	keys := src.MapKeys()
+	for _, key := range keys {
+		dkey := key.Convert(dest.Type().Key())
+		dval := reflect.New(dest.Type().Elem()).Elem()
+		err := store(dval, getVariantValue(src.MapIndex(key)))
+		if err != nil {
+			return err
+		}
+		dest.SetMapIndex(dkey, dval)
+	}
+	return nil
+}
+
+func storeSlice(dest, src reflect.Value) error {
+	switch {
+	case src.Type() == interfacesType && dest.Kind() == reflect.Struct:
+		// The decoder always decodes structs as slices of interface{}
+		return storeStruct(dest, src)
+	case !kindsAreCompatible(dest.Type(), src.Type()):
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"slice: cannot store a value of %s into %s",
+			src.Type(), dest.Type())
+	case isVariant(dest.Type()):
+		return storeSliceIntoVariant(dest, src)
+	case dest.Kind() == reflect.Interface:
+		return storeSliceIntoInterface(dest, src)
+	case isConvertibleTo(dest.Type().Elem(), src.Type().Elem()):
+		return storeSliceIntoSlice(dest, src)
+	default:
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"slice: cannot convert a value of %s into %s",
+			src.Type(), dest.Type())
+	}
+}
+
+func storeStruct(dest, src reflect.Value) error {
+	if isVariant(dest.Type()) {
+		return storeBase(dest, src)
+	}
+	dval := make([]any, 0, dest.NumField())
+	dtype := dest.Type()
+	for i := 0; i < dest.NumField(); i++ {
+		field := dest.Field(i)
+		ftype := dtype.Field(i)
+		if ftype.PkgPath != "" {
+			continue
+		}
+		if ftype.Tag.Get("dbus") == "-" {
+			continue
+		}
+		dval = append(dval, field.Addr().Interface())
+	}
+	if src.Len() != len(dval) {
+		return fmt.Errorf(
+			"dbus.Store: type mismatch: "+
+				"destination struct does not have "+
+				"enough fields need: %d have: %d",
+			src.Len(), len(dval))
+	}
+	return Store(src.Interface().([]any), dval...)
+}
+
+func storeSliceIntoVariant(dest, src reflect.Value) error {
+	dv := reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+	err := store(dv, src)
+	if err != nil {
+		return err
+	}
+	return storeBase(dest, dv)
+}
+
+func storeSliceIntoInterface(dest, src reflect.Value) error {
+	var dv reflect.Value
+	if isVariant(src.Type().Elem()) {
+		// Convert variants to interface{} recursively when converting
+		// to interface{}
+		dv = reflect.MakeSlice(reflect.SliceOf(interfaceType),
+			src.Len(), src.Cap())
+	} else {
+		dv = reflect.MakeSlice(src.Type(), src.Len(), src.Cap())
+	}
+	err := store(dv, src)
+	if err != nil {
+		return err
+	}
+	return storeBase(dest, dv)
+}
+
+func storeSliceIntoSlice(dest, src reflect.Value) error {
+	if dest.IsNil() || dest.Len() < src.Len() {
+		dest.Set(reflect.MakeSlice(dest.Type(), src.Len(), src.Cap()))
+	} else if dest.Len() > src.Len() {
+		dest.Set(dest.Slice(0, src.Len()))
+	}
+	for i := 0; i < src.Len(); i++ {
+		err := store(dest.Index(i), getVariantValue(src.Index(i)))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getVariantValue(in reflect.Value) reflect.Value {
+	if isVariant(in.Type()) {
+		return reflect.ValueOf(in.Interface().(Variant).Value())
+	}
+	return in
+}
+
+func isVariant(t reflect.Type) bool {
+	return t == variantType
+}
+
+// An ObjectPath is an object path as defined by the D-Bus spec.
+type ObjectPath string
+
+// IsValid returns whether the object path is valid.
+func (o ObjectPath) IsValid() bool {
+	s := string(o)
+	if len(s) == 0 {
+		return false
+	}
+	if s[0] != '/' {
+		return false
+	}
+	if s[len(s)-1] == '/' && len(s) != 1 {
+		return false
+	}
+	// probably not used, but technically possible
+	if s == "/" {
+		return true
+	}
+	split := strings.Split(s[1:], "/")
+	for _, v := range split {
+		if len(v) == 0 {
+			return false
+		}
+		for _, c := range v {
+			if !isMemberChar(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// A UnixFD is a Unix file descriptor sent over the wire. See the package-level
+// documentation for more information about Unix file descriptor passing.
+type UnixFD int32
+
+// A UnixFDIndex is the representation of a Unix file descriptor in a message.
+type UnixFDIndex uint32
+
+// alignment returns the alignment of values of type t.
+func alignment(t reflect.Type) int {
+	switch t {
+	case variantType:
+		return 1
+	case objectPathType:
+		return 4
+	case signatureType:
+		return 1
+	case interfacesType:
+		return 4
+	}
+	switch t.Kind() {
+	case reflect.Uint8:
+		return 1
+	case reflect.Uint16, reflect.Int16:
+		return 2
+	case reflect.Uint, reflect.Int, reflect.Uint32, reflect.Int32, reflect.String, reflect.Array, reflect.Slice, reflect.Map:
+		return 4
+	case reflect.Uint64, reflect.Int64, reflect.Float64, reflect.Struct:
+		return 8
+	case reflect.Ptr:
+		return alignment(t.Elem())
+	}
+	return 1
+}
+
+// isKeyType returns whether t is a valid type for a D-Bus dict.
+func isKeyType(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Int16, reflect.Int32, reflect.Int64, reflect.Float64,
+		reflect.String, reflect.Uint, reflect.Int:
+
+		return true
+	}
+	return false
+}
+
+// isValidInterface returns whether s is a valid name for an interface.
+func isValidInterface(s string) bool {
+	if len(s) == 0 || len(s) > 255 || s[0] == '.' {
+		return false
+	}
+	elem := strings.Split(s, ".")
+	if len(elem) < 2 {
+		return false
+	}
+	for _, v := range elem {
+		if len(v) == 0 {
+			return false
+		}
+		if v[0] >= '0' && v[0] <= '9' {
+			return false
+		}
+		for _, c := range v {
+			if !isMemberChar(c) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// isValidMember returns whether s is a valid name for a member.
+func isValidMember(s string) bool {
+	if len(s) == 0 || len(s) > 255 {
+		return false
+	}
+	i := strings.Index(s, ".")
+	if i != -1 {
+		return false
+	}
+	if s[0] >= '0' && s[0] <= '9' {
+		return false
+	}
+	for _, c := range s {
+		if !isMemberChar(c) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMemberChar(c rune) bool {
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') ||
+		(c >= 'a' && c <= 'z') || c == '_'
+}

--- a/vendor/github.com/godbus/dbus/v5/decoder.go
+++ b/vendor/github.com/godbus/dbus/v5/decoder.go
@@ -1,0 +1,376 @@
+package dbus
+
+import (
+	"encoding/binary"
+	"io"
+	"reflect"
+	"unsafe"
+)
+
+type decoder struct {
+	in    io.Reader
+	order binary.ByteOrder
+	pos   int
+	fds   []int
+
+	// The following fields are used to reduce memory allocs.
+	conv *stringConverter
+	buf  []byte
+	d    float64
+	y    [1]byte
+}
+
+// newDecoder returns a new decoder that reads values from in. The input is
+// expected to be in the given byte order.
+func newDecoder(in io.Reader, order binary.ByteOrder, fds []int) *decoder {
+	dec := new(decoder)
+	dec.in = in
+	dec.order = order
+	dec.fds = fds
+	dec.conv = newStringConverter(stringConverterBufferSize)
+	return dec
+}
+
+// Reset resets the decoder to be reading from in.
+func (dec *decoder) Reset(in io.Reader, order binary.ByteOrder, fds []int) {
+	dec.in = in
+	dec.order = order
+	dec.pos = 0
+	dec.fds = fds
+
+	if dec.conv == nil {
+		dec.conv = newStringConverter(stringConverterBufferSize)
+	}
+}
+
+// align aligns the input to the given boundary and panics on error.
+func (dec *decoder) align(n int) {
+	if dec.pos%n != 0 {
+		newpos := (dec.pos + n - 1) & ^(n - 1)
+		dec.read2buf(newpos - dec.pos)
+		dec.pos = newpos
+	}
+}
+
+// Calls binary.Read(dec.in, dec.order, v) and panics on read errors.
+func (dec *decoder) binread(v any) {
+	if err := binary.Read(dec.in, dec.order, v); err != nil {
+		panic(err)
+	}
+}
+
+func (dec *decoder) Decode(sig Signature) (vs []any, err error) {
+	defer func() {
+		var ok bool
+		v := recover()
+		if err, ok = v.(error); ok {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				err = FormatError("unexpected EOF")
+			}
+		}
+	}()
+	vs = make([]any, 0)
+	s := sig.str
+	for s != "" {
+		err, rem := validSingle(s, &depthCounter{})
+		if err != nil {
+			return nil, err
+		}
+		v := dec.decode(s[:len(s)-len(rem)], 0)
+		vs = append(vs, v)
+		s = rem
+	}
+	return vs, nil
+}
+
+// read2buf reads exactly n bytes from the reader dec.in into the buffer dec.buf
+// to reduce memory allocs.
+// The buffer grows automatically.
+func (dec *decoder) read2buf(n int) {
+	if cap(dec.buf) < n {
+		dec.buf = make([]byte, n)
+	} else {
+		dec.buf = dec.buf[:n]
+	}
+	if _, err := io.ReadFull(dec.in, dec.buf); err != nil {
+		panic(err)
+	}
+}
+
+// decodeU decodes uint32 obtained from the reader dec.in.
+// The goal is to reduce memory allocs.
+func (dec *decoder) decodeU() uint32 {
+	dec.align(4)
+	dec.read2buf(4)
+	dec.pos += 4
+	return dec.order.Uint32(dec.buf)
+}
+
+func (dec *decoder) decode(s string, depth int) any {
+	dec.align(alignment(typeFor(s)))
+	switch s[0] {
+	case 'y':
+		if _, err := dec.in.Read(dec.y[:]); err != nil {
+			panic(err)
+		}
+		dec.pos++
+		return dec.y[0]
+	case 'b':
+		switch dec.decodeU() {
+		case 0:
+			return false
+		case 1:
+			return true
+		default:
+			panic(FormatError("invalid value for boolean"))
+		}
+	case 'n':
+		dec.read2buf(2)
+		dec.pos += 2
+		return int16(dec.order.Uint16(dec.buf))
+	case 'i':
+		dec.read2buf(4)
+		dec.pos += 4
+		return int32(dec.order.Uint32(dec.buf))
+	case 'x':
+		dec.read2buf(8)
+		dec.pos += 8
+		return int64(dec.order.Uint64(dec.buf))
+	case 'q':
+		dec.read2buf(2)
+		dec.pos += 2
+		return dec.order.Uint16(dec.buf)
+	case 'u':
+		return dec.decodeU()
+	case 't':
+		dec.read2buf(8)
+		dec.pos += 8
+		return dec.order.Uint64(dec.buf)
+	case 'd':
+		dec.binread(&dec.d)
+		dec.pos += 8
+		return dec.d
+	case 's':
+		length := dec.decodeU()
+		p := int(length) + 1
+		dec.read2buf(p)
+		dec.pos += p
+		return dec.conv.String(dec.buf[:len(dec.buf)-1])
+	case 'o':
+		return ObjectPath(dec.decode("s", depth).(string))
+	case 'g':
+		length := dec.decode("y", depth).(byte)
+		p := int(length) + 1
+		dec.read2buf(p)
+		dec.pos += p
+		sig, err := ParseSignature(
+			dec.conv.String(dec.buf[:len(dec.buf)-1]),
+		)
+		if err != nil {
+			panic(err)
+		}
+		return sig
+	case 'v':
+		if depth >= 64 {
+			panic(FormatError("input exceeds container depth limit"))
+		}
+		var variant Variant
+		sig := dec.decode("g", depth).(Signature)
+		if len(sig.str) == 0 {
+			panic(FormatError("variant signature is empty"))
+		}
+		err, rem := validSingle(sig.str, &depthCounter{})
+		if err != nil {
+			panic(err)
+		}
+		if rem != "" {
+			panic(FormatError("variant signature has multiple types"))
+		}
+		variant.sig = sig
+		variant.value = dec.decode(sig.str, depth+1)
+		return variant
+	case 'h':
+		idx := dec.decodeU()
+		if int(idx) < len(dec.fds) {
+			return UnixFD(dec.fds[idx])
+		}
+		return UnixFDIndex(idx)
+	case 'a':
+		if len(s) > 1 && s[1] == '{' {
+			ksig := s[2:3]
+			vsig := s[3 : len(s)-1]
+			v := reflect.MakeMap(reflect.MapOf(typeFor(ksig), typeFor(vsig)))
+			if depth >= 63 {
+				panic(FormatError("input exceeds container depth limit"))
+			}
+			length := dec.decodeU()
+			// Even for empty maps, the correct padding must be included
+			dec.align(8)
+			spos := dec.pos
+			for dec.pos < spos+int(length) {
+				dec.align(8)
+				if !isKeyType(v.Type().Key()) {
+					panic(InvalidTypeError{v.Type()})
+				}
+				kv := dec.decode(ksig, depth+2)
+				vv := dec.decode(vsig, depth+2)
+				v.SetMapIndex(reflect.ValueOf(kv), reflect.ValueOf(vv))
+			}
+			return v.Interface()
+		}
+		if depth >= 64 {
+			panic(FormatError("input exceeds container depth limit"))
+		}
+		sig := s[1:]
+		length := dec.decodeU()
+		// capacity can be determined only for fixed-size element types
+		var capacity int
+		if s := sigByteSize(sig); s != 0 {
+			capacity = int(length) / s
+		}
+		v := reflect.MakeSlice(reflect.SliceOf(typeFor(sig)), 0, capacity)
+		// Even for empty arrays, the correct padding must be included
+		align := alignment(typeFor(s[1:]))
+		if len(s) > 1 && s[1] == '(' {
+			// Special case for arrays of structs
+			// structs decode as a slice of interface{} values
+			// but the dbus alignment does not match this
+			align = 8
+		}
+		dec.align(align)
+		spos := dec.pos
+		for dec.pos < spos+int(length) {
+			ev := dec.decode(s[1:], depth+1)
+			v = reflect.Append(v, reflect.ValueOf(ev))
+		}
+		return v.Interface()
+	case '(':
+		if depth >= 64 {
+			panic(FormatError("input exceeds container depth limit"))
+		}
+		dec.align(8)
+		v := make([]any, 0)
+		s = s[1 : len(s)-1]
+		for s != "" {
+			err, rem := validSingle(s, &depthCounter{})
+			if err != nil {
+				panic(err)
+			}
+			ev := dec.decode(s[:len(s)-len(rem)], depth+1)
+			v = append(v, ev)
+			s = rem
+		}
+		return v
+	default:
+		panic(SignatureError{Sig: s})
+	}
+}
+
+// sigByteSize tries to calculates size of the given signature in bytes.
+//
+// It returns zero when it can't, for example when it contains non-fixed size
+// types such as strings, maps and arrays that require reading of the transmitted
+// data, for that we would need to implement the unread method for Decoder first.
+func sigByteSize(sig string) int {
+	var total int
+	for offset := 0; offset < len(sig); {
+		switch sig[offset] {
+		case 'y':
+			total += 1
+			offset += 1
+		case 'n', 'q':
+			total += 2
+			offset += 1
+		case 'b', 'i', 'u', 'h':
+			total += 4
+			offset += 1
+		case 'x', 't', 'd':
+			total += 8
+			offset += 1
+		case '(':
+			i := 1
+			depth := 1
+			for i < len(sig[offset:]) && depth != 0 {
+				switch sig[offset+i] {
+				case '(':
+					depth++
+				case ')':
+					depth--
+				}
+				i++
+			}
+			s := sigByteSize(sig[offset+1 : offset+i-1])
+			if s == 0 {
+				return 0
+			}
+			total += s
+			offset += i
+		default:
+			return 0
+		}
+	}
+	return total
+}
+
+// A FormatError is an error in the wire format.
+type FormatError string
+
+func (e FormatError) Error() string {
+	return "dbus: wire format error: " + string(e)
+}
+
+// stringConverterBufferSize defines the recommended buffer size of 4KB.
+// It showed good results in a benchmark when decoding 35KB message,
+// see https://github.com/marselester/systemd#testing.
+const stringConverterBufferSize = 4096
+
+func newStringConverter(capacity int) *stringConverter {
+	return &stringConverter{
+		buf:    make([]byte, 0, capacity),
+		offset: 0,
+	}
+}
+
+// stringConverter converts bytes to strings with less allocs.
+// The idea is to accumulate bytes in a buffer with specified capacity
+// and create strings with unsafe package using bytes from a buffer.
+// For example, 10 "fizz" strings written to a 40-byte buffer
+// will result in 1 alloc instead of 10.
+//
+// Once a buffer is filled, a new one is created with the same capacity.
+// Old buffers will be eventually GC-ed
+// with no side effects to the returned strings.
+type stringConverter struct {
+	// buf is a temporary buffer where decoded strings are batched.
+	buf []byte
+	// offset is a buffer position where the last string was written.
+	offset int
+}
+
+// String converts bytes to a string.
+func (c *stringConverter) String(b []byte) string {
+	n := len(b)
+	if n == 0 {
+		return ""
+	}
+	// Must allocate because a string doesn't fit into the buffer.
+	if n > cap(c.buf) {
+		return string(b)
+	}
+
+	if len(c.buf)+n > cap(c.buf) {
+		c.buf = make([]byte, 0, cap(c.buf))
+		c.offset = 0
+	}
+	c.buf = append(c.buf, b...)
+
+	b = c.buf[c.offset:]
+	s := toString(b)
+	c.offset += n
+	return s
+}
+
+// toString converts a byte slice to a string without allocating.
+func toString(b []byte) string {
+	return unsafe.String(&b[0], len(b))
+}

--- a/vendor/github.com/godbus/dbus/v5/default_handler.go
+++ b/vendor/github.com/godbus/dbus/v5/default_handler.go
@@ -1,0 +1,338 @@
+package dbus
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+func newIntrospectIntf(h *defaultHandler) *exportedIntf {
+	methods := make(map[string]Method)
+	methods["Introspect"] = exportedMethod{
+		reflect.ValueOf(func(msg Message) (string, *Error) {
+			path := msg.Headers[FieldPath].value.(ObjectPath)
+			return h.introspectPath(path), nil
+		}),
+	}
+	return newExportedIntf(methods, true)
+}
+
+// NewDefaultHandler returns an instance of the default
+// call handler. This is useful if you want to implement only
+// one of the two handlers but not both.
+//
+// Deprecated: this is the default value, don't use it, it will be unexported.
+func NewDefaultHandler() *defaultHandler {
+	h := &defaultHandler{
+		objects:     make(map[ObjectPath]*exportedObj),
+		defaultIntf: make(map[string]*exportedIntf),
+	}
+	h.defaultIntf["org.freedesktop.DBus.Introspectable"] = newIntrospectIntf(h)
+	return h
+}
+
+type defaultHandler struct {
+	sync.RWMutex
+	objects     map[ObjectPath]*exportedObj
+	defaultIntf map[string]*exportedIntf
+}
+
+func (h *defaultHandler) PathExists(path ObjectPath) bool {
+	_, ok := h.objects[path]
+	return ok
+}
+
+func (h *defaultHandler) introspectPath(path ObjectPath) string {
+	subpath := make(map[string]struct{})
+	var xml bytes.Buffer
+	xml.WriteString("<node>")
+	for obj := range h.objects {
+		p := string(path)
+		if p != "/" {
+			p += "/"
+		}
+		if after, ok := strings.CutPrefix(string(obj), p); ok {
+			name, _, _ := strings.Cut(after, "/")
+			subpath[name] = struct{}{}
+		}
+	}
+	for s := range subpath {
+		xml.WriteString("\n\t<node name=\"" + s + "\"/>")
+	}
+	xml.WriteString("\n</node>")
+	return xml.String()
+}
+
+func (h *defaultHandler) LookupObject(path ObjectPath) (ServerObject, bool) {
+	h.RLock()
+	defer h.RUnlock()
+	object, ok := h.objects[path]
+	if ok {
+		return object, ok
+	}
+
+	// If an object wasn't found for this exact path,
+	// look for a matching subtree registration
+	subtreeObject := newExportedObject()
+	path = path[:strings.LastIndex(string(path), "/")]
+	for len(path) > 0 {
+		object, ok = h.objects[path]
+		if ok {
+			for name, iface := range object.interfaces {
+				// Only include this handler if it registered for the subtree
+				if iface.isFallbackInterface() {
+					subtreeObject.interfaces[name] = iface
+				}
+			}
+			break
+		}
+
+		path = path[:strings.LastIndex(string(path), "/")]
+	}
+
+	for name, intf := range h.defaultIntf {
+		if _, exists := subtreeObject.interfaces[name]; exists {
+			continue
+		}
+		subtreeObject.interfaces[name] = intf
+	}
+
+	return subtreeObject, true
+}
+
+func (h *defaultHandler) AddObject(path ObjectPath, object *exportedObj) {
+	h.Lock()
+	h.objects[path] = object
+	h.Unlock()
+}
+
+func (h *defaultHandler) DeleteObject(path ObjectPath) {
+	h.Lock()
+	delete(h.objects, path)
+	h.Unlock()
+}
+
+type exportedMethod struct {
+	reflect.Value
+}
+
+func (m exportedMethod) Call(args ...any) ([]any, error) {
+	t := m.Type()
+
+	params := make([]reflect.Value, len(args))
+	for i := 0; i < len(args); i++ {
+		params[i] = reflect.ValueOf(args[i]).Elem()
+	}
+
+	ret := m.Value.Call(params)
+	var err error
+	nilErr := false // The reflection will find almost-nils, let's only pass back clean ones!
+	if t.NumOut() > 0 {
+		if e, ok := ret[t.NumOut()-1].Interface().(*Error); ok { // godbus *Error
+			nilErr = ret[t.NumOut()-1].IsNil()
+			ret = ret[:t.NumOut()-1]
+			err = e
+		} else if ret[t.NumOut()-1].Type().Implements(errType) { // Go error
+			i := ret[t.NumOut()-1].Interface()
+			if i == nil {
+				nilErr = ret[t.NumOut()-1].IsNil()
+			} else {
+				err = i.(error)
+			}
+			ret = ret[:t.NumOut()-1]
+		}
+	}
+	out := make([]any, len(ret))
+	for i, val := range ret {
+		out[i] = val.Interface()
+	}
+	if nilErr || err == nil {
+		// concrete type to interface nil is a special case
+		return out, nil
+	}
+	return out, err
+}
+
+func (m exportedMethod) NumArguments() int {
+	return m.Value.Type().NumIn()
+}
+
+func (m exportedMethod) ArgumentValue(i int) any {
+	return reflect.Zero(m.Type().In(i)).Interface()
+}
+
+func (m exportedMethod) NumReturns() int {
+	return m.Value.Type().NumOut()
+}
+
+func (m exportedMethod) ReturnValue(i int) any {
+	return reflect.Zero(m.Type().Out(i)).Interface()
+}
+
+func newExportedObject() *exportedObj {
+	return &exportedObj{
+		interfaces: make(map[string]*exportedIntf),
+	}
+}
+
+type exportedObj struct {
+	mu         sync.RWMutex
+	interfaces map[string]*exportedIntf
+}
+
+func (obj *exportedObj) LookupInterface(name string) (Interface, bool) {
+	if name == "" {
+		return obj, true
+	}
+	obj.mu.RLock()
+	defer obj.mu.RUnlock()
+	intf, exists := obj.interfaces[name]
+	return intf, exists
+}
+
+func (obj *exportedObj) AddInterface(name string, iface *exportedIntf) {
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+	obj.interfaces[name] = iface
+}
+
+func (obj *exportedObj) DeleteInterface(name string) {
+	obj.mu.Lock()
+	defer obj.mu.Unlock()
+	delete(obj.interfaces, name)
+}
+
+func (obj *exportedObj) LookupMethod(name string) (Method, bool) {
+	obj.mu.RLock()
+	defer obj.mu.RUnlock()
+	for _, intf := range obj.interfaces {
+		method, exists := intf.LookupMethod(name)
+		if exists {
+			return method, exists
+		}
+	}
+	return nil, false
+}
+
+func newExportedIntf(methods map[string]Method, includeSubtree bool) *exportedIntf {
+	return &exportedIntf{
+		methods:        methods,
+		includeSubtree: includeSubtree,
+	}
+}
+
+type exportedIntf struct {
+	methods map[string]Method
+
+	// Whether or not this export is for the entire subtree
+	includeSubtree bool
+}
+
+func (obj *exportedIntf) LookupMethod(name string) (Method, bool) {
+	out, exists := obj.methods[name]
+	return out, exists
+}
+
+func (obj *exportedIntf) isFallbackInterface() bool {
+	return obj.includeSubtree
+}
+
+// NewDefaultSignalHandler returns an instance of the default
+// signal handler. This is useful if you want to implement only
+// one of the two handlers but not both.
+//
+// Deprecated: this is the default value, don't use it, it will be unexported.
+func NewDefaultSignalHandler() *defaultSignalHandler {
+	return &defaultSignalHandler{}
+}
+
+type defaultSignalHandler struct {
+	mu      sync.RWMutex
+	closed  bool
+	signals []*signalChannelData
+}
+
+func (sh *defaultSignalHandler) DeliverSignal(intf, name string, signal *Signal) {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	if sh.closed {
+		return
+	}
+	for _, scd := range sh.signals {
+		scd.deliver(signal)
+	}
+}
+
+func (sh *defaultSignalHandler) Terminate() {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+
+	for _, scd := range sh.signals {
+		scd.close()
+		close(scd.ch)
+	}
+	sh.closed = true
+	sh.signals = nil
+}
+
+func (sh *defaultSignalHandler) AddSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	sh.signals = append(sh.signals, &signalChannelData{
+		ch:   ch,
+		done: make(chan struct{}),
+	})
+}
+
+func (sh *defaultSignalHandler) RemoveSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	for i := len(sh.signals) - 1; i >= 0; i-- {
+		if ch == sh.signals[i].ch {
+			sh.signals[i].close()
+			copy(sh.signals[i:], sh.signals[i+1:])
+			sh.signals[len(sh.signals)-1] = nil
+			sh.signals = sh.signals[:len(sh.signals)-1]
+		}
+	}
+}
+
+type signalChannelData struct {
+	wg   sync.WaitGroup
+	ch   chan<- *Signal
+	done chan struct{}
+}
+
+func (scd *signalChannelData) deliver(signal *Signal) {
+	select {
+	case scd.ch <- signal:
+	case <-scd.done:
+		return
+	default:
+		scd.wg.Add(1)
+		go scd.deferredDeliver(signal)
+	}
+}
+
+func (scd *signalChannelData) deferredDeliver(signal *Signal) {
+	select {
+	case scd.ch <- signal:
+	case <-scd.done:
+	}
+	scd.wg.Done()
+}
+
+func (scd *signalChannelData) close() {
+	close(scd.done)
+	scd.wg.Wait() // wait until all spawned goroutines return
+}

--- a/vendor/github.com/godbus/dbus/v5/doc.go
+++ b/vendor/github.com/godbus/dbus/v5/doc.go
@@ -1,0 +1,70 @@
+/*
+Package dbus implements bindings to the D-Bus message bus system.
+
+To use the message bus API, you first need to connect to a bus (usually the
+session or system bus). The acquired connection then can be used to call methods
+on remote objects and emit or receive signals. Using the Export method, you can
+arrange D-Bus methods calls to be directly translated to method calls on a Go
+value.
+
+# Conversion Rules
+
+For outgoing messages, Go types are automatically converted to the
+corresponding D-Bus types. See the official specification at
+https://dbus.freedesktop.org/doc/dbus-specification.html#type-system for more
+information on the D-Bus type system. The following types are directly encoded
+as their respective D-Bus equivalents:
+
+	Go type     | D-Bus type
+	------------+-----------
+	byte        | BYTE
+	bool        | BOOLEAN
+	int16       | INT16
+	uint16      | UINT16
+	int         | INT32
+	uint        | UINT32
+	int32       | INT32
+	uint32      | UINT32
+	int64       | INT64
+	uint64      | UINT64
+	float64     | DOUBLE
+	string      | STRING
+	ObjectPath  | OBJECT_PATH
+	Signature   | SIGNATURE
+	Variant     | VARIANT
+	interface{} | VARIANT
+	UnixFDIndex | UNIX_FD
+
+Slices and arrays encode as ARRAYs of their element type.
+
+Maps encode as DICTs, provided that their key type can be used as a key for
+a DICT.
+
+Structs other than Variant and Signature encode as a STRUCT containing their
+exported fields in order. Fields whose tags contain `dbus:"-"` and unexported
+fields will be skipped.
+
+Pointers encode as the value they're pointed to.
+
+Types convertible to one of the base types above will be mapped as the
+base type.
+
+Trying to encode any other type or a slice, map or struct containing an
+unsupported type will result in an InvalidTypeError.
+
+For incoming messages, the inverse of these rules are used, with the exception
+of STRUCTs. Incoming STRUCTS are represented as a slice of empty interfaces
+containing the struct fields in the correct order. The Store function can be
+used to convert such values to Go structs.
+
+# Unix FD passing
+
+Handling Unix file descriptors deserves special mention. To use them, you should
+first check that they are supported on a connection by calling SupportsUnixFDs.
+If it returns true, all method of Connection will translate messages containing
+UnixFD's to messages that are accompanied by the given file descriptors with the
+UnixFD values being substituted by the correct indices. Similarly, the indices
+of incoming messages are automatically resolved. It shouldn't be necessary to use
+UnixFDIndex.
+*/
+package dbus

--- a/vendor/github.com/godbus/dbus/v5/encoder.go
+++ b/vendor/github.com/godbus/dbus/v5/encoder.go
@@ -1,0 +1,235 @@
+package dbus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"reflect"
+	"strings"
+	"unicode/utf8"
+)
+
+// An encoder encodes values to the D-Bus wire format.
+type encoder struct {
+	out   io.Writer
+	fds   []int
+	order binary.ByteOrder
+	pos   int
+}
+
+// NewEncoder returns a new encoder that writes to out in the given byte order.
+func newEncoder(out io.Writer, order binary.ByteOrder, fds []int) *encoder {
+	enc := newEncoderAtOffset(out, 0, order, fds)
+	return enc
+}
+
+// newEncoderAtOffset returns a new encoder that writes to out in the given
+// byte order. Specify the offset to initialize pos for proper alignment
+// computation.
+func newEncoderAtOffset(out io.Writer, offset int, order binary.ByteOrder, fds []int) *encoder {
+	enc := new(encoder)
+	enc.out = out
+	enc.order = order
+	enc.pos = offset
+	enc.fds = fds
+	return enc
+}
+
+// Aligns the next output to be on a multiple of n. Panics on write errors.
+func (enc *encoder) align(n int) {
+	pad := enc.padding(0, n)
+	if pad > 0 {
+		empty := make([]byte, pad)
+		if _, err := enc.out.Write(empty); err != nil {
+			panic(err)
+		}
+		enc.pos += pad
+	}
+}
+
+// pad returns the number of bytes of padding, based on current position and additional offset.
+// and alignment.
+func (enc *encoder) padding(offset, algn int) int {
+	abs := enc.pos + offset
+	if abs%algn != 0 {
+		newabs := (abs + algn - 1) & ^(algn - 1)
+		return newabs - abs
+	}
+	return 0
+}
+
+// Calls binary.Write(enc.out, enc.order, v) and panics on write errors.
+func (enc *encoder) binwrite(v any) {
+	if err := binary.Write(enc.out, enc.order, v); err != nil {
+		panic(err)
+	}
+}
+
+// Encode encodes the given values to the underlying reader. All written values
+// are aligned properly as required by the D-Bus spec.
+func (enc *encoder) Encode(vs ...any) (err error) {
+	defer func() {
+		err, _ = recover().(error)
+	}()
+	for _, v := range vs {
+		enc.encode(reflect.ValueOf(v), 0)
+	}
+	return nil
+}
+
+// encode encodes the given value to the writer and panics on error. depth holds
+// the depth of the container nesting.
+func (enc *encoder) encode(v reflect.Value, depth int) {
+	if depth > 64 {
+		panic(FormatError("input exceeds depth limitation"))
+	}
+	enc.align(alignment(v.Type()))
+	switch v.Kind() {
+	case reflect.Uint8:
+		var b [1]byte
+		b[0] = byte(v.Uint())
+		if _, err := enc.out.Write(b[:]); err != nil {
+			panic(err)
+		}
+		enc.pos++
+	case reflect.Bool:
+		if v.Bool() {
+			enc.encode(reflect.ValueOf(uint32(1)), depth)
+		} else {
+			enc.encode(reflect.ValueOf(uint32(0)), depth)
+		}
+	case reflect.Int16:
+		enc.binwrite(int16(v.Int()))
+		enc.pos += 2
+	case reflect.Uint16:
+		enc.binwrite(uint16(v.Uint()))
+		enc.pos += 2
+	case reflect.Int, reflect.Int32:
+		if v.Type() == unixFDType {
+			fd := v.Int()
+			idx := len(enc.fds)
+			enc.fds = append(enc.fds, int(fd))
+			enc.binwrite(uint32(idx))
+		} else {
+			enc.binwrite(int32(v.Int()))
+		}
+		enc.pos += 4
+	case reflect.Uint, reflect.Uint32:
+		enc.binwrite(uint32(v.Uint()))
+		enc.pos += 4
+	case reflect.Int64:
+		enc.binwrite(v.Int())
+		enc.pos += 8
+	case reflect.Uint64:
+		enc.binwrite(v.Uint())
+		enc.pos += 8
+	case reflect.Float64:
+		enc.binwrite(v.Float())
+		enc.pos += 8
+	case reflect.String:
+		str := v.String()
+		if !utf8.ValidString(str) {
+			panic(FormatError("input has a not-utf8 char in string"))
+		}
+		if strings.IndexByte(str, byte(0)) != -1 {
+			panic(FormatError("input has a null char('\\000') in string"))
+		}
+		if v.Type() == objectPathType {
+			if !ObjectPath(str).IsValid() {
+				panic(FormatError("invalid object path"))
+			}
+		}
+		enc.encode(reflect.ValueOf(uint32(len(str))), depth)
+		b := make([]byte, v.Len()+1)
+		copy(b, str)
+		b[len(b)-1] = 0
+		n, err := enc.out.Write(b)
+		if err != nil {
+			panic(err)
+		}
+		enc.pos += n
+	case reflect.Ptr:
+		enc.encode(v.Elem(), depth)
+	case reflect.Slice, reflect.Array:
+		// Lookahead offset: 4 bytes for uint32 length (with alignment),
+		// plus alignment for elements.
+		n := enc.padding(0, 4) + 4
+		offset := enc.pos + n + enc.padding(n, alignment(v.Type().Elem()))
+
+		var buf bytes.Buffer
+		bufenc := newEncoderAtOffset(&buf, offset, enc.order, enc.fds)
+
+		for i := 0; i < v.Len(); i++ {
+			bufenc.encode(v.Index(i), depth+1)
+		}
+
+		if buf.Len() > 1<<26 {
+			panic(FormatError("input exceeds array size limitation"))
+		}
+
+		enc.fds = bufenc.fds
+		enc.encode(reflect.ValueOf(uint32(buf.Len())), depth)
+		length := buf.Len()
+		enc.align(alignment(v.Type().Elem()))
+		if _, err := buf.WriteTo(enc.out); err != nil {
+			panic(err)
+		}
+		enc.pos += length
+	case reflect.Struct:
+		switch t := v.Type(); t {
+		case signatureType:
+			str := v.Field(0)
+			enc.encode(reflect.ValueOf(byte(str.Len())), depth)
+			b := make([]byte, str.Len()+1)
+			copy(b, str.String())
+			b[len(b)-1] = 0
+			n, err := enc.out.Write(b)
+			if err != nil {
+				panic(err)
+			}
+			enc.pos += n
+		case variantType:
+			variant := v.Interface().(Variant)
+			enc.encode(reflect.ValueOf(variant.sig), depth+1)
+			enc.encode(reflect.ValueOf(variant.value), depth+1)
+		default:
+			for i := 0; i < v.Type().NumField(); i++ {
+				field := t.Field(i)
+				if field.PkgPath == "" && field.Tag.Get("dbus") != "-" {
+					enc.encode(v.Field(i), depth+1)
+				}
+			}
+		}
+	case reflect.Map:
+		// Maps are arrays of structures, so they actually increase the depth by
+		// 2.
+		if !isKeyType(v.Type().Key()) {
+			panic(InvalidTypeError{v.Type()})
+		}
+		keys := v.MapKeys()
+		// Lookahead offset: 4 bytes for uint32 length (with alignment),
+		// plus 8-byte alignment
+		n := enc.padding(0, 4) + 4
+		offset := enc.pos + n + enc.padding(n, 8)
+
+		var buf bytes.Buffer
+		bufenc := newEncoderAtOffset(&buf, offset, enc.order, enc.fds)
+		for _, k := range keys {
+			bufenc.align(8)
+			bufenc.encode(k, depth+2)
+			bufenc.encode(v.MapIndex(k), depth+2)
+		}
+		enc.fds = bufenc.fds
+		enc.encode(reflect.ValueOf(uint32(buf.Len())), depth)
+		length := buf.Len()
+		enc.align(8)
+		if _, err := buf.WriteTo(enc.out); err != nil {
+			panic(err)
+		}
+		enc.pos += length
+	case reflect.Interface:
+		enc.encode(reflect.ValueOf(MakeVariant(v.Interface())), depth)
+	default:
+		panic(InvalidTypeError{v.Type()})
+	}
+}

--- a/vendor/github.com/godbus/dbus/v5/escape.go
+++ b/vendor/github.com/godbus/dbus/v5/escape.go
@@ -1,0 +1,84 @@
+package dbus
+
+import "net/url"
+
+// EscapeBusAddressValue implements a requirement to escape the values
+// in D-Bus server addresses, as defined by the D-Bus specification at
+// https://dbus.freedesktop.org/doc/dbus-specification.html#addresses.
+func EscapeBusAddressValue(val string) string {
+	toEsc := strNeedsEscape(val)
+	if toEsc == 0 {
+		// Avoid unneeded allocation/copying.
+		return val
+	}
+
+	// Avoid allocation for short paths.
+	var buf [64]byte
+	var out []byte
+	// Every to-be-escaped byte needs 2 extra bytes.
+	required := len(val) + 2*toEsc
+	if required <= len(buf) {
+		out = buf[:required]
+	} else {
+		out = make([]byte, required)
+	}
+
+	j := 0
+	for i := 0; i < len(val); i++ {
+		if ch := val[i]; needsEscape(ch) {
+			// Convert ch to %xx, where xx is hex value.
+			out[j] = '%'
+			out[j+1] = hexchar(ch >> 4)
+			out[j+2] = hexchar(ch & 0x0F)
+			j += 3
+		} else {
+			out[j] = ch
+			j++
+		}
+	}
+
+	return string(out)
+}
+
+// UnescapeBusAddressValue unescapes values in D-Bus server addresses,
+// as defined by the D-Bus specification at
+// https://dbus.freedesktop.org/doc/dbus-specification.html#addresses.
+func UnescapeBusAddressValue(val string) (string, error) {
+	// Looks like url.PathUnescape does exactly what is required.
+	return url.PathUnescape(val)
+}
+
+// hexchar returns an octal representation of a n, where n < 16.
+// For invalid values of n, the function panics.
+func hexchar(n byte) byte {
+	const hex = "0123456789abcdef"
+
+	// For n >= len(hex), runtime will panic.
+	return hex[n]
+}
+
+// needsEscape tells if a byte is NOT one of optionally-escaped bytes.
+func needsEscape(c byte) bool {
+	if 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || '0' <= c && c <= '9' {
+		return false
+	}
+	switch c {
+	case '-', '_', '/', '\\', '.', '*':
+		return false
+	}
+
+	return true
+}
+
+// strNeedsEscape tells how many bytes in the string need escaping.
+func strNeedsEscape(val string) int {
+	count := 0
+
+	for i := 0; i < len(val); i++ {
+		if needsEscape(val[i]) {
+			count++
+		}
+	}
+
+	return count
+}

--- a/vendor/github.com/godbus/dbus/v5/export.go
+++ b/vendor/github.com/godbus/dbus/v5/export.go
@@ -1,0 +1,484 @@
+package dbus
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+)
+
+var (
+	ErrMsgInvalidArg = Error{
+		"org.freedesktop.DBus.Error.InvalidArgs",
+		[]any{"Invalid type / number of args"},
+	}
+	ErrMsgNoObject = Error{
+		"org.freedesktop.DBus.Error.NoSuchObject",
+		[]any{"No such object"},
+	}
+	ErrMsgUnknownMethod = Error{
+		"org.freedesktop.DBus.Error.UnknownMethod",
+		[]any{"Unknown / invalid method"},
+	}
+	ErrMsgUnknownInterface = Error{
+		"org.freedesktop.DBus.Error.UnknownInterface",
+		[]any{"Object does not implement the interface"},
+	}
+)
+
+func MakeNoObjectError(path ObjectPath) Error {
+	return Error{
+		"org.freedesktop.DBus.Error.NoSuchObject",
+		[]any{fmt.Sprintf("No such object '%s'", string(path))},
+	}
+}
+
+func MakeUnknownMethodError(methodName string) Error {
+	return Error{
+		"org.freedesktop.DBus.Error.UnknownMethod",
+		[]any{fmt.Sprintf("Unknown / invalid method '%s'", methodName)},
+	}
+}
+
+func MakeUnknownInterfaceError(ifaceName string) Error {
+	return Error{
+		"org.freedesktop.DBus.Error.UnknownInterface",
+		[]any{fmt.Sprintf("Object does not implement the interface '%s'", ifaceName)},
+	}
+}
+
+func MakeFailedError(err error) *Error {
+	return &Error{
+		"org.freedesktop.DBus.Error.Failed",
+		[]any{err.Error()},
+	}
+}
+
+// Sender is a type which can be used in exported methods to receive the message
+// sender.
+type Sender string
+
+func computeMethodName(name string, mapping map[string]string) string {
+	newname, ok := mapping[name]
+	if ok {
+		name = newname
+	}
+	return name
+}
+
+func getMethods(in any, mapping map[string]string) map[string]reflect.Value {
+	if in == nil {
+		return nil
+	}
+	methods := make(map[string]reflect.Value)
+	val := reflect.ValueOf(in)
+	typ := val.Type()
+	for i := 0; i < typ.NumMethod(); i++ {
+		methtype := typ.Method(i)
+		method := val.Method(i)
+		t := method.Type()
+		// only track valid methods must return *Error as last arg
+		// and must be exported
+		if t.NumOut() == 0 ||
+			t.Out(t.NumOut()-1) != reflect.TypeOf(&ErrMsgInvalidArg) ||
+			methtype.PkgPath != "" {
+			continue
+		}
+		// map names while building table
+		methods[computeMethodName(methtype.Name, mapping)] = method
+	}
+	return methods
+}
+
+func getAllMethods(in any, mapping map[string]string) map[string]reflect.Value {
+	if in == nil {
+		return nil
+	}
+	methods := make(map[string]reflect.Value)
+	val := reflect.ValueOf(in)
+	typ := val.Type()
+	for i := 0; i < typ.NumMethod(); i++ {
+		methtype := typ.Method(i)
+		method := val.Method(i)
+		// map names while building table
+		methods[computeMethodName(methtype.Name, mapping)] = method
+	}
+	return methods
+}
+
+func standardMethodArgumentDecode(m Method, sender string, msg *Message, body []any) ([]any, error) {
+	pointers := make([]any, m.NumArguments())
+	decode := make([]any, 0, len(body))
+
+	for i := 0; i < m.NumArguments(); i++ {
+		tp := reflect.TypeOf(m.ArgumentValue(i))
+		val := reflect.New(tp)
+		pointers[i] = val.Interface()
+		if tp == reflect.TypeOf((*Sender)(nil)).Elem() {
+			val.Elem().SetString(sender)
+		} else if tp == reflect.TypeOf((*Message)(nil)).Elem() {
+			val.Elem().Set(reflect.ValueOf(*msg))
+		} else {
+			decode = append(decode, pointers[i])
+		}
+	}
+
+	if len(decode) != len(body) {
+		return nil, ErrMsgInvalidArg
+	}
+
+	if err := Store(body, decode...); err != nil {
+		return nil, ErrMsgInvalidArg
+	}
+
+	return pointers, nil
+}
+
+func (conn *Conn) decodeArguments(m Method, sender string, msg *Message) ([]any, error) {
+	if decoder, ok := m.(ArgumentDecoder); ok {
+		return decoder.DecodeArguments(conn, sender, msg, msg.Body)
+	}
+	return standardMethodArgumentDecode(m, sender, msg, msg.Body)
+}
+
+// handleCall handles the given method call (i.e. looks if it's one of the
+// pre-implemented ones and searches for a corresponding handler if not).
+func (conn *Conn) handleCall(msg *Message) {
+	name := msg.Headers[FieldMember].value.(string)
+	path := msg.Headers[FieldPath].value.(ObjectPath)
+	ifaceName, _ := msg.Headers[FieldInterface].value.(string)
+	sender, hasSender := msg.Headers[FieldSender].value.(string)
+	serial := msg.serial
+
+	if len(name) == 0 {
+		conn.sendError(ErrMsgUnknownMethod, sender, serial)
+	}
+
+	if ifaceName == "org.freedesktop.DBus.Peer" {
+		switch name {
+		case "Ping":
+			conn.sendReply(sender, serial)
+		case "GetMachineId":
+			conn.sendReply(sender, serial, conn.uuid)
+		default:
+			conn.sendError(MakeUnknownMethodError(name), sender, serial)
+		}
+		return
+	}
+
+	object, ok := conn.handler.LookupObject(path)
+	if !ok {
+		conn.sendError(MakeNoObjectError(path), sender, serial)
+		return
+	}
+
+	iface, exists := object.LookupInterface(ifaceName)
+	if !exists {
+		conn.sendError(MakeUnknownInterfaceError(ifaceName), sender, serial)
+		return
+	}
+
+	m, exists := iface.LookupMethod(name)
+	if !exists {
+		conn.sendError(MakeUnknownMethodError(name), sender, serial)
+		return
+	}
+	args, err := conn.decodeArguments(m, sender, msg)
+	if err != nil {
+		conn.sendError(err, sender, serial)
+		return
+	}
+
+	ret, err := m.Call(args...)
+	if err != nil {
+		conn.sendError(err, sender, serial)
+		return
+	}
+
+	if msg.Flags&FlagNoReplyExpected == 0 {
+		reply := new(Message)
+		reply.Type = TypeMethodReply
+		reply.Headers = make(map[HeaderField]Variant)
+		if hasSender {
+			reply.Headers[FieldDestination] = msg.Headers[FieldSender]
+		}
+		reply.Headers[FieldReplySerial] = MakeVariant(msg.serial)
+		reply.Body = make([]any, len(ret))
+		copy(reply.Body, ret)
+		reply.Headers[FieldSignature] = MakeVariant(SignatureOf(reply.Body...))
+
+		if err := conn.sendMessageAndIfClosed(reply, nil); err != nil {
+			if _, ok := err.(FormatError); ok {
+				fmt.Fprintf(os.Stderr, "dbus: replacing invalid reply to %s.%s on obj %s: %s\n", ifaceName, name, path, err)
+			}
+		}
+	}
+}
+
+// Emit emits the given signal on the message bus. The name parameter must be
+// formatted as "interface.member", e.g., "org.freedesktop.DBus.NameLost".
+func (conn *Conn) Emit(path ObjectPath, name string, values ...any) error {
+	i := strings.LastIndex(name, ".")
+	if i == -1 {
+		return errors.New("dbus: invalid method name")
+	}
+	iface := name[:i]
+	member := name[i+1:]
+	msg := new(Message)
+	msg.Type = TypeSignal
+	msg.Headers = make(map[HeaderField]Variant)
+	msg.Headers[FieldInterface] = MakeVariant(iface)
+	msg.Headers[FieldMember] = MakeVariant(member)
+	msg.Headers[FieldPath] = MakeVariant(path)
+	msg.Body = values
+	if len(values) > 0 {
+		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(values...))
+	}
+
+	var closed bool
+	err := conn.sendMessageAndIfClosed(msg, func() {
+		closed = true
+	})
+	if closed {
+		return ErrClosed
+	}
+	return err
+}
+
+// Export registers the given value to be exported as an object on the
+// message bus.
+//
+// If a method call on the given path and interface is received, an exported
+// method with the same name is called with v as the receiver if the
+// parameters match and the last return value is of type *Error. If this
+// *Error is not nil, it is sent back to the caller as an error.
+// Otherwise, a method reply is sent with the other return values as its body.
+//
+// Any parameters with the special type Sender are set to the sender of the
+// dbus message when the method is called. Parameters of this type do not
+// contribute to the dbus signature of the method (i.e. the method is exposed
+// as if the parameters of type Sender were not there).
+//
+// Similarly, any parameters with the type Message are set to the raw message
+// received on the bus. Again, parameters of this type do not contribute to the
+// dbus signature of the method.
+//
+// Every method call is executed in a new goroutine, so the method may be called
+// in multiple goroutines at once.
+//
+// Method calls on the interface org.freedesktop.DBus.Peer will be automatically
+// handled for every object.
+//
+// Passing nil as the first parameter will cause conn to cease handling calls on
+// the given combination of path and interface.
+//
+// Export returns an error if path is not a valid path name.
+func (conn *Conn) Export(v any, path ObjectPath, iface string) error {
+	return conn.ExportWithMap(v, nil, path, iface)
+}
+
+// ExportAll registers all exported methods defined by the given object on
+// the message bus.
+//
+// Unlike Export there is no requirement to have the last parameter as type
+// *Error. If you want to be able to return error then you can append an error
+// type parameter to your method signature. If the error returned is not nil,
+// it is sent back to the caller as an error. Otherwise, a method reply is
+// sent with the other return values as its body.
+func (conn *Conn) ExportAll(v any, path ObjectPath, iface string) error {
+	return conn.export(getAllMethods(v, nil), path, iface, false)
+}
+
+// ExportWithMap works exactly like Export but provides the ability to remap
+// method names (e.g. export a lower-case method).
+//
+// The keys in the map are the real method names (exported on the struct), and
+// the values are the method names to be exported on DBus.
+func (conn *Conn) ExportWithMap(v any, mapping map[string]string, path ObjectPath, iface string) error {
+	return conn.export(getMethods(v, mapping), path, iface, false)
+}
+
+// ExportSubtree works exactly like Export but registers the given value for
+// an entire subtree rather under the root path provided.
+//
+// In order to make this useful, one parameter in each of the value's exported
+// methods should be a Message, in which case it will contain the raw message
+// (allowing one to get access to the path that caused the method to be called).
+//
+// Note that more specific export paths take precedence over less specific. For
+// example, a method call using the ObjectPath /foo/bar/baz will call a method
+// exported on /foo/bar before a method exported on /foo.
+func (conn *Conn) ExportSubtree(v any, path ObjectPath, iface string) error {
+	return conn.ExportSubtreeWithMap(v, nil, path, iface)
+}
+
+// ExportSubtreeWithMap works exactly like ExportSubtree but provides the
+// ability to remap method names (e.g. export a lower-case method).
+//
+// The keys in the map are the real method names (exported on the struct), and
+// the values are the method names to be exported on DBus.
+func (conn *Conn) ExportSubtreeWithMap(v any, mapping map[string]string, path ObjectPath, iface string) error {
+	return conn.export(getMethods(v, mapping), path, iface, true)
+}
+
+// ExportMethodTable like Export registers the given methods as an object
+// on the message bus. Unlike Export the it uses a method table to define
+// the object instead of a native go object.
+//
+// The method table is a map from method name to function closure
+// representing the method. This allows an object exported on the bus to not
+// necessarily be a native go object. It can be useful for generating exposed
+// methods on the fly.
+//
+// Any non-function objects in the method table are ignored.
+func (conn *Conn) ExportMethodTable(methods map[string]any, path ObjectPath, iface string) error {
+	return conn.exportMethodTable(methods, path, iface, false)
+}
+
+// Like ExportSubtree, but with the same caveats as ExportMethodTable.
+func (conn *Conn) ExportSubtreeMethodTable(methods map[string]any, path ObjectPath, iface string) error {
+	return conn.exportMethodTable(methods, path, iface, true)
+}
+
+func (conn *Conn) exportMethodTable(methods map[string]any, path ObjectPath, iface string, includeSubtree bool) error {
+	var out map[string]reflect.Value
+	if methods != nil {
+		out = make(map[string]reflect.Value)
+		for name, method := range methods {
+			rval := reflect.ValueOf(method)
+			if rval.Kind() != reflect.Func {
+				continue
+			}
+			t := rval.Type()
+			// only track valid methods must return *Error as last arg
+			if t.NumOut() == 0 ||
+				t.Out(t.NumOut()-1) != reflect.TypeOf(&ErrMsgInvalidArg) {
+				continue
+			}
+			out[name] = rval
+		}
+	}
+	return conn.export(out, path, iface, includeSubtree)
+}
+
+func (conn *Conn) unexport(h *defaultHandler, path ObjectPath, iface string) error {
+	if h.PathExists(path) {
+		obj := h.objects[path]
+		obj.DeleteInterface(iface)
+		if len(obj.interfaces) == 0 {
+			h.DeleteObject(path)
+		}
+	}
+	return nil
+}
+
+// export is the worker function for all exports/registrations.
+func (conn *Conn) export(methods map[string]reflect.Value, path ObjectPath, iface string, includeSubtree bool) error {
+	h, ok := conn.handler.(*defaultHandler)
+	if !ok {
+		return fmt.Errorf(
+			`dbus: export only allowed on the default handler. Received: %T"`,
+			conn.handler)
+	}
+
+	if !path.IsValid() {
+		return fmt.Errorf(`dbus: Invalid path name: "%s"`, path)
+	}
+
+	// Remove a previous export if the interface is nil
+	if methods == nil {
+		return conn.unexport(h, path, iface)
+	}
+
+	// If this is the first handler for this path, make a new map to hold all
+	// handlers for this path.
+	if !h.PathExists(path) {
+		h.AddObject(path, newExportedObject())
+	}
+
+	exportedMethods := make(map[string]Method)
+	for name, method := range methods {
+		exportedMethods[name] = exportedMethod{method}
+	}
+
+	// Finally, save this handler
+	obj := h.objects[path]
+	obj.AddInterface(iface, newExportedIntf(exportedMethods, includeSubtree))
+
+	return nil
+}
+
+// ReleaseName calls org.freedesktop.DBus.ReleaseName and awaits a response.
+func (conn *Conn) ReleaseName(name string) (ReleaseNameReply, error) {
+	var r uint32
+	err := conn.busObj.Call("org.freedesktop.DBus.ReleaseName", 0, name).Store(&r)
+	if err != nil {
+		return 0, err
+	}
+	return ReleaseNameReply(r), nil
+}
+
+// RequestName calls org.freedesktop.DBus.RequestName and awaits a response.
+func (conn *Conn) RequestName(name string, flags RequestNameFlags) (RequestNameReply, error) {
+	var r uint32
+	err := conn.busObj.Call("org.freedesktop.DBus.RequestName", 0, name, flags).Store(&r)
+	if err != nil {
+		return 0, err
+	}
+	return RequestNameReply(r), nil
+}
+
+// ReleaseNameReply is the reply to a ReleaseName call.
+type ReleaseNameReply uint32
+
+const (
+	ReleaseNameReplyReleased ReleaseNameReply = 1 + iota
+	ReleaseNameReplyNonExistent
+	ReleaseNameReplyNotOwner
+)
+
+func (rep ReleaseNameReply) String() string {
+	switch rep {
+	case ReleaseNameReplyReleased:
+		return "released"
+	case ReleaseNameReplyNonExistent:
+		return "non existent"
+	case ReleaseNameReplyNotOwner:
+		return "not owner"
+	}
+	return "unknown"
+}
+
+// RequestNameFlags represents the possible flags for a RequestName call.
+type RequestNameFlags uint32
+
+const (
+	NameFlagAllowReplacement RequestNameFlags = 1 << iota
+	NameFlagReplaceExisting
+	NameFlagDoNotQueue
+)
+
+// RequestNameReply is the reply to a RequestName call.
+type RequestNameReply uint32
+
+const (
+	RequestNameReplyPrimaryOwner RequestNameReply = 1 + iota
+	RequestNameReplyInQueue
+	RequestNameReplyExists
+	RequestNameReplyAlreadyOwner
+)
+
+func (rep RequestNameReply) String() string {
+	switch rep {
+	case RequestNameReplyPrimaryOwner:
+		return "primary owner"
+	case RequestNameReplyInQueue:
+		return "in queue"
+	case RequestNameReplyExists:
+		return "exists"
+	case RequestNameReplyAlreadyOwner:
+		return "already owner"
+	}
+	return "unknown"
+}

--- a/vendor/github.com/godbus/dbus/v5/match.go
+++ b/vendor/github.com/godbus/dbus/v5/match.go
@@ -1,0 +1,89 @@
+package dbus
+
+import (
+	"strconv"
+	"strings"
+)
+
+// MatchOption specifies option for dbus routing match rule. Options can be constructed with WithMatch* helpers.
+// For full list of available options consult
+// https://dbus.freedesktop.org/doc/dbus-specification.html#message-bus-routing-match-rules
+type MatchOption struct {
+	key   string
+	value string
+}
+
+func formatMatchOptions(options []MatchOption) string {
+	items := make([]string, 0, len(options))
+	for _, option := range options {
+		items = append(items, option.key+"='"+option.value+"'")
+	}
+	return strings.Join(items, ",")
+}
+
+// WithMatchOption creates match option with given key and value
+func WithMatchOption(key, value string) MatchOption {
+	return MatchOption{key, value}
+}
+
+// It does not make sense to have a public WithMatchType function
+// because clients can only subscribe to messages with signal type.
+func withMatchTypeSignal() MatchOption {
+	return WithMatchOption("type", "signal")
+}
+
+// WithMatchSender sets sender match option.
+func WithMatchSender(sender string) MatchOption {
+	return WithMatchOption("sender", sender)
+}
+
+// WithMatchSender sets interface match option.
+func WithMatchInterface(iface string) MatchOption {
+	return WithMatchOption("interface", iface)
+}
+
+// WithMatchMember sets member match option.
+func WithMatchMember(member string) MatchOption {
+	return WithMatchOption("member", member)
+}
+
+// WithMatchObjectPath creates match option that filters events based on given path
+func WithMatchObjectPath(path ObjectPath) MatchOption {
+	return WithMatchOption("path", string(path))
+}
+
+// WithMatchPathNamespace sets path_namespace match option.
+func WithMatchPathNamespace(namespace ObjectPath) MatchOption {
+	return WithMatchOption("path_namespace", string(namespace))
+}
+
+// WithMatchDestination sets destination match option.
+func WithMatchDestination(destination string) MatchOption {
+	return WithMatchOption("destination", destination)
+}
+
+// WithMatchArg sets argN match option, range of N is 0 to 63.
+func WithMatchArg(argIdx int, value string) MatchOption {
+	if argIdx < 0 || argIdx > 63 {
+		panic("range of argument index is 0 to 63")
+	}
+	return WithMatchOption("arg"+strconv.Itoa(argIdx), value)
+}
+
+// WithMatchArgPath sets argN path match option, range of N is 0 to 63.
+func WithMatchArgPath(argIdx int, path string) MatchOption {
+	if argIdx < 0 || argIdx > 63 {
+		panic("range of argument index is 0 to 63")
+	}
+	return WithMatchOption("arg"+strconv.Itoa(argIdx)+"path", path)
+}
+
+// WithMatchArg0Namespace sets arg0namespace match option.
+func WithMatchArg0Namespace(arg0Namespace string) MatchOption {
+	return WithMatchOption("arg0namespace", arg0Namespace)
+}
+
+// WithMatchEavesdrop sets eavesdrop match option.
+func WithMatchEavesdrop(eavesdrop bool) MatchOption {
+	return WithMatchOption("eavesdrop", strconv.FormatBool(eavesdrop))
+}

--- a/vendor/github.com/godbus/dbus/v5/message.go
+++ b/vendor/github.com/godbus/dbus/v5/message.go
@@ -1,0 +1,393 @@
+package dbus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+)
+
+const protoVersion byte = 1
+
+// Flags represents the possible flags of a D-Bus message.
+type Flags byte
+
+const (
+	// FlagNoReplyExpected signals that the message is not expected to generate
+	// a reply. If this flag is set on outgoing messages, any possible reply
+	// will be discarded.
+	FlagNoReplyExpected Flags = 1 << iota
+	// FlagNoAutoStart signals that the message bus should not automatically
+	// start an application when handling this message.
+	FlagNoAutoStart
+	// FlagAllowInteractiveAuthorization may be set on a method call
+	// message to inform the receiving side that the caller is prepared
+	// to wait for interactive authorization, which might take a
+	// considerable time to complete. For instance, if this flag is set,
+	// it would be appropriate to query the user for passwords or
+	// confirmation via Polkit or a similar framework.
+	FlagAllowInteractiveAuthorization
+)
+
+// Type represents the possible types of a D-Bus message.
+type Type byte
+
+const (
+	TypeMethodCall Type = 1 + iota
+	TypeMethodReply
+	TypeError
+	TypeSignal
+	typeMax
+)
+
+func (t Type) String() string {
+	switch t {
+	case TypeMethodCall:
+		return "method call"
+	case TypeMethodReply:
+		return "reply"
+	case TypeError:
+		return "error"
+	case TypeSignal:
+		return "signal"
+	}
+	return "invalid"
+}
+
+// HeaderField represents the possible byte codes for the headers
+// of a D-Bus message.
+type HeaderField byte
+
+const (
+	FieldPath HeaderField = 1 + iota
+	FieldInterface
+	FieldMember
+	FieldErrorName
+	FieldReplySerial
+	FieldDestination
+	FieldSender
+	FieldSignature
+	FieldUnixFDs
+	fieldMax
+)
+
+// An InvalidMessageError describes the reason why a D-Bus message is regarded as
+// invalid.
+type InvalidMessageError string
+
+func (e InvalidMessageError) Error() string {
+	return "dbus: invalid message: " + string(e)
+}
+
+// fieldType are the types of the various header fields.
+var fieldTypes = [fieldMax]reflect.Type{
+	FieldPath:        objectPathType,
+	FieldInterface:   stringType,
+	FieldMember:      stringType,
+	FieldErrorName:   stringType,
+	FieldReplySerial: uint32Type,
+	FieldDestination: stringType,
+	FieldSender:      stringType,
+	FieldSignature:   signatureType,
+	FieldUnixFDs:     uint32Type,
+}
+
+// requiredFields lists the header fields that are required by the different
+// message types.
+var requiredFields = [typeMax][]HeaderField{
+	TypeMethodCall:  {FieldPath, FieldMember},
+	TypeMethodReply: {FieldReplySerial},
+	TypeError:       {FieldErrorName, FieldReplySerial},
+	TypeSignal:      {FieldPath, FieldInterface, FieldMember},
+}
+
+// Message represents a single D-Bus message.
+type Message struct {
+	Type
+	Flags
+	Headers map[HeaderField]Variant
+	Body    []any
+
+	serial uint32
+}
+
+type header struct {
+	Field byte
+	Variant
+}
+
+func DecodeMessageWithFDs(rd io.Reader, fds []int) (msg *Message, err error) {
+	var order binary.ByteOrder
+	var hlength, length uint32
+	var typ, flags, proto byte
+	var headers []header
+
+	b := make([]byte, 1)
+	_, err = rd.Read(b)
+	if err != nil {
+		return
+	}
+	switch b[0] {
+	case 'l':
+		order = binary.LittleEndian
+	case 'B':
+		order = binary.BigEndian
+	default:
+		return nil, InvalidMessageError("invalid byte order")
+	}
+
+	dec := newDecoder(rd, order, fds)
+	dec.pos = 1
+
+	msg = new(Message)
+	vs, err := dec.Decode(Signature{"yyyuu"})
+	if err != nil {
+		return nil, err
+	}
+	if err = Store(vs, &typ, &flags, &proto, &length, &msg.serial); err != nil {
+		return nil, err
+	}
+	msg.Type = Type(typ)
+	msg.Flags = Flags(flags)
+
+	// get the header length separately because we need it later
+	b = make([]byte, 4)
+	_, err = io.ReadFull(rd, b)
+	if err != nil {
+		return nil, err
+	}
+	if err := binary.Read(bytes.NewBuffer(b), order, &hlength); err != nil {
+		return nil, err
+	}
+	if hlength+length+16 > 1<<27 {
+		return nil, InvalidMessageError("message is too long")
+	}
+	dec = newDecoder(io.MultiReader(bytes.NewBuffer(b), rd), order, fds)
+	dec.pos = 12
+	vs, err = dec.Decode(Signature{"a(yv)"})
+	if err != nil {
+		return nil, err
+	}
+	if err = Store(vs, &headers); err != nil {
+		return nil, err
+	}
+
+	msg.Headers = make(map[HeaderField]Variant)
+	for _, v := range headers {
+		msg.Headers[HeaderField(v.Field)] = v.Variant
+	}
+
+	dec.align(8)
+	body := make([]byte, int(length))
+	if length != 0 {
+		_, err := io.ReadFull(rd, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err = msg.validateHeader(); err != nil {
+		return nil, err
+	}
+	sig, _ := msg.Headers[FieldSignature].value.(Signature)
+	if sig.str != "" {
+		buf := bytes.NewBuffer(body)
+		dec = newDecoder(buf, order, fds)
+		vs, err := dec.Decode(sig)
+		if err != nil {
+			return nil, err
+		}
+		msg.Body = vs
+	}
+
+	return
+}
+
+// DecodeMessage tries to decode a single message in the D-Bus wire format
+// from the given reader. The byte order is figured out from the first byte.
+// The possibly returned error can be an error of the underlying reader, an
+// InvalidMessageError or a FormatError.
+func DecodeMessage(rd io.Reader) (msg *Message, err error) {
+	return DecodeMessageWithFDs(rd, make([]int, 0))
+}
+
+type nullwriter struct{}
+
+func (nullwriter) Write(p []byte) (cnt int, err error) {
+	return len(p), nil
+}
+
+func (msg *Message) CountFds() (int, error) {
+	if len(msg.Body) == 0 {
+		return 0, nil
+	}
+	enc := newEncoder(nullwriter{}, nativeEndian, make([]int, 0))
+	err := enc.Encode(msg.Body...)
+	return len(enc.fds), err
+}
+
+func (msg *Message) EncodeToWithFDs(out io.Writer, order binary.ByteOrder) (fds []int, err error) {
+	if err := msg.validateHeader(); err != nil {
+		return nil, err
+	}
+	var vs [7]any
+	switch order {
+	case binary.LittleEndian:
+		vs[0] = byte('l')
+	case binary.BigEndian:
+		vs[0] = byte('B')
+	default:
+		return nil, errors.New("dbus: invalid byte order")
+	}
+	body := new(bytes.Buffer)
+	fds = make([]int, 0)
+	enc := newEncoder(body, order, fds)
+	if len(msg.Body) != 0 {
+		err = enc.Encode(msg.Body...)
+		if err != nil {
+			return
+		}
+	}
+	vs[1] = msg.Type
+	vs[2] = msg.Flags
+	vs[3] = protoVersion
+	vs[4] = uint32(len(body.Bytes()))
+	vs[5] = msg.serial
+	headers := make([]header, 0, len(msg.Headers))
+	for k, v := range msg.Headers {
+		headers = append(headers, header{byte(k), v})
+	}
+	vs[6] = headers
+	var buf bytes.Buffer
+	enc = newEncoder(&buf, order, enc.fds)
+	err = enc.Encode(vs[:]...)
+	if err != nil {
+		return
+	}
+	enc.align(8)
+	if _, err := body.WriteTo(&buf); err != nil {
+		return nil, err
+	}
+	if buf.Len() > 1<<27 {
+		return nil, InvalidMessageError("message is too long")
+	}
+	if _, err := buf.WriteTo(out); err != nil {
+		return nil, err
+	}
+	return enc.fds, nil
+}
+
+// EncodeTo encodes and sends a message to the given writer. The byte order must
+// be either binary.LittleEndian or binary.BigEndian. If the message is not
+// valid or an error occurs when writing, an error is returned.
+func (msg *Message) EncodeTo(out io.Writer, order binary.ByteOrder) (err error) {
+	_, err = msg.EncodeToWithFDs(out, order)
+	return err
+}
+
+// IsValid checks whether msg is a valid message and returns an
+// InvalidMessageError or FormatError if it is not.
+func (msg *Message) IsValid() error {
+	return msg.EncodeTo(io.Discard, nativeEndian)
+}
+
+func (msg *Message) validateHeader() error {
+	if msg.Flags & ^(FlagNoAutoStart|FlagNoReplyExpected|FlagAllowInteractiveAuthorization) != 0 {
+		return InvalidMessageError("invalid flags")
+	}
+	if msg.Type == 0 || msg.Type >= typeMax {
+		return InvalidMessageError("invalid message type")
+	}
+	for k, v := range msg.Headers {
+		if k == 0 || k >= fieldMax {
+			return InvalidMessageError("invalid header")
+		}
+		if reflect.TypeOf(v.value) != fieldTypes[k] {
+			return InvalidMessageError("invalid type of header field")
+		}
+	}
+	for _, v := range requiredFields[msg.Type] {
+		if _, ok := msg.Headers[v]; !ok {
+			return InvalidMessageError("missing required header")
+		}
+	}
+	if path, ok := msg.Headers[FieldPath]; ok {
+		if !path.value.(ObjectPath).IsValid() {
+			return InvalidMessageError("invalid path name")
+		}
+	}
+	if iface, ok := msg.Headers[FieldInterface]; ok {
+		if !isValidInterface(iface.value.(string)) {
+			return InvalidMessageError("invalid interface name")
+		}
+	}
+	if member, ok := msg.Headers[FieldMember]; ok {
+		if !isValidMember(member.value.(string)) {
+			return InvalidMessageError("invalid member name")
+		}
+	}
+	if errname, ok := msg.Headers[FieldErrorName]; ok {
+		if !isValidInterface(errname.value.(string)) {
+			return InvalidMessageError("invalid error name")
+		}
+	}
+	if len(msg.Body) != 0 {
+		if _, ok := msg.Headers[FieldSignature]; !ok {
+			return InvalidMessageError("missing signature")
+		}
+	}
+
+	return nil
+}
+
+// Serial returns the message's serial number. The returned value is only valid
+// for messages received by eavesdropping.
+func (msg *Message) Serial() uint32 {
+	return msg.serial
+}
+
+// String returns a string representation of a message similar to the format of
+// dbus-monitor.
+func (msg *Message) String() string {
+	if err := msg.IsValid(); err != nil {
+		return "<invalid>"
+	}
+	s := msg.Type.String()
+	if v, ok := msg.Headers[FieldSender]; ok {
+		s += " from " + v.value.(string)
+	}
+	if v, ok := msg.Headers[FieldDestination]; ok {
+		s += " to " + v.value.(string)
+	}
+	s += " serial " + strconv.FormatUint(uint64(msg.serial), 10)
+	if v, ok := msg.Headers[FieldReplySerial]; ok {
+		s += " reply_serial " + strconv.FormatUint(uint64(v.value.(uint32)), 10)
+	}
+	if v, ok := msg.Headers[FieldUnixFDs]; ok {
+		s += " unixfds " + strconv.FormatUint(uint64(v.value.(uint32)), 10)
+	}
+	if v, ok := msg.Headers[FieldPath]; ok {
+		s += " path " + string(v.value.(ObjectPath))
+	}
+	if v, ok := msg.Headers[FieldInterface]; ok {
+		s += " interface " + v.value.(string)
+	}
+	if v, ok := msg.Headers[FieldErrorName]; ok {
+		s += " error " + v.value.(string)
+	}
+	if v, ok := msg.Headers[FieldMember]; ok {
+		s += " member " + v.value.(string)
+	}
+	if len(msg.Body) != 0 {
+		s += "\n"
+	}
+	for i, v := range msg.Body {
+		s += "  " + MakeVariant(v).String()
+		if i != len(msg.Body)-1 {
+			s += "\n"
+		}
+	}
+	return s
+}

--- a/vendor/github.com/godbus/dbus/v5/object.go
+++ b/vendor/github.com/godbus/dbus/v5/object.go
@@ -1,0 +1,181 @@
+package dbus
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// BusObject is the interface of a remote object on which methods can be
+// invoked.
+type BusObject interface {
+	Call(method string, flags Flags, args ...any) *Call
+	CallWithContext(ctx context.Context, method string, flags Flags, args ...any) *Call
+	Go(method string, flags Flags, ch chan *Call, args ...any) *Call
+	GoWithContext(ctx context.Context, method string, flags Flags, ch chan *Call, args ...any) *Call
+	AddMatchSignal(iface, member string, options ...MatchOption) *Call
+	RemoveMatchSignal(iface, member string, options ...MatchOption) *Call
+	GetProperty(p string) (Variant, error)
+	StoreProperty(p string, value any) error
+	SetProperty(p string, v any) error
+	Destination() string
+	Path() ObjectPath
+}
+
+// Object represents a remote object on which methods can be invoked.
+type Object struct {
+	conn *Conn
+	dest string
+	path ObjectPath
+}
+
+// Call calls a method with (*Object).Go and waits for its reply.
+func (o *Object) Call(method string, flags Flags, args ...any) *Call {
+	return <-o.createCall(context.Background(), method, flags, make(chan *Call, 1), args...).Done
+}
+
+// CallWithContext acts like Call but takes a context
+func (o *Object) CallWithContext(ctx context.Context, method string, flags Flags, args ...any) *Call {
+	return <-o.createCall(ctx, method, flags, make(chan *Call, 1), args...).Done
+}
+
+// AddMatchSignal subscribes BusObject to signals from specified interface,
+// method (member). Additional filter rules can be added via WithMatch* option constructors.
+// Note: To filter events by object path you have to specify this path via an option.
+//
+// Deprecated: use (*Conn) AddMatchSignal instead.
+func (o *Object) AddMatchSignal(iface, member string, options ...MatchOption) *Call {
+	base := []MatchOption{
+		withMatchTypeSignal(),
+		WithMatchInterface(iface),
+		WithMatchMember(member),
+	}
+
+	options = append(base, options...)
+	return o.conn.BusObject().Call(
+		"org.freedesktop.DBus.AddMatch",
+		0,
+		formatMatchOptions(options),
+	)
+}
+
+// RemoveMatchSignal unsubscribes BusObject from signals from specified interface,
+// method (member). Additional filter rules can be added via WithMatch* option constructors
+//
+// Deprecated: use (*Conn) RemoveMatchSignal instead.
+func (o *Object) RemoveMatchSignal(iface, member string, options ...MatchOption) *Call {
+	base := []MatchOption{
+		withMatchTypeSignal(),
+		WithMatchInterface(iface),
+		WithMatchMember(member),
+	}
+
+	options = append(base, options...)
+	return o.conn.BusObject().Call(
+		"org.freedesktop.DBus.RemoveMatch",
+		0,
+		formatMatchOptions(options),
+	)
+}
+
+// Go calls a method with the given arguments asynchronously. It returns a
+// Call structure representing this method call. The passed channel will
+// return the same value once the call is done. If ch is nil, a new channel
+// will be allocated. Otherwise, ch has to be buffered or Go will panic.
+//
+// If the flags include FlagNoReplyExpected, ch is ignored and a Call structure
+// is returned with any error in Err and a closed channel in Done containing
+// the returned Call as it's one entry.
+//
+// If the method parameter contains a dot ('.'), the part before the last dot
+// specifies the interface on which the method is called.
+func (o *Object) Go(method string, flags Flags, ch chan *Call, args ...any) *Call {
+	return o.createCall(context.Background(), method, flags, ch, args...)
+}
+
+// GoWithContext acts like Go but takes a context
+func (o *Object) GoWithContext(ctx context.Context, method string, flags Flags, ch chan *Call, args ...any) *Call {
+	return o.createCall(ctx, method, flags, ch, args...)
+}
+
+func (o *Object) createCall(ctx context.Context, method string, flags Flags, ch chan *Call, args ...any) *Call {
+	if ctx == nil {
+		panic("nil context")
+	}
+	iface := ""
+	i := strings.LastIndex(method, ".")
+	if i != -1 {
+		iface = method[:i]
+	}
+	method = method[i+1:]
+	msg := new(Message)
+	msg.Type = TypeMethodCall
+	msg.Flags = flags & (FlagNoAutoStart | FlagNoReplyExpected)
+	msg.Headers = make(map[HeaderField]Variant)
+	msg.Headers[FieldPath] = MakeVariant(o.path)
+	msg.Headers[FieldDestination] = MakeVariant(o.dest)
+	msg.Headers[FieldMember] = MakeVariant(method)
+	if iface != "" {
+		msg.Headers[FieldInterface] = MakeVariant(iface)
+	}
+	msg.Body = args
+	if len(args) > 0 {
+		msg.Headers[FieldSignature] = MakeVariant(SignatureOf(args...))
+	}
+	return o.conn.SendWithContext(ctx, msg, ch)
+}
+
+// GetProperty calls org.freedesktop.DBus.Properties.Get on the given
+// object. The property name must be given in interface.member notation.
+func (o *Object) GetProperty(p string) (Variant, error) {
+	var result Variant
+	err := o.StoreProperty(p, &result)
+	return result, err
+}
+
+// StoreProperty calls org.freedesktop.DBus.Properties.Get on the given
+// object. The property name must be given in interface.member notation.
+// It stores the returned property into the provided value.
+func (o *Object) StoreProperty(p string, value any) error {
+	idx := strings.LastIndex(p, ".")
+	if idx == -1 || idx+1 == len(p) {
+		return errors.New("dbus: invalid property " + p)
+	}
+
+	iface := p[:idx]
+	prop := p[idx+1:]
+
+	return o.Call("org.freedesktop.DBus.Properties.Get", 0, iface, prop).
+		Store(value)
+}
+
+// SetProperty calls org.freedesktop.DBus.Properties.Set on the given
+// object. The property name must be given in interface.member notation.
+// Panics if v is not a valid Variant type.
+func (o *Object) SetProperty(p string, v any) error {
+	// v might already be a variant...
+	variant, ok := v.(Variant)
+	if !ok {
+		// Otherwise, make it into one.
+		variant = MakeVariant(v)
+	}
+	idx := strings.LastIndex(p, ".")
+	if idx == -1 || idx+1 == len(p) {
+		return errors.New("dbus: invalid property " + p)
+	}
+
+	iface := p[:idx]
+	prop := p[idx+1:]
+
+	return o.Call("org.freedesktop.DBus.Properties.Set", 0, iface, prop, variant).Err
+}
+
+// Destination returns the destination that calls on (o *Object) are sent to.
+func (o *Object) Destination() string {
+	return o.dest
+}
+
+// Path returns the path that calls on (o *Object") are sent to.
+func (o *Object) Path() ObjectPath {
+	return o.path
+}

--- a/vendor/github.com/godbus/dbus/v5/sequence.go
+++ b/vendor/github.com/godbus/dbus/v5/sequence.go
@@ -1,0 +1,24 @@
+package dbus
+
+// Sequence represents the value of a monotonically increasing counter.
+type Sequence uint64
+
+const (
+	// NoSequence indicates the absence of a sequence value.
+	NoSequence Sequence = 0
+)
+
+// sequenceGenerator represents a monotonically increasing counter.
+type sequenceGenerator struct {
+	nextSequence Sequence
+}
+
+func (generator *sequenceGenerator) next() Sequence {
+	result := generator.nextSequence
+	generator.nextSequence++
+	return result
+}
+
+func newSequenceGenerator() *sequenceGenerator {
+	return &sequenceGenerator{nextSequence: 1}
+}

--- a/vendor/github.com/godbus/dbus/v5/sequential_handler.go
+++ b/vendor/github.com/godbus/dbus/v5/sequential_handler.go
@@ -1,0 +1,125 @@
+package dbus
+
+import (
+	"sync"
+)
+
+// NewSequentialSignalHandler returns an instance of a new
+// signal handler that guarantees sequential processing of signals. It is a
+// guarantee of this signal handler that signals will be written to
+// channels in the order they are received on the DBus connection.
+func NewSequentialSignalHandler() SignalHandler {
+	return &sequentialSignalHandler{}
+}
+
+type sequentialSignalHandler struct {
+	mu      sync.RWMutex
+	closed  bool
+	signals []*sequentialSignalChannelData
+}
+
+func (sh *sequentialSignalHandler) DeliverSignal(intf, name string, signal *Signal) {
+	sh.mu.RLock()
+	defer sh.mu.RUnlock()
+	if sh.closed {
+		return
+	}
+	for _, scd := range sh.signals {
+		scd.deliver(signal)
+	}
+}
+
+func (sh *sequentialSignalHandler) Terminate() {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+
+	for _, scd := range sh.signals {
+		scd.close()
+		close(scd.ch)
+	}
+	sh.closed = true
+	sh.signals = nil
+}
+
+func (sh *sequentialSignalHandler) AddSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	sh.signals = append(sh.signals, newSequentialSignalChannelData(ch))
+}
+
+func (sh *sequentialSignalHandler) RemoveSignal(ch chan<- *Signal) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+	if sh.closed {
+		return
+	}
+	for i := len(sh.signals) - 1; i >= 0; i-- {
+		if ch == sh.signals[i].ch {
+			sh.signals[i].close()
+			copy(sh.signals[i:], sh.signals[i+1:])
+			sh.signals[len(sh.signals)-1] = nil
+			sh.signals = sh.signals[:len(sh.signals)-1]
+		}
+	}
+}
+
+type sequentialSignalChannelData struct {
+	ch   chan<- *Signal
+	in   chan *Signal
+	done chan struct{}
+}
+
+func newSequentialSignalChannelData(ch chan<- *Signal) *sequentialSignalChannelData {
+	scd := &sequentialSignalChannelData{
+		ch:   ch,
+		in:   make(chan *Signal),
+		done: make(chan struct{}),
+	}
+	go scd.bufferSignals()
+	return scd
+}
+
+func (scd *sequentialSignalChannelData) bufferSignals() {
+	defer close(scd.done)
+
+	// Ensure that signals are delivered to scd.ch in the same
+	// order they are received from scd.in.
+	var queue []*Signal
+	for {
+		if len(queue) == 0 {
+			signal, ok := <-scd.in
+			if !ok {
+				return
+			}
+			queue = append(queue, signal)
+		}
+		select {
+		case scd.ch <- queue[0]:
+			copy(queue, queue[1:])
+			queue[len(queue)-1] = nil
+			queue = queue[:len(queue)-1]
+		case signal, ok := <-scd.in:
+			if !ok {
+				return
+			}
+			queue = append(queue, signal)
+		}
+	}
+}
+
+func (scd *sequentialSignalChannelData) deliver(signal *Signal) {
+	scd.in <- signal
+}
+
+func (scd *sequentialSignalChannelData) close() {
+	close(scd.in)
+	// Ensure that bufferSignals() has exited and won't attempt
+	// any future sends on scd.ch
+	<-scd.done
+}

--- a/vendor/github.com/godbus/dbus/v5/server_interfaces.go
+++ b/vendor/github.com/godbus/dbus/v5/server_interfaces.go
@@ -1,0 +1,107 @@
+package dbus
+
+// Terminator allows a handler to implement a shutdown mechanism that
+// is called when the connection terminates.
+type Terminator interface {
+	Terminate()
+}
+
+// Handler is the representation of a D-Bus Application.
+//
+// The Handler must have a way to lookup objects given
+// an ObjectPath. The returned object must implement the
+// ServerObject interface.
+type Handler interface {
+	LookupObject(path ObjectPath) (ServerObject, bool)
+}
+
+// ServerObject is the representation of an D-Bus Object.
+//
+// Objects are registered at a path for a given Handler.
+// The Objects implement D-Bus interfaces. The semantics
+// of Interface lookup is up to the implementation of
+// the ServerObject. The ServerObject implementation may
+// choose to implement empty string as a valid interface
+// representing all methods or not per the D-Bus specification.
+type ServerObject interface {
+	LookupInterface(name string) (Interface, bool)
+}
+
+// An Interface is the representation of a D-Bus Interface.
+//
+// Interfaces are a grouping of methods implemented by the Objects.
+// Interfaces are responsible for routing method calls.
+type Interface interface {
+	LookupMethod(name string) (Method, bool)
+}
+
+// A Method represents the exposed methods on D-Bus.
+type Method interface {
+	// Call requires that all arguments are decoded before being passed to it.
+	Call(args ...any) ([]any, error)
+	NumArguments() int
+	NumReturns() int
+	// ArgumentValue returns a representative value for the argument at position
+	// it should be of the proper type. reflect.Zero would be a good mechanism
+	// to use for this Value.
+	ArgumentValue(position int) any
+	// ReturnValue returns a representative value for the return at position
+	// it should be of the proper type. reflect.Zero would be a good mechanism
+	// to use for this Value.
+	ReturnValue(position int) any
+}
+
+// An Argument Decoder can decode arguments using the non-standard mechanism
+//
+// If a method implements this interface then the non-standard
+// decoder will be used.
+//
+// Method arguments must be decoded from the message.
+// The mechanism for doing this will vary based on the
+// implementation of the method. A normal approach is provided
+// as part of this library, but may be replaced with
+// any other decoding scheme.
+type ArgumentDecoder interface {
+	// To decode the arguments of a method the sender and message are
+	// provided in case the semantics of the implementer provides access
+	// to these as part of the method invocation.
+	DecodeArguments(conn *Conn, sender string, msg *Message, args []any) ([]any, error)
+}
+
+// A SignalHandler is responsible for delivering a signal.
+//
+// Signal delivery may be changed from the default channel
+// based approach by Handlers implementing the SignalHandler
+// interface.
+type SignalHandler interface {
+	DeliverSignal(iface, name string, signal *Signal)
+}
+
+// SignalRegistrar manages signal delivery channels.
+//
+// This is an optional set of methods for `SignalHandler`.
+type SignalRegistrar interface {
+	AddSignal(ch chan<- *Signal)
+	RemoveSignal(ch chan<- *Signal)
+}
+
+// A DBusError is used to convert a generic object to a D-Bus error.
+//
+// Any custom error mechanism may implement this interface to provide
+// a custom encoding of the error on D-Bus. By default if a normal
+// error is returned, it will be encoded as the generic
+// "org.freedesktop.DBus.Error.Failed" error. By implementing this
+// interface as well a custom encoding may be provided.
+type DBusError interface {
+	DBusError() (string, []any)
+}
+
+// SerialGenerator is responsible for serials generation.
+//
+// Different approaches for the serial generation can be used,
+// maintaining a map guarded with a mutex (the standard way) or
+// simply increment an atomic counter.
+type SerialGenerator interface {
+	GetSerial() uint32
+	RetireSerial(serial uint32)
+}

--- a/vendor/github.com/godbus/dbus/v5/sig.go
+++ b/vendor/github.com/godbus/dbus/v5/sig.go
@@ -1,0 +1,298 @@
+package dbus
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var sigToType = map[byte]reflect.Type{
+	'y': byteType,
+	'b': boolType,
+	'n': int16Type,
+	'q': uint16Type,
+	'i': int32Type,
+	'u': uint32Type,
+	'x': int64Type,
+	't': uint64Type,
+	'd': float64Type,
+	's': stringType,
+	'g': signatureType,
+	'o': objectPathType,
+	'v': variantType,
+	'h': unixFDIndexType,
+}
+
+// Signature represents a correct type signature as specified by the D-Bus
+// specification. The zero value represents the empty signature, "".
+type Signature struct {
+	str string
+}
+
+// SignatureOf returns the concatenation of all the signatures of the given
+// values. It panics if one of them is not representable in D-Bus.
+func SignatureOf(vs ...any) Signature {
+	var s string
+	for _, v := range vs {
+		s += getSignature(reflect.TypeOf(v), &depthCounter{})
+	}
+	return Signature{s}
+}
+
+// SignatureOfType returns the signature of the given type. It panics if the
+// type is not representable in D-Bus.
+func SignatureOfType(t reflect.Type) Signature {
+	return Signature{getSignature(t, &depthCounter{})}
+}
+
+// getSignature returns the signature of the given type and panics on unknown types.
+func getSignature(t reflect.Type, depth *depthCounter) (sig string) {
+	if !depth.Valid() {
+		panic("container nesting too deep")
+	}
+	defer func() {
+		if len(sig) > 255 {
+			panic("signature exceeds the length limitation")
+		}
+	}()
+	// handle simple types first
+	switch t.Kind() {
+	case reflect.Uint8:
+		return "y"
+	case reflect.Bool:
+		return "b"
+	case reflect.Int16:
+		return "n"
+	case reflect.Uint16:
+		return "q"
+	case reflect.Int, reflect.Int32:
+		if t == unixFDType {
+			return "h"
+		}
+		return "i"
+	case reflect.Uint, reflect.Uint32:
+		if t == unixFDIndexType {
+			return "h"
+		}
+		return "u"
+	case reflect.Int64:
+		return "x"
+	case reflect.Uint64:
+		return "t"
+	case reflect.Float64:
+		return "d"
+	case reflect.Ptr:
+		return getSignature(t.Elem(), depth)
+	case reflect.String:
+		if t == objectPathType {
+			return "o"
+		}
+		return "s"
+	case reflect.Struct:
+		switch t {
+		case variantType:
+			return "v"
+		case signatureType:
+			return "g"
+		}
+		var s string
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			if field.PkgPath == "" && field.Tag.Get("dbus") != "-" {
+				s += getSignature(t.Field(i).Type, depth.EnterStruct())
+			}
+		}
+		if len(s) == 0 {
+			panic(InvalidTypeError{t})
+		}
+		return "(" + s + ")"
+	case reflect.Array, reflect.Slice:
+		return "a" + getSignature(t.Elem(), depth.EnterArray())
+	case reflect.Map:
+		if !isKeyType(t.Key()) {
+			panic(InvalidTypeError{t})
+		}
+		return "a{" + getSignature(t.Key(), depth.EnterArray().EnterDictEntry()) + getSignature(t.Elem(), depth.EnterArray().EnterDictEntry()) + "}"
+	case reflect.Interface:
+		return "v"
+	}
+	panic(InvalidTypeError{t})
+}
+
+// ParseSignature returns the signature represented by this string, or a
+// SignatureError if the string is not a valid signature.
+func ParseSignature(s string) (sig Signature, err error) {
+	if len(s) == 0 {
+		return
+	}
+	if len(s) > 255 {
+		return Signature{""}, SignatureError{s, "too long"}
+	}
+	sig.str = s
+	for err == nil && len(s) != 0 {
+		err, s = validSingle(s, &depthCounter{})
+	}
+	if err != nil {
+		sig = Signature{""}
+	}
+
+	return
+}
+
+// ParseSignatureMust behaves like ParseSignature, except that it panics if s
+// is not valid.
+func ParseSignatureMust(s string) Signature {
+	sig, err := ParseSignature(s)
+	if err != nil {
+		panic(err)
+	}
+	return sig
+}
+
+// Empty returns whether the signature is the empty signature.
+func (s Signature) Empty() bool {
+	return s.str == ""
+}
+
+// Single returns whether the signature represents a single, complete type.
+func (s Signature) Single() bool {
+	err, r := validSingle(s.str, &depthCounter{})
+	return err != nil && r == ""
+}
+
+// String returns the signature's string representation.
+func (s Signature) String() string {
+	return s.str
+}
+
+// A SignatureError indicates that a signature passed to a function or received
+// on a connection is not a valid signature.
+type SignatureError struct {
+	Sig    string
+	Reason string
+}
+
+func (e SignatureError) Error() string {
+	return fmt.Sprintf("dbus: invalid signature: %q (%s)", e.Sig, e.Reason)
+}
+
+type depthCounter struct {
+	arrayDepth, structDepth, dictEntryDepth int
+}
+
+func (cnt *depthCounter) Valid() bool {
+	return cnt.arrayDepth <= 32 && cnt.structDepth <= 32 && cnt.dictEntryDepth <= 32
+}
+
+func (cnt depthCounter) EnterArray() *depthCounter {
+	cnt.arrayDepth++
+	return &cnt
+}
+
+func (cnt depthCounter) EnterStruct() *depthCounter {
+	cnt.structDepth++
+	return &cnt
+}
+
+func (cnt depthCounter) EnterDictEntry() *depthCounter {
+	cnt.dictEntryDepth++
+	return &cnt
+}
+
+// Try to read a single type from this string. If it was successful, err is nil
+// and rem is the remaining unparsed part. Otherwise, err is a non-nil
+// SignatureError and rem is "". depth is the current recursion depth which may
+// not be greater than 64 and should be given as 0 on the first call.
+func validSingle(s string, depth *depthCounter) (err error, rem string) { //nolint:staticcheck // Ignore "ST1008: error should be returned as the last argument".
+	if s == "" {
+		return SignatureError{Sig: s, Reason: "empty signature"}, ""
+	}
+	if !depth.Valid() {
+		return SignatureError{Sig: s, Reason: "container nesting too deep"}, ""
+	}
+	switch s[0] {
+	case 'y', 'b', 'n', 'q', 'i', 'u', 'x', 't', 'd', 's', 'g', 'o', 'v', 'h':
+		return nil, s[1:]
+	case 'a':
+		if len(s) > 1 && s[1] == '{' {
+			i := findMatching(s[1:], '{', '}')
+			if i == -1 {
+				return SignatureError{Sig: s, Reason: "unmatched '{'"}, ""
+			}
+			i++
+			rem = s[i+1:]
+			s = s[2:i]
+			if len(s) == 0 {
+				return SignatureError{Sig: s, Reason: "empty dict"}, ""
+			}
+			if err, _ = validSingle(s[:1], depth.EnterArray().EnterDictEntry()); err != nil {
+				return err, ""
+			}
+			err, nr := validSingle(s[1:], depth.EnterArray().EnterDictEntry())
+			if err != nil {
+				return err, ""
+			}
+			if nr != "" {
+				return SignatureError{Sig: s, Reason: "too many types in dict"}, ""
+			}
+			return nil, rem
+		}
+		return validSingle(s[1:], depth.EnterArray())
+	case '(':
+		i := findMatching(s, '(', ')')
+		if i == -1 {
+			return SignatureError{Sig: s, Reason: "unmatched ')'"}, ""
+		}
+		rem = s[i+1:]
+		s = s[1:i]
+		for err == nil && s != "" {
+			err, s = validSingle(s, depth.EnterStruct())
+		}
+		if err != nil {
+			rem = ""
+		}
+		return
+	}
+	return SignatureError{Sig: s, Reason: "invalid type character"}, ""
+}
+
+func findMatching(s string, left, right rune) int {
+	n := 0
+	for i, v := range s {
+		switch v {
+		case left:
+			n++
+		case right:
+			n--
+		}
+		if n == 0 {
+			return i
+		}
+	}
+	return -1
+}
+
+// typeFor returns the type of the given signature. It ignores any left over
+// characters and panics if s doesn't start with a valid type signature.
+func typeFor(s string) (t reflect.Type) {
+	err, _ := validSingle(s, &depthCounter{})
+	if err != nil {
+		panic(err)
+	}
+
+	if t, ok := sigToType[s[0]]; ok {
+		return t
+	}
+	switch s[0] {
+	case 'a':
+		if s[1] == '{' {
+			i := strings.LastIndex(s, "}")
+			t = reflect.MapOf(sigToType[s[2]], typeFor(s[3:i]))
+		} else {
+			t = reflect.SliceOf(typeFor(s[1:]))
+		}
+	case '(':
+		t = interfacesType
+	}
+	return
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_darwin.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_darwin.go
@@ -1,0 +1,6 @@
+package dbus
+
+func (t *unixTransport) SendNullByte() error {
+	_, err := t.Write([]byte{0})
+	return err
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_generic.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_generic.go
@@ -1,0 +1,52 @@
+package dbus
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"unsafe"
+)
+
+var nativeEndian binary.ByteOrder
+
+func detectEndianness() binary.ByteOrder {
+	var x uint32 = 0x01020304
+	if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
+}
+
+func init() {
+	nativeEndian = detectEndianness()
+}
+
+type genericTransport struct {
+	io.ReadWriteCloser
+}
+
+func (t genericTransport) SendNullByte() error {
+	_, err := t.Write([]byte{0})
+	return err
+}
+
+func (t genericTransport) SupportsUnixFDs() bool {
+	return false
+}
+
+func (t genericTransport) EnableUnixFDs() {}
+
+func (t genericTransport) ReadMessage() (*Message, error) {
+	return DecodeMessage(t)
+}
+
+func (t genericTransport) SendMessage(msg *Message) error {
+	fds, err := msg.CountFds()
+	if err != nil {
+		return err
+	}
+	if fds != 0 {
+		return errors.New("dbus: unix fd passing not enabled")
+	}
+	return msg.EncodeTo(t, nativeEndian)
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_nonce_tcp.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_nonce_tcp.go
@@ -1,0 +1,41 @@
+//go:build !windows
+
+package dbus
+
+import (
+	"errors"
+	"net"
+	"os"
+)
+
+func init() {
+	transports["nonce-tcp"] = newNonceTcpTransport
+}
+
+func newNonceTcpTransport(keys string) (transport, error) {
+	host := getKey(keys, "host")
+	port := getKey(keys, "port")
+	noncefile := getKey(keys, "noncefile")
+	if host == "" || port == "" || noncefile == "" {
+		return nil, errors.New("dbus: unsupported address (must set host, port and noncefile)")
+	}
+	protocol, err := tcpFamily(keys)
+	if err != nil {
+		return nil, err
+	}
+	socket, err := net.Dial(protocol, net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(noncefile)
+	if err != nil {
+		socket.Close()
+		return nil, err
+	}
+	_, err = socket.Write(b)
+	if err != nil {
+		socket.Close()
+		return nil, err
+	}
+	return NewConn(socket)
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_tcp.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_tcp.go
@@ -1,0 +1,41 @@
+package dbus
+
+import (
+	"errors"
+	"net"
+)
+
+func init() {
+	transports["tcp"] = newTcpTransport
+}
+
+func tcpFamily(keys string) (string, error) {
+	switch getKey(keys, "family") {
+	case "":
+		return "tcp", nil
+	case "ipv4":
+		return "tcp4", nil
+	case "ipv6":
+		return "tcp6", nil
+	default:
+		return "", errors.New("dbus: invalid tcp family (must be ipv4 or ipv6)")
+	}
+}
+
+func newTcpTransport(keys string) (transport, error) {
+	host := getKey(keys, "host")
+	port := getKey(keys, "port")
+	if host == "" || port == "" {
+		return nil, errors.New("dbus: unsupported address (must set host and port)")
+	}
+
+	protocol, err := tcpFamily(keys)
+	if err != nil {
+		return nil, err
+	}
+	socket, err := net.Dial(protocol, net.JoinHostPort(host, port))
+	if err != nil {
+		return nil, err
+	}
+	return NewConn(socket)
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unix.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unix.go
@@ -1,0 +1,291 @@
+//go:build !windows && !solaris
+
+package dbus
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+)
+
+// msghead represents the part of the message header
+// that has a constant size (byte order + 15 bytes).
+type msghead struct {
+	Type      Type
+	Flags     Flags
+	Proto     byte
+	BodyLen   uint32
+	Serial    uint32
+	HeaderLen uint32
+}
+
+type oobReader struct {
+	conn *net.UnixConn
+	oob  []byte
+	buf  [4096]byte
+
+	// The following fields are used to reduce memory allocs.
+	headers  []header
+	csheader []byte
+	b        *bytes.Buffer
+	r        *bytes.Reader
+	dec      *decoder
+	msghead
+}
+
+func (o *oobReader) Read(b []byte) (n int, err error) {
+	n, oobn, flags, _, err := o.conn.ReadMsgUnix(b, o.buf[:])
+	if err != nil {
+		return n, err
+	}
+	if flags&syscall.MSG_CTRUNC != 0 {
+		return n, errors.New("dbus: control data truncated (too many fds received)")
+	}
+	o.oob = append(o.oob, o.buf[:oobn]...)
+	return n, nil
+}
+
+type unixTransport struct {
+	*net.UnixConn
+	rdr        *oobReader
+	hasUnixFDs bool
+}
+
+func newUnixTransportFromConn(conn *net.UnixConn) transport {
+	t := new(unixTransport)
+	t.UnixConn = conn
+	t.hasUnixFDs = true
+
+	return t
+}
+
+func newUnixTransport(keys string) (transport, error) {
+	var err error
+
+	t := new(unixTransport)
+	abstract := getKey(keys, "abstract")
+	path := getKey(keys, "path")
+	switch {
+	case abstract == "" && path == "":
+		return nil, errors.New("dbus: invalid address (neither path nor abstract set)")
+	case abstract != "" && path == "":
+		t.UnixConn, err = net.DialUnix("unix", nil, &net.UnixAddr{Name: "@" + abstract, Net: "unix"})
+		if err != nil {
+			return nil, err
+		}
+		return t, nil
+	case abstract == "" && path != "":
+		t.UnixConn, err = net.DialUnix("unix", nil, &net.UnixAddr{Name: path, Net: "unix"})
+		if err != nil {
+			return nil, err
+		}
+		return t, nil
+	default:
+		return nil, errors.New("dbus: invalid address (both path and abstract set)")
+	}
+}
+
+func init() {
+	transports["unix"] = newUnixTransport
+}
+
+func (t *unixTransport) EnableUnixFDs() {
+	t.hasUnixFDs = true
+}
+
+func (t *unixTransport) ReadMessage() (*Message, error) {
+	// To be sure that all bytes of out-of-band data are read, we use a special
+	// reader that uses ReadUnix on the underlying connection instead of Read
+	// and gathers the out-of-band data in a buffer.
+	if t.rdr == nil {
+		t.rdr = &oobReader{
+			conn: t.UnixConn,
+			// This buffer is used to decode the part of the header that has a constant size.
+			csheader: make([]byte, 16),
+			b:        &bytes.Buffer{},
+			// The reader helps to read from the buffer several times.
+			r:   &bytes.Reader{},
+			dec: &decoder{},
+		}
+	} else {
+		t.rdr.oob = t.rdr.oob[:0]
+		t.rdr.headers = t.rdr.headers[:0]
+	}
+	var (
+		r   = t.rdr.r
+		b   = t.rdr.b
+		dec = t.rdr.dec
+	)
+
+	_, err := io.ReadFull(t.rdr, t.rdr.csheader)
+	if err != nil {
+		return nil, err
+	}
+
+	var order binary.ByteOrder
+	switch t.rdr.csheader[0] {
+	case 'l':
+		order = binary.LittleEndian
+	case 'B':
+		order = binary.BigEndian
+	default:
+		return nil, InvalidMessageError("invalid byte order")
+	}
+
+	r.Reset(t.rdr.csheader[1:])
+	if err := binary.Read(r, order, &t.rdr.msghead); err != nil {
+		return nil, err
+	}
+
+	msg := &Message{
+		Type:   t.rdr.Type,
+		Flags:  t.rdr.Flags,
+		serial: t.rdr.Serial,
+	}
+	// Length of header fields (without alignment).
+	hlen := t.rdr.HeaderLen
+	if hlen%8 != 0 {
+		hlen += 8 - (hlen % 8)
+	}
+	if hlen+t.rdr.BodyLen+16 > 1<<27 {
+		return nil, InvalidMessageError("message is too long")
+	}
+
+	// Decode headers and look for unix fds.
+	b.Reset()
+	if _, err = b.Write(t.rdr.csheader[12:]); err != nil {
+		return nil, err
+	}
+	if _, err = io.CopyN(b, t.rdr, int64(hlen)); err != nil {
+		return nil, err
+	}
+	dec.Reset(b, order, nil)
+	dec.pos = 12
+	vs, err := dec.Decode(Signature{"a(yv)"})
+	if err != nil {
+		return nil, err
+	}
+	if err = Store(vs, &t.rdr.headers); err != nil {
+		return nil, err
+	}
+	var unixfds uint32
+	for _, v := range t.rdr.headers {
+		if v.Field == byte(FieldUnixFDs) {
+			unixfds, _ = v.value.(uint32)
+		}
+	}
+
+	msg.Headers = make(map[HeaderField]Variant)
+	for _, v := range t.rdr.headers {
+		msg.Headers[HeaderField(v.Field)] = v.Variant
+	}
+
+	dec.align(8)
+	body := make([]byte, t.rdr.BodyLen)
+	if _, err = io.ReadFull(t.rdr, body); err != nil {
+		return nil, err
+	}
+	r.Reset(body)
+
+	if unixfds != 0 {
+		if !t.hasUnixFDs {
+			return nil, errors.New("dbus: got unix fds on unsupported transport")
+		}
+		// read the fds from the OOB data
+		scms, err := syscall.ParseSocketControlMessage(t.rdr.oob)
+		if err != nil {
+			return nil, err
+		}
+		if len(scms) != 1 {
+			return nil, errors.New("dbus: received more than one socket control message")
+		}
+		fds, err := syscall.ParseUnixRights(&scms[0])
+		if err != nil {
+			return nil, err
+		}
+		dec.Reset(r, order, fds)
+		if err = decodeMessageBody(msg, dec); err != nil {
+			return nil, err
+		}
+		// substitute the values in the message body (which are indices for the
+		// array receiver via OOB) with the actual values
+		for i, v := range msg.Body {
+			switch index := v.(type) {
+			case UnixFDIndex:
+				if uint32(index) >= unixfds {
+					return nil, InvalidMessageError("invalid index for unix fd")
+				}
+				msg.Body[i] = UnixFD(fds[index])
+			case []UnixFDIndex:
+				fdArray := make([]UnixFD, len(index))
+				for k, j := range index {
+					if uint32(j) >= unixfds {
+						return nil, InvalidMessageError("invalid index for unix fd")
+					}
+					fdArray[k] = UnixFD(fds[j])
+				}
+				msg.Body[i] = fdArray
+			}
+		}
+		return msg, nil
+	}
+
+	dec.Reset(r, order, nil)
+	if err = decodeMessageBody(msg, dec); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+func decodeMessageBody(msg *Message, dec *decoder) error {
+	if err := msg.validateHeader(); err != nil {
+		return err
+	}
+
+	sig, _ := msg.Headers[FieldSignature].value.(Signature)
+	if sig.str == "" {
+		return nil
+	}
+
+	var err error
+	msg.Body, err = dec.Decode(sig)
+	return err
+}
+
+func (t *unixTransport) SendMessage(msg *Message) error {
+	fdcnt, err := msg.CountFds()
+	if err != nil {
+		return err
+	}
+	if fdcnt != 0 {
+		if !t.hasUnixFDs {
+			return errors.New("dbus: unix fd passing not enabled")
+		}
+		msg.Headers[FieldUnixFDs] = MakeVariant(uint32(fdcnt))
+		buf := new(bytes.Buffer)
+		fds, err := msg.EncodeToWithFDs(buf, nativeEndian)
+		if err != nil {
+			return err
+		}
+		oob := syscall.UnixRights(fds...)
+		n, oobn, err := t.WriteMsgUnix(buf.Bytes(), oob, nil)
+		if err != nil {
+			return err
+		}
+		if n != buf.Len() || oobn != len(oob) {
+			return io.ErrShortWrite
+		}
+	} else {
+		if err := msg.EncodeTo(t, nativeEndian); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *unixTransport) SupportsUnixFDs() bool {
+	return true
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_dragonfly.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_dragonfly.go
@@ -1,0 +1,95 @@
+// The UnixCredentials system call is currently only implemented on Linux
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// https://golang.org/s/go1.4-syscall
+// http://code.google.com/p/go/source/browse/unix/sockcmsg_linux.go?repo=sys
+
+// Local implementation of the UnixCredentials system call for DragonFly BSD
+
+package dbus
+
+/*
+#include <sys/ucred.h>
+*/
+import "C"
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// http://golang.org/src/pkg/syscall/ztypes_linux_amd64.go
+// http://golang.org/src/pkg/syscall/ztypes_dragonfly_amd64.go
+type Ucred struct {
+	Pid int32
+	Uid uint32
+	Gid uint32
+}
+
+// http://golang.org/src/pkg/syscall/types_linux.go
+// http://golang.org/src/pkg/syscall/types_dragonfly.go
+// https://github.com/DragonFlyBSD/DragonFlyBSD/blob/master/sys/sys/ucred.h
+const (
+	SizeofUcred = C.sizeof_struct_ucred
+)
+
+// http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+func cmsgAlignOf(salen int) int {
+	// From http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+	//salign := sizeofPtr
+	// NOTE: It seems like 64-bit Darwin and DragonFly BSD kernels
+	// still require 32-bit aligned access to network subsystem.
+	//if darwin64Bit || dragonfly64Bit {
+	//	salign = 4
+	//}
+	salign := 4
+	return (salen + salign - 1) & ^(salign - 1)
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+func cmsgData(h *syscall.Cmsghdr) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(unsafe.Pointer(h)) + uintptr(cmsgAlignOf(syscall.SizeofCmsghdr)))
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// UnixCredentials encodes credentials into a socket control message
+// for sending to another process. This can be used for
+// authentication.
+func UnixCredentials(ucred *Ucred) []byte {
+	b := make([]byte, syscall.CmsgSpace(SizeofUcred))
+	h := (*syscall.Cmsghdr)(unsafe.Pointer(&b[0]))
+	h.Level = syscall.SOL_SOCKET
+	h.Type = syscall.SCM_CREDS
+	h.SetLen(syscall.CmsgLen(SizeofUcred))
+	*((*Ucred)(cmsgData(h))) = *ucred
+	return b
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// ParseUnixCredentials decodes a socket control message that contains
+// credentials in a Ucred structure. To receive such a message, the
+// SO_PASSCRED option must be enabled on the socket.
+func ParseUnixCredentials(m *syscall.SocketControlMessage) (*Ucred, error) {
+	if m.Header.Level != syscall.SOL_SOCKET {
+		return nil, syscall.EINVAL
+	}
+	if m.Header.Type != syscall.SCM_CREDS {
+		return nil, syscall.EINVAL
+	}
+	ucred := *(*Ucred)(unsafe.Pointer(&m.Data[0]))
+	return &ucred, nil
+}
+
+func (t *unixTransport) SendNullByte() error {
+	ucred := &Ucred{Pid: int32(os.Getpid()), Uid: uint32(os.Getuid()), Gid: uint32(os.Getgid())}
+	b := UnixCredentials(ucred)
+	_, oobn, err := t.UnixConn.WriteMsgUnix([]byte{0}, b, nil)
+	if err != nil {
+		return err
+	}
+	if oobn != len(b) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_freebsd.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_freebsd.go
@@ -1,0 +1,94 @@
+// The UnixCredentials system call is currently only implemented on Linux
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// https://golang.org/s/go1.4-syscall
+// http://code.google.com/p/go/source/browse/unix/sockcmsg_linux.go?repo=sys
+
+// Local implementation of the UnixCredentials system call for FreeBSD
+
+package dbus
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// http://golang.org/src/pkg/syscall/ztypes_linux_amd64.go
+// https://golang.org/src/syscall/ztypes_freebsd_amd64.go
+//
+// Note: FreeBSD actually uses a 'struct cmsgcred' which starts with
+// these fields and adds a list of the additional groups for the
+// sender.
+type Ucred struct {
+	Pid  int32
+	Uid  uint32
+	Euid uint32
+	Gid  uint32
+}
+
+// https://github.com/freebsd/freebsd/blob/master/sys/sys/socket.h
+//
+// The cmsgcred structure contains the above four fields, followed by
+// a uint16 count of additional groups, uint16 padding to align and a
+// 16 element array of uint32 for the additional groups. The size is
+// the same across all supported platforms.
+const (
+	SizeofCmsgcred = 84 // 4*4 + 2*2 + 16*4
+)
+
+// http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+func cmsgAlignOf(salen int) int {
+	salign := unix.SizeofPtr
+
+	return (salen + salign - 1) & ^(salign - 1)
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_unix.go
+func cmsgData(h *syscall.Cmsghdr) unsafe.Pointer {
+	return unsafe.Pointer(uintptr(unsafe.Pointer(h)) + uintptr(cmsgAlignOf(syscall.SizeofCmsghdr)))
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// UnixCredentials encodes credentials into a socket control message
+// for sending to another process. This can be used for
+// authentication.
+func UnixCredentials(ucred *Ucred) []byte {
+	b := make([]byte, syscall.CmsgSpace(SizeofCmsgcred))
+	h := (*syscall.Cmsghdr)(unsafe.Pointer(&b[0]))
+	h.Level = syscall.SOL_SOCKET
+	h.Type = syscall.SCM_CREDS
+	h.SetLen(syscall.CmsgLen(SizeofCmsgcred))
+	*((*Ucred)(cmsgData(h))) = *ucred
+	return b
+}
+
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// ParseUnixCredentials decodes a socket control message that contains
+// credentials in a Ucred structure. To receive such a message, the
+// SO_PASSCRED option must be enabled on the socket.
+func ParseUnixCredentials(m *syscall.SocketControlMessage) (*Ucred, error) {
+	if m.Header.Level != syscall.SOL_SOCKET {
+		return nil, syscall.EINVAL
+	}
+	if m.Header.Type != syscall.SCM_CREDS {
+		return nil, syscall.EINVAL
+	}
+	ucred := *(*Ucred)(unsafe.Pointer(&m.Data[0]))
+	return &ucred, nil
+}
+
+func (t *unixTransport) SendNullByte() error {
+	ucred := &Ucred{Pid: int32(os.Getpid()), Uid: uint32(os.Getuid()), Gid: uint32(os.Getgid())}
+	b := UnixCredentials(ucred)
+	_, oobn, err := t.UnixConn.WriteMsgUnix([]byte{0}, b, nil)
+	if err != nil {
+		return err
+	}
+	if oobn != len(b) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_linux.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_linux.go
@@ -1,0 +1,25 @@
+// The UnixCredentials system call is currently only implemented on Linux
+// http://golang.org/src/pkg/syscall/sockcmsg_linux.go
+// https://golang.org/s/go1.4-syscall
+// http://code.google.com/p/go/source/browse/unix/sockcmsg_linux.go?repo=sys
+
+package dbus
+
+import (
+	"io"
+	"os"
+	"syscall"
+)
+
+func (t *unixTransport) SendNullByte() error {
+	ucred := &syscall.Ucred{Pid: int32(os.Getpid()), Uid: uint32(os.Getuid()), Gid: uint32(os.Getgid())}
+	b := syscall.UnixCredentials(ucred)
+	_, oobn, err := t.WriteMsgUnix([]byte{0}, b, nil)
+	if err != nil {
+		return err
+	}
+	if oobn != len(b) {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_netbsd.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_netbsd.go
@@ -1,0 +1,14 @@
+package dbus
+
+import "io"
+
+func (t *unixTransport) SendNullByte() error {
+	n, _, err := t.UnixConn.WriteMsgUnix([]byte{0}, nil, nil)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_unixcred_openbsd.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_unixcred_openbsd.go
@@ -1,0 +1,14 @@
+package dbus
+
+import "io"
+
+func (t *unixTransport) SendNullByte() error {
+	n, _, err := t.UnixConn.WriteMsgUnix([]byte{0}, nil, nil)
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/vendor/github.com/godbus/dbus/v5/transport_zos.go
+++ b/vendor/github.com/godbus/dbus/v5/transport_zos.go
@@ -1,0 +1,6 @@
+package dbus
+
+func (t *unixTransport) SendNullByte() error {
+	_, err := t.Write([]byte{0})
+	return err
+}

--- a/vendor/github.com/godbus/dbus/v5/variant.go
+++ b/vendor/github.com/godbus/dbus/v5/variant.go
@@ -1,0 +1,169 @@
+package dbus
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+)
+
+// Variant represents the D-Bus variant type.
+type Variant struct {
+	sig   Signature
+	value any
+}
+
+// MakeVariant converts the given value to a Variant. It panics if v cannot be
+// represented as a D-Bus type.
+func MakeVariant(v any) Variant {
+	return MakeVariantWithSignature(v, SignatureOf(v))
+}
+
+// MakeVariantWithSignature converts the given value to a Variant.
+func MakeVariantWithSignature(v any, s Signature) Variant {
+	return Variant{s, v}
+}
+
+// ParseVariant parses the given string as a variant as described at
+// https://developer.gnome.org/glib/stable/gvariant-text.html. If sig is not
+// empty, it is taken to be the expected signature for the variant.
+func ParseVariant(s string, sig Signature) (Variant, error) {
+	tokens := varLex(s)
+	p := &varParser{tokens: tokens}
+	n, err := varMakeNode(p)
+	if err != nil {
+		return Variant{}, err
+	}
+	if sig.str == "" {
+		sig, err = varInfer(n)
+		if err != nil {
+			return Variant{}, err
+		}
+	}
+	v, err := n.Value(sig)
+	if err != nil {
+		return Variant{}, err
+	}
+	return MakeVariant(v), nil
+}
+
+// format returns a formatted version of v and whether this string can be parsed
+// unambiguously.
+func (v Variant) format() (string, bool) {
+	switch v.sig.str[0] {
+	case 'b', 'i':
+		return fmt.Sprint(v.value), true
+	case 'n', 'q', 'u', 'x', 't', 'd', 'h':
+		return fmt.Sprint(v.value), false
+	case 's':
+		return strconv.Quote(v.value.(string)), true
+	case 'o':
+		return strconv.Quote(string(v.value.(ObjectPath))), false
+	case 'g':
+		return strconv.Quote(v.value.(Signature).str), false
+	case 'v':
+		s, unamb := v.value.(Variant).format()
+		if !unamb {
+			return "<@" + v.value.(Variant).sig.str + " " + s + ">", true
+		}
+		return "<" + s + ">", true
+	case 'y':
+		return fmt.Sprintf("%#x", v.value.(byte)), false
+	}
+	rv := reflect.ValueOf(v.value)
+	switch rv.Kind() {
+	case reflect.Slice, reflect.Array:
+		if rv.Len() == 0 {
+			return "[]", false
+		}
+		unamb := true
+		buf := bytes.NewBuffer([]byte("["))
+		for i := 0; i < rv.Len(); i++ {
+			// TODO: slooow
+			s, b := MakeVariant(rv.Index(i).Interface()).format()
+			unamb = unamb && b
+			buf.WriteString(s)
+			if i != rv.Len()-1 {
+				buf.WriteString(", ")
+			}
+		}
+		buf.WriteByte(']')
+		return buf.String(), unamb
+	case reflect.Map:
+		if rv.Len() == 0 {
+			return "{}", false
+		}
+		unamb := true
+		var buf bytes.Buffer
+		kvs := make([]string, rv.Len())
+		for i, k := range rv.MapKeys() {
+			s, b := MakeVariant(k.Interface()).format()
+			unamb = unamb && b
+			buf.Reset()
+			buf.WriteString(s)
+			buf.WriteString(": ")
+			s, b = MakeVariant(rv.MapIndex(k).Interface()).format()
+			unamb = unamb && b
+			buf.WriteString(s)
+			kvs[i] = buf.String()
+		}
+		buf.Reset()
+		buf.WriteByte('{')
+		sort.Strings(kvs)
+		for i, kv := range kvs {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(kv)
+		}
+		buf.WriteByte('}')
+		return buf.String(), unamb
+	case reflect.Struct:
+		if rv.NumField() == 0 {
+			return "()", false
+		}
+		unamb := true
+		var buf bytes.Buffer
+		buf.WriteByte('(')
+		for i := 0; i < rv.NumField(); i++ {
+			s, b := MakeVariant(rv.Field(i).Interface()).format()
+			unamb = unamb && b
+			buf.WriteString(s)
+			buf.WriteString(",")
+			if i != rv.NumField()-1 {
+				buf.WriteString(" ")
+			}
+		}
+		buf.WriteByte(')')
+		return buf.String(), unamb
+
+	}
+	return `"INVALID"`, true
+}
+
+// Signature returns the D-Bus signature of the underlying value of v.
+func (v Variant) Signature() Signature {
+	return v.sig
+}
+
+// String returns the string representation of the underlying value of v as
+// described at https://developer.gnome.org/glib/stable/gvariant-text.html.
+func (v Variant) String() string {
+	s, unamb := v.format()
+	if !unamb {
+		return "@" + v.sig.str + " " + s
+	}
+	return s
+}
+
+// Value returns the underlying value of v.
+func (v Variant) Value() any {
+	return v.value
+}
+
+// Store converts the variant into a native go type using the same
+// mechanism as the "Store" function.
+func (v Variant) Store(value any) error {
+	return storeInterfaces(v.value, value)
+}

--- a/vendor/github.com/godbus/dbus/v5/variant_lexer.go
+++ b/vendor/github.com/godbus/dbus/v5/variant_lexer.go
@@ -1,0 +1,284 @@
+package dbus
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Heavily inspired by the lexer from text/template.
+
+type varToken struct {
+	typ varTokenType
+	val string
+}
+
+type varTokenType byte
+
+const (
+	tokEOF varTokenType = iota
+	tokError
+	tokNumber
+	tokString
+	tokBool
+	tokArrayStart
+	tokArrayEnd
+	tokDictStart
+	tokDictEnd
+	tokVariantStart
+	tokVariantEnd
+	tokComma
+	tokColon
+	tokType
+	tokByteString
+)
+
+type varLexer struct {
+	input  string
+	start  int
+	pos    int
+	width  int
+	tokens []varToken
+}
+
+type lexState func(*varLexer) lexState
+
+func varLex(s string) []varToken {
+	l := &varLexer{input: s}
+	l.run()
+	return l.tokens
+}
+
+func (l *varLexer) accept(valid string) bool {
+	if strings.ContainsRune(valid, l.next()) {
+		return true
+	}
+	l.backup()
+	return false
+}
+
+func (l *varLexer) backup() {
+	l.pos -= l.width
+}
+
+func (l *varLexer) emit(t varTokenType) {
+	l.tokens = append(l.tokens, varToken{t, l.input[l.start:l.pos]})
+	l.start = l.pos
+}
+
+func (l *varLexer) errorf(format string, v ...any) lexState {
+	l.tokens = append(l.tokens, varToken{
+		tokError,
+		fmt.Sprintf(format, v...),
+	})
+	return nil
+}
+
+func (l *varLexer) ignore() {
+	l.start = l.pos
+}
+
+func (l *varLexer) next() rune {
+	var r rune
+
+	if l.pos >= len(l.input) {
+		l.width = 0
+		return -1
+	}
+	r, l.width = utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += l.width
+	return r
+}
+
+func (l *varLexer) run() {
+	for state := varLexNormal; state != nil; {
+		state = state(l)
+	}
+}
+
+func (l *varLexer) peek() rune {
+	r := l.next()
+	l.backup()
+	return r
+}
+
+func varLexNormal(l *varLexer) lexState {
+	for {
+		r := l.next()
+		switch {
+		case r == -1:
+			l.emit(tokEOF)
+			return nil
+		case r == '[':
+			l.emit(tokArrayStart)
+		case r == ']':
+			l.emit(tokArrayEnd)
+		case r == '{':
+			l.emit(tokDictStart)
+		case r == '}':
+			l.emit(tokDictEnd)
+		case r == '<':
+			l.emit(tokVariantStart)
+		case r == '>':
+			l.emit(tokVariantEnd)
+		case r == ':':
+			l.emit(tokColon)
+		case r == ',':
+			l.emit(tokComma)
+		case r == '\'' || r == '"':
+			l.backup()
+			return varLexString
+		case r == '@':
+			l.backup()
+			return varLexType
+		case unicode.IsSpace(r):
+			l.ignore()
+		case unicode.IsNumber(r) || r == '+' || r == '-':
+			l.backup()
+			return varLexNumber
+		case r == 'b':
+			pos := l.start
+			if n := l.peek(); n == '"' || n == '\'' {
+				return varLexByteString
+			}
+			// not a byte string; try to parse it as a type or bool below
+			l.pos = pos + 1
+			l.width = 1
+			fallthrough
+		default:
+			// either a bool or a type. Try bools first.
+			l.backup()
+			if l.pos+4 <= len(l.input) {
+				if l.input[l.pos:l.pos+4] == "true" {
+					l.pos += 4
+					l.emit(tokBool)
+					continue
+				}
+			}
+			if l.pos+5 <= len(l.input) {
+				if l.input[l.pos:l.pos+5] == "false" {
+					l.pos += 5
+					l.emit(tokBool)
+					continue
+				}
+			}
+			// must be a type.
+			return varLexType
+		}
+	}
+}
+
+var varTypeMap = map[string]string{
+	"boolean":    "b",
+	"byte":       "y",
+	"int16":      "n",
+	"uint16":     "q",
+	"int32":      "i",
+	"uint32":     "u",
+	"int64":      "x",
+	"uint64":     "t",
+	"double":     "f",
+	"string":     "s",
+	"objectpath": "o",
+	"signature":  "g",
+}
+
+func varLexByteString(l *varLexer) lexState {
+	q := l.next()
+Loop:
+	for {
+		switch l.next() {
+		case '\\':
+			if r := l.next(); r != -1 {
+				break
+			}
+			fallthrough
+		case -1:
+			return l.errorf("unterminated bytestring")
+		case q:
+			break Loop
+		}
+	}
+	l.emit(tokByteString)
+	return varLexNormal
+}
+
+func varLexNumber(l *varLexer) lexState {
+	l.accept("+-")
+	digits := "0123456789"
+	if l.accept("0") {
+		if l.accept("x") {
+			digits = "0123456789abcdefABCDEF"
+		} else {
+			digits = "01234567"
+		}
+	}
+	for strings.ContainsRune(digits, l.next()) {
+	}
+	l.backup()
+	if l.accept(".") {
+		for strings.ContainsRune(digits, l.next()) {
+		}
+		l.backup()
+	}
+	if l.accept("eE") {
+		l.accept("+-")
+		for strings.ContainsRune("0123456789", l.next()) {
+		}
+		l.backup()
+	}
+	if r := l.peek(); unicode.IsLetter(r) {
+		l.next()
+		return l.errorf("bad number syntax: %q", l.input[l.start:l.pos])
+	}
+	l.emit(tokNumber)
+	return varLexNormal
+}
+
+func varLexString(l *varLexer) lexState {
+	q := l.next()
+Loop:
+	for {
+		switch l.next() {
+		case '\\':
+			if r := l.next(); r != -1 {
+				break
+			}
+			fallthrough
+		case -1:
+			return l.errorf("unterminated string")
+		case q:
+			break Loop
+		}
+	}
+	l.emit(tokString)
+	return varLexNormal
+}
+
+func varLexType(l *varLexer) lexState {
+	at := l.accept("@")
+	for {
+		r := l.next()
+		if r == -1 {
+			break
+		}
+		if unicode.IsSpace(r) {
+			l.backup()
+			break
+		}
+	}
+	if at {
+		if _, err := ParseSignature(l.input[l.start+1 : l.pos]); err != nil {
+			return l.errorf("%s", err)
+		}
+	} else {
+		if _, ok := varTypeMap[l.input[l.start:l.pos]]; ok {
+			l.emit(tokType)
+			return varLexNormal
+		}
+		return l.errorf("unrecognized type %q", l.input[l.start:l.pos])
+	}
+	l.emit(tokType)
+	return varLexNormal
+}

--- a/vendor/github.com/godbus/dbus/v5/variant_parser.go
+++ b/vendor/github.com/godbus/dbus/v5/variant_parser.go
@@ -1,0 +1,815 @@
+package dbus
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+type varParser struct {
+	tokens []varToken
+	i      int
+}
+
+func (p *varParser) backup() {
+	p.i--
+}
+
+func (p *varParser) next() varToken {
+	if p.i < len(p.tokens) {
+		t := p.tokens[p.i]
+		p.i++
+		return t
+	}
+	return varToken{typ: tokEOF}
+}
+
+type varNode interface {
+	Infer() (Signature, error)
+	String() string
+	Sigs() sigSet
+	Value(Signature) (any, error)
+}
+
+func varMakeNode(p *varParser) (varNode, error) {
+	var sig Signature
+
+	for {
+		t := p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		case tokNumber:
+			return varMakeNumNode(t, sig)
+		case tokString:
+			return varMakeStringNode(t, sig)
+		case tokBool:
+			if sig.str != "" && sig.str != "b" {
+				return nil, varTypeError{t.val, sig}
+			}
+			b, err := strconv.ParseBool(t.val)
+			if err != nil {
+				return nil, err
+			}
+			return boolNode(b), nil
+		case tokArrayStart:
+			return varMakeArrayNode(p, sig)
+		case tokVariantStart:
+			return varMakeVariantNode(p, sig)
+		case tokDictStart:
+			return varMakeDictNode(p, sig)
+		case tokType:
+			if sig.str != "" {
+				return nil, errors.New("unexpected type annotation")
+			}
+			if t.val[0] == '@' {
+				sig.str = t.val[1:]
+			} else {
+				sig.str = varTypeMap[t.val]
+			}
+		case tokByteString:
+			if sig.str != "" && sig.str != "ay" {
+				return nil, varTypeError{t.val, sig}
+			}
+			b, err := varParseByteString(t.val)
+			if err != nil {
+				return nil, err
+			}
+			return byteStringNode(b), nil
+		default:
+			return nil, fmt.Errorf("unexpected %q", t.val)
+		}
+	}
+}
+
+type varTypeError struct {
+	val string
+	sig Signature
+}
+
+func (e varTypeError) Error() string {
+	return fmt.Sprintf("dbus: can't parse %q as type %q", e.val, e.sig.str)
+}
+
+type sigSet map[Signature]bool
+
+func (s sigSet) Empty() bool {
+	return len(s) == 0
+}
+
+func (s sigSet) Intersect(s2 sigSet) sigSet {
+	r := make(sigSet)
+	for k := range s {
+		if s2[k] {
+			r[k] = true
+		}
+	}
+	return r
+}
+
+func (s sigSet) Single() (Signature, bool) {
+	if len(s) == 1 {
+		for k := range s {
+			return k, true
+		}
+	}
+	return Signature{}, false
+}
+
+func (s sigSet) ToArray() sigSet {
+	r := make(sigSet, len(s))
+	for k := range s {
+		r[Signature{"a" + k.str}] = true
+	}
+	return r
+}
+
+type numNode struct {
+	sig Signature
+	str string
+	val any
+}
+
+var numSigSet = sigSet{
+	Signature{"y"}: true,
+	Signature{"n"}: true,
+	Signature{"q"}: true,
+	Signature{"i"}: true,
+	Signature{"u"}: true,
+	Signature{"x"}: true,
+	Signature{"t"}: true,
+	Signature{"d"}: true,
+}
+
+func (n numNode) Infer() (Signature, error) {
+	if strings.ContainsAny(n.str, ".e") {
+		return Signature{"d"}, nil
+	}
+	return Signature{"i"}, nil
+}
+
+func (n numNode) String() string {
+	return n.str
+}
+
+func (n numNode) Sigs() sigSet {
+	if n.sig.str != "" {
+		return sigSet{n.sig: true}
+	}
+	if strings.ContainsAny(n.str, ".e") {
+		return sigSet{Signature{"d"}: true}
+	}
+	return numSigSet
+}
+
+func (n numNode) Value(sig Signature) (any, error) {
+	if n.sig.str != "" && n.sig != sig {
+		return nil, varTypeError{n.str, sig}
+	}
+	if n.val != nil {
+		return n.val, nil
+	}
+	return varNumAs(n.str, sig)
+}
+
+func varMakeNumNode(tok varToken, sig Signature) (varNode, error) {
+	if sig.str == "" {
+		return numNode{str: tok.val}, nil
+	}
+	num, err := varNumAs(tok.val, sig)
+	if err != nil {
+		return nil, err
+	}
+	return numNode{sig: sig, val: num}, nil
+}
+
+func varNumAs(s string, sig Signature) (any, error) {
+	isUnsigned := false
+	size := 32
+	switch sig.str {
+	case "n":
+		size = 16
+	case "i":
+	case "x":
+		size = 64
+	case "y":
+		size = 8
+		isUnsigned = true
+	case "q":
+		size = 16
+		isUnsigned = true
+	case "u":
+		isUnsigned = true
+	case "t":
+		size = 64
+		isUnsigned = true
+	case "d":
+		d, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, err
+		}
+		return d, nil
+	default:
+		return nil, varTypeError{s, sig}
+	}
+	base := 10
+	if after, ok := strings.CutPrefix(s, "0x"); ok {
+		base = 16
+		s = after
+	}
+	if after, ok := strings.CutPrefix(s, "0"); ok && len(s) != 1 {
+		base = 8
+		s = after
+	}
+	if isUnsigned {
+		i, err := strconv.ParseUint(s, base, size)
+		if err != nil {
+			return nil, err
+		}
+		var v any = i
+		switch sig.str {
+		case "y":
+			v = byte(i)
+		case "q":
+			v = uint16(i)
+		case "u":
+			v = uint32(i)
+		}
+		return v, nil
+	}
+	i, err := strconv.ParseInt(s, base, size)
+	if err != nil {
+		return nil, err
+	}
+	var v any = i
+	switch sig.str {
+	case "n":
+		v = int16(i)
+	case "i":
+		v = int32(i)
+	}
+	return v, nil
+}
+
+type stringNode struct {
+	sig Signature
+	str string // parsed
+	val any    // has correct type
+}
+
+var stringSigSet = sigSet{
+	Signature{"s"}: true,
+	Signature{"g"}: true,
+	Signature{"o"}: true,
+}
+
+func (n stringNode) Infer() (Signature, error) {
+	return Signature{"s"}, nil
+}
+
+func (n stringNode) String() string {
+	return n.str
+}
+
+func (n stringNode) Sigs() sigSet {
+	if n.sig.str != "" {
+		return sigSet{n.sig: true}
+	}
+	return stringSigSet
+}
+
+func (n stringNode) Value(sig Signature) (any, error) {
+	if n.sig.str != "" && n.sig != sig {
+		return nil, varTypeError{n.str, sig}
+	}
+	if n.val != nil {
+		return n.val, nil
+	}
+	switch sig.str {
+	case "g":
+		return Signature{n.str}, nil
+	case "o":
+		return ObjectPath(n.str), nil
+	case "s":
+		return n.str, nil
+	default:
+		return nil, varTypeError{n.str, sig}
+	}
+}
+
+func varMakeStringNode(tok varToken, sig Signature) (varNode, error) {
+	if sig.str != "" && sig.str != "s" && sig.str != "g" && sig.str != "o" {
+		return nil, fmt.Errorf("invalid type %q for string", sig.str)
+	}
+	s, err := varParseString(tok.val)
+	if err != nil {
+		return nil, err
+	}
+	n := stringNode{str: s}
+	if sig.str == "" {
+		return stringNode{str: s}, nil
+	}
+	n.sig = sig
+	switch sig.str {
+	case "o":
+		n.val = ObjectPath(s)
+	case "g":
+		n.val = Signature{s}
+	case "s":
+		n.val = s
+	}
+	return n, nil
+}
+
+func varParseString(s string) (string, error) {
+	// quotes are guaranteed to be there
+	s = s[1 : len(s)-1]
+	buf := new(bytes.Buffer)
+	for len(s) != 0 {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			return "", errors.New("invalid UTF-8")
+		}
+		s = s[size:]
+		if r != '\\' {
+			buf.WriteRune(r)
+			continue
+		}
+		r, size = utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			return "", errors.New("invalid UTF-8")
+		}
+		s = s[size:]
+		switch r {
+		case 'a':
+			buf.WriteRune(0x7)
+		case 'b':
+			buf.WriteRune(0x8)
+		case 'f':
+			buf.WriteRune(0xc)
+		case 'n':
+			buf.WriteRune('\n')
+		case 'r':
+			buf.WriteRune('\r')
+		case 't':
+			buf.WriteRune('\t')
+		case '\n':
+		case 'u':
+			if len(s) < 4 {
+				return "", errors.New("short unicode escape")
+			}
+			r, err := strconv.ParseUint(s[:4], 16, 32)
+			if err != nil {
+				return "", err
+			}
+			buf.WriteRune(rune(r))
+			s = s[4:]
+		case 'U':
+			if len(s) < 8 {
+				return "", errors.New("short unicode escape")
+			}
+			r, err := strconv.ParseUint(s[:8], 16, 32)
+			if err != nil {
+				return "", err
+			}
+			buf.WriteRune(rune(r))
+			s = s[8:]
+		default:
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String(), nil
+}
+
+var boolSigSet = sigSet{Signature{"b"}: true}
+
+type boolNode bool
+
+func (boolNode) Infer() (Signature, error) {
+	return Signature{"b"}, nil
+}
+
+func (b boolNode) String() string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func (boolNode) Sigs() sigSet {
+	return boolSigSet
+}
+
+func (b boolNode) Value(sig Signature) (any, error) {
+	if sig.str != "b" {
+		return nil, varTypeError{b.String(), sig}
+	}
+	return bool(b), nil
+}
+
+type arrayNode struct {
+	set      sigSet
+	children []varNode
+}
+
+func (n arrayNode) Infer() (Signature, error) {
+	for _, v := range n.children {
+		csig, err := varInfer(v)
+		if err != nil {
+			continue
+		}
+		return Signature{"a" + csig.str}, nil
+	}
+	return Signature{}, fmt.Errorf("can't infer type for %q", n.String())
+}
+
+func (n arrayNode) String() string {
+	s := "["
+	for i, v := range n.children {
+		s += v.String()
+		if i != len(n.children)-1 {
+			s += ", "
+		}
+	}
+	return s + "]"
+}
+
+func (n arrayNode) Sigs() sigSet {
+	return n.set
+}
+
+func (n arrayNode) Value(sig Signature) (any, error) {
+	if n.set.Empty() {
+		// no type information whatsoever, so this must be an empty slice
+		return reflect.MakeSlice(typeFor(sig.str), 0, 0).Interface(), nil
+	}
+	if !n.set[sig] {
+		return nil, varTypeError{n.String(), sig}
+	}
+	s := reflect.MakeSlice(typeFor(sig.str), len(n.children), len(n.children))
+	for i, v := range n.children {
+		rv, err := v.Value(Signature{sig.str[1:]})
+		if err != nil {
+			return nil, err
+		}
+		s.Index(i).Set(reflect.ValueOf(rv))
+	}
+	return s.Interface(), nil
+}
+
+func varMakeArrayNode(p *varParser, sig Signature) (varNode, error) {
+	var n arrayNode
+	if sig.str != "" {
+		n.set = sigSet{sig: true}
+	}
+	if t := p.next(); t.typ == tokArrayEnd {
+		return n, nil
+	} else {
+		p.backup()
+	}
+Loop:
+	for {
+		t := p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		}
+		p.backup()
+		cn, err := varMakeNode(p)
+		if err != nil {
+			return nil, err
+		}
+		if cset := cn.Sigs(); !cset.Empty() {
+			if n.set.Empty() {
+				n.set = cset.ToArray()
+			} else {
+				nset := cset.ToArray().Intersect(n.set)
+				if nset.Empty() {
+					return nil, fmt.Errorf("can't parse %q with given type information", cn.String())
+				}
+				n.set = nset
+			}
+		}
+		n.children = append(n.children, cn)
+		switch t := p.next(); t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		case tokArrayEnd:
+			break Loop
+		case tokComma:
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected %q", t.val)
+		}
+	}
+	return n, nil
+}
+
+type variantNode struct {
+	n varNode
+}
+
+var variantSet = sigSet{
+	Signature{"v"}: true,
+}
+
+func (variantNode) Infer() (Signature, error) {
+	return Signature{"v"}, nil
+}
+
+func (n variantNode) String() string {
+	return "<" + n.n.String() + ">"
+}
+
+func (variantNode) Sigs() sigSet {
+	return variantSet
+}
+
+func (n variantNode) Value(sig Signature) (any, error) {
+	if sig.str != "v" {
+		return nil, varTypeError{n.String(), sig}
+	}
+	sig, err := varInfer(n.n)
+	if err != nil {
+		return nil, err
+	}
+	v, err := n.n.Value(sig)
+	if err != nil {
+		return nil, err
+	}
+	return MakeVariant(v), nil
+}
+
+func varMakeVariantNode(p *varParser, sig Signature) (varNode, error) {
+	n, err := varMakeNode(p)
+	if err != nil {
+		return nil, err
+	}
+	if t := p.next(); t.typ != tokVariantEnd {
+		return nil, fmt.Errorf("unexpected %q", t.val)
+	}
+	vn := variantNode{n}
+	if sig.str != "" && sig.str != "v" {
+		return nil, varTypeError{vn.String(), sig}
+	}
+	return variantNode{n}, nil
+}
+
+type dictEntry struct {
+	key, val varNode
+}
+
+type dictNode struct {
+	kset, vset sigSet
+	children   []dictEntry
+}
+
+func (n dictNode) Infer() (Signature, error) {
+	for _, v := range n.children {
+		ksig, err := varInfer(v.key)
+		if err != nil {
+			continue
+		}
+		vsig, err := varInfer(v.val)
+		if err != nil {
+			continue
+		}
+		return Signature{"a{" + ksig.str + vsig.str + "}"}, nil
+	}
+	return Signature{}, fmt.Errorf("can't infer type for %q", n.String())
+}
+
+func (n dictNode) String() string {
+	s := "{"
+	for i, v := range n.children {
+		s += v.key.String() + ": " + v.val.String()
+		if i != len(n.children)-1 {
+			s += ", "
+		}
+	}
+	return s + "}"
+}
+
+func (n dictNode) Sigs() sigSet {
+	r := sigSet{}
+	for k := range n.kset {
+		for v := range n.vset {
+			sig := "a{" + k.str + v.str + "}"
+			r[Signature{sig}] = true
+		}
+	}
+	return r
+}
+
+func (n dictNode) Value(sig Signature) (any, error) {
+	set := n.Sigs()
+	if set.Empty() {
+		// no type information -> empty dict
+		return reflect.MakeMap(typeFor(sig.str)).Interface(), nil
+	}
+	if !set[sig] {
+		return nil, varTypeError{n.String(), sig}
+	}
+	m := reflect.MakeMap(typeFor(sig.str))
+	ksig := Signature{sig.str[2:3]}
+	vsig := Signature{sig.str[3 : len(sig.str)-1]}
+	for _, v := range n.children {
+		kv, err := v.key.Value(ksig)
+		if err != nil {
+			return nil, err
+		}
+		vv, err := v.val.Value(vsig)
+		if err != nil {
+			return nil, err
+		}
+		m.SetMapIndex(reflect.ValueOf(kv), reflect.ValueOf(vv))
+	}
+	return m.Interface(), nil
+}
+
+func varMakeDictNode(p *varParser, sig Signature) (varNode, error) {
+	var n dictNode
+
+	if sig.str != "" {
+		if len(sig.str) < 5 {
+			return nil, fmt.Errorf("invalid signature %q for dict type", sig)
+		}
+		ksig := Signature{string(sig.str[2])}
+		vsig := Signature{sig.str[3 : len(sig.str)-1]}
+		n.kset = sigSet{ksig: true}
+		n.vset = sigSet{vsig: true}
+	}
+	if t := p.next(); t.typ == tokDictEnd {
+		return n, nil
+	} else {
+		p.backup()
+	}
+Loop:
+	for {
+		t := p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		}
+		p.backup()
+		kn, err := varMakeNode(p)
+		if err != nil {
+			return nil, err
+		}
+		if kset := kn.Sigs(); !kset.Empty() {
+			if n.kset.Empty() {
+				n.kset = kset
+			} else {
+				n.kset = kset.Intersect(n.kset)
+				if n.kset.Empty() {
+					return nil, fmt.Errorf("can't parse %q with given type information", kn.String())
+				}
+			}
+		}
+		t = p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		case tokColon:
+		default:
+			return nil, fmt.Errorf("unexpected %q", t.val)
+		}
+		t = p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		}
+		p.backup()
+		vn, err := varMakeNode(p)
+		if err != nil {
+			return nil, err
+		}
+		if vset := vn.Sigs(); !vset.Empty() {
+			if n.vset.Empty() {
+				n.vset = vset
+			} else {
+				n.vset = n.vset.Intersect(vset)
+				if n.vset.Empty() {
+					return nil, fmt.Errorf("can't parse %q with given type information", vn.String())
+				}
+			}
+		}
+		n.children = append(n.children, dictEntry{kn, vn})
+		t = p.next()
+		switch t.typ {
+		case tokEOF:
+			return nil, io.ErrUnexpectedEOF
+		case tokError:
+			return nil, errors.New(t.val)
+		case tokDictEnd:
+			break Loop
+		case tokComma:
+			continue
+		default:
+			return nil, fmt.Errorf("unexpected %q", t.val)
+		}
+	}
+	return n, nil
+}
+
+type byteStringNode []byte
+
+var byteStringSet = sigSet{
+	Signature{"ay"}: true,
+}
+
+func (byteStringNode) Infer() (Signature, error) {
+	return Signature{"ay"}, nil
+}
+
+func (b byteStringNode) String() string {
+	return string(b)
+}
+
+func (b byteStringNode) Sigs() sigSet {
+	return byteStringSet
+}
+
+func (b byteStringNode) Value(sig Signature) (any, error) {
+	if sig.str != "ay" {
+		return nil, varTypeError{b.String(), sig}
+	}
+	return []byte(b), nil
+}
+
+func varParseByteString(s string) ([]byte, error) {
+	// quotes and b at start are guaranteed to be there
+	b := make([]byte, 0, 1)
+	s = s[2 : len(s)-1]
+	for len(s) != 0 {
+		c := s[0]
+		s = s[1:]
+		if c != '\\' {
+			b = append(b, c)
+			continue
+		}
+		c = s[0]
+		s = s[1:]
+		switch c {
+		case 'a':
+			b = append(b, 0x7)
+		case 'b':
+			b = append(b, 0x8)
+		case 'f':
+			b = append(b, 0xc)
+		case 'n':
+			b = append(b, '\n')
+		case 'r':
+			b = append(b, '\r')
+		case 't':
+			b = append(b, '\t')
+		case 'x':
+			if len(s) < 2 {
+				return nil, errors.New("short escape")
+			}
+			n, err := strconv.ParseUint(s[:2], 16, 8)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, byte(n))
+			s = s[2:]
+		case '0':
+			if len(s) < 3 {
+				return nil, errors.New("short escape")
+			}
+			n, err := strconv.ParseUint(s[:3], 8, 8)
+			if err != nil {
+				return nil, err
+			}
+			b = append(b, byte(n))
+			s = s[3:]
+		default:
+			b = append(b, c)
+		}
+	}
+	return append(b, 0), nil
+}
+
+func varInfer(n varNode) (Signature, error) {
+	if sig, ok := n.Sigs().Single(); ok {
+		return sig, nil
+	}
+	return n.Infer()
+}

--- a/vendor/github.com/zalando/go-keyring/.catwatch.yml
+++ b/vendor/github.com/zalando/go-keyring/.catwatch.yml
@@ -1,0 +1,1 @@
+title: go-keyring

--- a/vendor/github.com/zalando/go-keyring/.gitignore
+++ b/vendor/github.com/zalando/go-keyring/.gitignore
@@ -1,0 +1,23 @@
+# https://github.com/github/gitignore
+
+######################### Go ###################################################
+# https://raw.githubusercontent.com/github/gitignore/master/Go.gitignore
+################################################################################
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+vendor/
+
+# Go workspace file
+go.work

--- a/vendor/github.com/zalando/go-keyring/.zappr.yml
+++ b/vendor/github.com/zalando/go-keyring/.zappr.yml
@@ -1,0 +1,8 @@
+approvals:
+  groups:
+    zalando:
+      minimum: 2
+      from:
+        orgs:
+          - "zalando"
+X-Zalando-Team: teapot

--- a/vendor/github.com/zalando/go-keyring/CONTRIBUTING.md
+++ b/vendor/github.com/zalando/go-keyring/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to Go keyring library
+
+Please open an issue for bugs and feature requests. We are open to Pull Requests, but we would like to discuss features with you.
+If you want to submit a PR, always use feature branches and let people discuss changes in pull requests.
+
+Pull requests should only be merged after all discussions have been concluded and at least 2 reviewers has given their
+**approval**.
+
+## Guidelines
+
+- **every code change** should have a test
+- keep the current code style

--- a/vendor/github.com/zalando/go-keyring/LICENSE
+++ b/vendor/github.com/zalando/go-keyring/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Zalando SE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/zalando/go-keyring/MAINTAINERS
+++ b/vendor/github.com/zalando/go-keyring/MAINTAINERS
@@ -1,0 +1,2 @@
+Mikkel Oscar Lyderik Larsen <mikkel.larsen@zalando.de>
+Sandor Szücs <sandor.szuecs@zalando.de>

--- a/vendor/github.com/zalando/go-keyring/README.md
+++ b/vendor/github.com/zalando/go-keyring/README.md
@@ -1,0 +1,269 @@
+# Go Keyring library
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/zalando/go-keyring)](https://goreportcard.com/report/github.com/zalando/go-keyring)
+[![GoDoc](https://godoc.org/github.com/zalando/go-keyring?status.svg)](https://godoc.org/github.com/zalando/go-keyring)
+
+`go-keyring` is an OS-agnostic library for *setting*, *getting* and *deleting*
+secrets from the system keyring. It supports **OS X**, **Linux/BSD (dbus)** and
+**Windows**.
+
+go-keyring was created after its authors searched for, but couldn't find, a better alternative. It aims to simplify
+using statically linked binaries, which is cumbersome when relying on C bindings (as other keyring libraries do).
+
+#### Potential Uses
+
+If you're working with an application that needs to store user credentials
+locally on the user's machine, go-keyring might come in handy. For instance, if you are writing a CLI for an API
+that requires a username and password, you can store this information in the
+keyring instead of having the user type it on every invocation.
+
+## Dependencies
+
+#### OS X
+
+The OS X implementation depends on the `/usr/bin/security` binary for
+interfacing with the OS X keychain. It should be available by default.
+
+#### Linux and *BSD
+
+The Linux and *BSD implementation depends on the [Secret Service][SecretService] dbus
+interface, which is provided by [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring).
+
+It's expected that the default collection `login` exists in the keyring, because
+it's the default in most distros. If it doesn't exist, you can create it through the
+keyring frontend program [Seahorse](https://wiki.gnome.org/Apps/Seahorse):
+
+* Open `seahorse`
+* Go to **File > New > Password Keyring**
+* Click **Continue**
+* When asked for a name, use: **login**
+
+## Example Usage
+
+How to *set* and *get* a secret from the keyring:
+
+```go
+package main
+
+import (
+    "log"
+
+    "github.com/zalando/go-keyring"
+)
+
+func main() {
+    service := "my-app"
+    user := "anon"
+    password := "secret"
+
+    // set password
+    err := keyring.Set(service, user, password)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    // get password
+    secret, err := keyring.Get(service, user)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    log.Println(secret)
+}
+
+```
+
+## Direct CLI Usage
+
+While this library provides a convenient Go API, you can also interact with the system keyring directly using OS-specific command-line tools. This can be useful for debugging, scripting, or understanding what the library does under the hood. You can use the CLI to set-up the secrets from a script and then access them from Go, or vice-versa.
+
+### macOS
+
+macOS uses the `security` command to interact with the Keychain.
+
+**Set a password:**
+```bash
+security add-generic-password -U -s "service" -a "user" -w "password"
+```
+
+**Get a password:**
+```bash
+security find-generic-password -s "service" -wa "user"
+```
+
+**Delete a password:**
+```bash
+security delete-generic-password -s "service" -a "user"
+```
+
+Where:
+- `-s` specifies the service name
+- `-a` specifies the account/username
+- `-w` specifies the password to store
+- `-U` updates the password if it already exists
+- The `w` option in `-wa` outputs only the password value
+
+### Linux and *BSD
+
+Linux and *BSD systems use the Secret Service API via D-Bus. The easiest way to interact with it from the command line is using `secret-tool`, which is part of libsecret.
+
+**Install secret-tool (if not already installed):**
+```bash
+# Debian/Ubuntu
+sudo apt-get install libsecret-tools
+
+# Fedora/RHEL
+sudo dnf install libsecret
+
+# Arch Linux
+sudo pacman -S libsecret
+```
+
+**Set a password:**
+```bash
+secret-tool store --label="Password for 'user' on 'service'" service "service" username "user"
+# You'll be prompted to enter the password
+```
+
+Or provide the password directly:
+```bash
+echo -n "password" | secret-tool store --label="Password for 'user' on 'service'" service "service" username "user"
+```
+
+**Get a password:**
+```bash
+secret-tool lookup service "service" username "user"
+```
+
+**Delete a password:**
+```bash
+secret-tool clear service "service" username "user"
+```
+
+Note: The `service` and `username` are attributes used to identify the secret. The label is a human-readable description.
+
+### Windows
+
+Windows uses the Credential Manager, which can be accessed via `cmdkey` or PowerShell.
+
+**Using cmdkey:**
+
+**Set a password:**
+```cmd
+cmdkey /generic:"service:user" /user:"user" /pass:"password"
+```
+
+**Get a password:**
+
+`cmdkey` doesn't support retrieving passwords directly. Use PowerShell instead:
+```powershell
+$cred = Get-StoredCredential -Target "service:user"
+$cred.GetNetworkCredential().Password
+```
+
+Or using the Windows API via PowerShell:
+```powershell
+[System.Net.NetworkCredential]::new("", (Get-StoredCredential -Target "service:user").Password).Password
+```
+
+**Delete a password:**
+```cmd
+cmdkey /delete:"service:user"
+```
+
+**Using PowerShell with CredentialManager module:**
+
+First, install the CredentialManager module:
+```powershell
+Install-Module -Name CredentialManager -Force
+```
+
+**Set a password:**
+```powershell
+New-StoredCredential -Target "service:user" -UserName "user" -Password "password" -Type Generic -Persist LocalMachine
+```
+
+**Get a password:**
+```powershell
+(Get-StoredCredential -Target "service:user").GetNetworkCredential().Password
+```
+
+**Delete a password:**
+```powershell
+Remove-StoredCredential -Target "service:user"
+```
+
+Note: On Windows, the library combines the service and username as `service:username` for the credential target name.
+
+## Tests
+
+### Running tests
+
+Running the tests is simple:
+
+```
+go test
+```
+
+Which OS you use *does* matter. If you're using **Linux** or **BSD**, it will
+test the implementation in `keyring_unix.go`. If running the tests
+on **OS X**, it will test the implementation in `keyring_darwin.go`.
+
+### Mocking
+
+If you need to mock the keyring behavior for testing on systems without a keyring implementation you can call `MockInit()` which will replace the OS defined provider with an in-memory one.
+
+```go
+package implementation
+
+import (
+    "testing"
+
+    "github.com/zalando/go-keyring"
+)
+
+func TestMockedSetGet(t *testing.T) {
+    keyring.MockInit()
+    err := keyring.Set("service", "user", "password")
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    p, err := keyring.Get("service", "user")
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if p != "password" {
+        t.Error("password was not the expected string")
+    }
+
+}
+
+```
+
+## Contributing/TODO
+
+We welcome contributions from the community; please use [CONTRIBUTING.md](CONTRIBUTING.md) as your guidelines for getting started. Here are some items that we'd love help with:
+
+* The code base
+* Better test coverage
+
+Please use GitHub issues as the starting point for contributions, new ideas and/or bug reports.
+
+## Contact
+
+* E-Mail: <team-teapot@zalando.de>
+* Security issues: Please send an email to the [maintainers](MAINTAINERS), and we'll try to get back to you within two workdays. If you don't hear back, send an email to <team-teapot@zalando.de> and someone will respond within five days max.
+
+## Contributors
+
+Thanks to:
+
+* [your name here]
+
+## License
+
+See [LICENSE](LICENSE) file.
+
+[SecretService]: https://specifications.freedesktop.org/secret-service-spec/latest/

--- a/vendor/github.com/zalando/go-keyring/SECURITY.md
+++ b/vendor/github.com/zalando/go-keyring/SECURITY.md
@@ -1,0 +1,8 @@
+We acknowledge that every line of code that we write may potentially contain security issues.
+We are trying to deal with it responsibly and provide patches as quickly as possible.
+
+We host our bug bounty program on HackerOne, it is currently private, therefore if you would like to report a vulnerability and get rewarded for it, please ask to join our program by filling this form:
+
+https://corporate.zalando.com/en/services-and-contact#security-form
+
+You can also send your report via this form if you do not want to join our bug bounty program and just want to report a vulnerability or security issue.

--- a/vendor/github.com/zalando/go-keyring/internal/shellescape/LICENSE
+++ b/vendor/github.com/zalando/go-keyring/internal/shellescape/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Alessio Treglia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/zalando/go-keyring/internal/shellescape/shellescape.go
+++ b/vendor/github.com/zalando/go-keyring/internal/shellescape/shellescape.go
@@ -1,0 +1,39 @@
+/*
+Package shellescape provides the shellescape.Quote to escape arbitrary
+strings for a safe use as command line arguments in the most common
+POSIX shells.
+
+The original Python package which this work was inspired by can be found
+at https://pypi.python.org/pypi/shellescape.
+
+Portions of this file are from al.essio.dev/pkg/shellescape, © 2016 Alessio Treglia under the MIT License.
+See LICENSE for more information.
+*/
+package shellescape
+
+/*
+The functionality provided by shellescape.Quote could be helpful
+in those cases where it is known that the output of a Go program will
+be appended to/used in the context of shell programs' command line arguments.
+*/
+
+import (
+	"regexp"
+	"strings"
+)
+
+var pattern *regexp.Regexp = regexp.MustCompile(`[^\w@%+=:,./-]`)
+
+// Quote returns a shell-escaped version of the string s. The returned value
+// is a string that can safely be used as one token in a shell command line.
+func Quote(s string) string {
+	if len(s) == 0 {
+		return "''"
+	}
+
+	if pattern.MatchString(s) {
+		return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+	}
+
+	return s
+}

--- a/vendor/github.com/zalando/go-keyring/keyring.go
+++ b/vendor/github.com/zalando/go-keyring/keyring.go
@@ -1,0 +1,50 @@
+package keyring
+
+import "errors"
+
+// provider set in the init function by the relevant os file e.g.:
+// keyring_unix.go
+var provider Keyring = fallbackServiceProvider{}
+
+var (
+	// ErrNotFound is the expected error if the secret isn't found in the
+	// keyring.
+	ErrNotFound = errors.New("secret not found in keyring")
+	// ErrSetDataTooBig is returned if `Set` was called with too much data.
+	// On MacOS: The combination of service, username & password should not exceed ~3000 bytes
+	// On Windows: The service is limited to 32KiB while the password is limited to 2560 bytes
+	// On Linux/Unix: There is no theoretical limit but performance suffers with big values (>100KiB)
+	ErrSetDataTooBig = errors.New("data passed to Set was too big")
+)
+
+// Keyring provides a simple set/get interface for a keyring service.
+type Keyring interface {
+	// Set password in keyring for user.
+	Set(service, user, password string) error
+	// Get password from keyring given service and user name.
+	Get(service, user string) (string, error)
+	// Delete secret from keyring.
+	Delete(service, user string) error
+	// DeleteAll deletes all secrets for a given service
+	DeleteAll(service string) error
+}
+
+// Set password in keyring for user.
+func Set(service, user, password string) error {
+	return provider.Set(service, user, password)
+}
+
+// Get password from keyring given service and user name.
+func Get(service, user string) (string, error) {
+	return provider.Get(service, user)
+}
+
+// Delete secret from keyring.
+func Delete(service, user string) error {
+	return provider.Delete(service, user)
+}
+
+// DeleteAll deletes all secrets for a given service
+func DeleteAll(service string) error {
+	return provider.DeleteAll(service)
+}

--- a/vendor/github.com/zalando/go-keyring/keyring_darwin.go
+++ b/vendor/github.com/zalando/go-keyring/keyring_darwin.go
@@ -1,0 +1,140 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyring
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/zalando/go-keyring/internal/shellescape"
+)
+
+const (
+	execPathKeychain = "/usr/bin/security"
+
+	// encodingPrefix is a well-known prefix added to strings encoded by Set.
+	encodingPrefix       = "go-keyring-encoded:"
+	base64EncodingPrefix = "go-keyring-base64:"
+)
+
+type macOSXKeychain struct{}
+
+// func (*MacOSXKeychain) IsAvailable() bool {
+// 	return exec.Command(execPathKeychain).Run() != exec.ErrNotFound
+// }
+
+// Get password from macos keyring given service and user name.
+func (k macOSXKeychain) Get(service, username string) (string, error) {
+	out, err := exec.Command(
+		execPathKeychain,
+		"find-generic-password",
+		"-s", service,
+		"-wa", username).CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "could not be found") {
+			err = ErrNotFound
+		}
+		return "", err
+	}
+
+	trimStr := strings.TrimSpace(string(out[:]))
+	// if the string has the well-known prefix, assume it's encoded
+	if strings.HasPrefix(trimStr, encodingPrefix) {
+		dec, err := hex.DecodeString(trimStr[len(encodingPrefix):])
+		return string(dec), err
+	} else if strings.HasPrefix(trimStr, base64EncodingPrefix) {
+		dec, err := base64.StdEncoding.DecodeString(trimStr[len(base64EncodingPrefix):])
+		return string(dec), err
+	}
+
+	return trimStr, nil
+}
+
+// Set stores a secret in the macos keyring given a service name and a user.
+func (k macOSXKeychain) Set(service, username, password string) error {
+	// if the added secret has multiple lines or some non ascii,
+	// osx will hex encode it on return. To avoid getting garbage, we
+	// encode all passwords
+	password = base64EncodingPrefix + base64.StdEncoding.EncodeToString([]byte(password))
+
+	cmd := exec.Command(execPathKeychain, "-i")
+	stdIn, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err = cmd.Start(); err != nil {
+		return err
+	}
+
+	command := fmt.Sprintf("add-generic-password -U -s %s -a %s -w %s\n", shellescape.Quote(service), shellescape.Quote(username), shellescape.Quote(password))
+	if len(command) > 4096 {
+		return ErrSetDataTooBig
+	}
+
+	if _, err := io.WriteString(stdIn, command); err != nil {
+		return err
+	}
+
+	if err = stdIn.Close(); err != nil {
+		return err
+	}
+
+	err = cmd.Wait()
+	return err
+}
+
+// Delete deletes a secret, identified by service & user, from the keyring.
+func (k macOSXKeychain) Delete(service, username string) error {
+	out, err := exec.Command(
+		execPathKeychain,
+		"delete-generic-password",
+		"-s", service,
+		"-a", username).CombinedOutput()
+	if strings.Contains(string(out), "could not be found") {
+		err = ErrNotFound
+	}
+	return err
+}
+
+// DeleteAll deletes all secrets for a given service
+func (k macOSXKeychain) DeleteAll(service string) error {
+	// if service is empty, do nothing otherwise it might accidentally delete all secrets
+	if service == "" {
+		return ErrNotFound
+	}
+	// Delete each secret in a while loop until there is no more left
+	// under the service
+	for {
+		out, err := exec.Command(
+			execPathKeychain,
+			"delete-generic-password",
+			"-s", service).CombinedOutput()
+		if strings.Contains(string(out), "could not be found") {
+			return nil
+		} else if err != nil {
+			return err
+		}
+	}
+
+}
+
+func init() {
+	provider = macOSXKeychain{}
+}

--- a/vendor/github.com/zalando/go-keyring/keyring_fallback.go
+++ b/vendor/github.com/zalando/go-keyring/keyring_fallback.go
@@ -1,0 +1,27 @@
+package keyring
+
+import (
+	"errors"
+	"runtime"
+)
+
+// All of the following methods error out on unsupported platforms
+var ErrUnsupportedPlatform = errors.New("unsupported platform: " + runtime.GOOS)
+
+type fallbackServiceProvider struct{}
+
+func (fallbackServiceProvider) Set(service, user, pass string) error {
+	return ErrUnsupportedPlatform
+}
+
+func (fallbackServiceProvider) Get(service, user string) (string, error) {
+	return "", ErrUnsupportedPlatform
+}
+
+func (fallbackServiceProvider) Delete(service, user string) error {
+	return ErrUnsupportedPlatform
+}
+
+func (fallbackServiceProvider) DeleteAll(service string) error {
+	return ErrUnsupportedPlatform
+}

--- a/vendor/github.com/zalando/go-keyring/keyring_mock.go
+++ b/vendor/github.com/zalando/go-keyring/keyring_mock.go
@@ -1,0 +1,71 @@
+package keyring
+
+type mockProvider struct {
+	mockStore map[string]map[string]string
+	mockError error
+}
+
+// Set stores user and pass in the keyring under the defined service
+// name.
+func (m *mockProvider) Set(service, user, pass string) error {
+	if m.mockError != nil {
+		return m.mockError
+	}
+	if m.mockStore == nil {
+		m.mockStore = make(map[string]map[string]string)
+	}
+	if m.mockStore[service] == nil {
+		m.mockStore[service] = make(map[string]string)
+	}
+	m.mockStore[service][user] = pass
+	return nil
+}
+
+// Get gets a secret from the keyring given a service name and a user.
+func (m *mockProvider) Get(service, user string) (string, error) {
+	if m.mockError != nil {
+		return "", m.mockError
+	}
+	if b, ok := m.mockStore[service]; ok {
+		if v, ok := b[user]; ok {
+			return v, nil
+		}
+	}
+	return "", ErrNotFound
+}
+
+// Delete deletes a secret, identified by service & user, from the keyring.
+func (m *mockProvider) Delete(service, user string) error {
+	if m.mockError != nil {
+		return m.mockError
+	}
+	if m.mockStore != nil {
+		if _, ok := m.mockStore[service]; ok {
+			if _, ok := m.mockStore[service][user]; ok {
+				delete(m.mockStore[service], user)
+				return nil
+			}
+		}
+	}
+	return ErrNotFound
+}
+
+// DeleteAll deletes all secrets for a given service
+func (m *mockProvider) DeleteAll(service string) error {
+	if m.mockError != nil {
+		return m.mockError
+	}
+	delete(m.mockStore, service)
+	return nil
+}
+
+// MockInit sets the provider to a mocked memory store
+func MockInit() {
+	provider = &mockProvider{}
+}
+
+// MockInitWithError sets the provider to a mocked memory store
+// that returns the given error on all operations
+func MockInitWithError(err error) {
+	provider = &mockProvider{mockError: err}
+}

--- a/vendor/github.com/zalando/go-keyring/keyring_unix.go
+++ b/vendor/github.com/zalando/go-keyring/keyring_unix.go
@@ -1,0 +1,182 @@
+//go:build (dragonfly && cgo) || (freebsd && cgo) || linux || netbsd || openbsd
+
+package keyring
+
+import (
+	"fmt"
+
+	dbus "github.com/godbus/dbus/v5"
+	ss "github.com/zalando/go-keyring/secret_service"
+)
+
+type secretServiceProvider struct{}
+
+// Set stores user and pass in the keyring under the defined service
+// name.
+func (s secretServiceProvider) Set(service, user, pass string) error {
+	svc, err := ss.NewSecretService()
+	if err != nil {
+		return err
+	}
+
+	// open a session
+	session, err := svc.OpenSession()
+	if err != nil {
+		return err
+	}
+	defer svc.Close(session)
+
+	attributes := map[string]string{
+		"username": user,
+		"service":  service,
+	}
+
+	secret := ss.NewSecret(session.Path(), pass)
+
+	collection := svc.GetLoginCollection()
+
+	err = svc.Unlock(collection.Path())
+	if err != nil {
+		return err
+	}
+
+	err = svc.CreateItem(collection,
+		fmt.Sprintf("Password for '%s' on '%s'", user, service),
+		attributes, secret)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// findItem looksup an item by service and user.
+func (s secretServiceProvider) findItem(svc *ss.SecretService, service, user string) (dbus.ObjectPath, error) {
+	collection := svc.GetLoginCollection()
+
+	search := map[string]string{
+		"username": user,
+		"service":  service,
+	}
+
+	err := svc.Unlock(collection.Path())
+	if err != nil {
+		return "", err
+	}
+
+	results, err := svc.SearchItems(collection, search)
+	if err != nil {
+		return "", err
+	}
+
+	if len(results) == 0 {
+		return "", ErrNotFound
+	}
+
+	return results[0], nil
+}
+
+// findServiceItems looksup all items by service.
+func (s secretServiceProvider) findServiceItems(svc *ss.SecretService, service string) ([]dbus.ObjectPath, error) {
+	collection := svc.GetLoginCollection()
+
+	search := map[string]string{
+		"service": service,
+	}
+
+	err := svc.Unlock(collection.Path())
+	if err != nil {
+		return []dbus.ObjectPath{}, err
+	}
+
+	results, err := svc.SearchItems(collection, search)
+	if err != nil {
+		return []dbus.ObjectPath{}, err
+	}
+
+	if len(results) == 0 {
+		return []dbus.ObjectPath{}, ErrNotFound
+	}
+
+	return results, nil
+}
+
+// Get gets a secret from the keyring given a service name and a user.
+func (s secretServiceProvider) Get(service, user string) (string, error) {
+	svc, err := ss.NewSecretService()
+	if err != nil {
+		return "", err
+	}
+
+	item, err := s.findItem(svc, service, user)
+	if err != nil {
+		return "", err
+	}
+
+	// open a session
+	session, err := svc.OpenSession()
+	if err != nil {
+		return "", err
+	}
+	defer svc.Close(session)
+
+	// unlock if invdividual item is locked
+	err = svc.Unlock(item)
+	if err != nil {
+		return "", err
+	}
+
+	secret, err := svc.GetSecret(item, session.Path())
+	if err != nil {
+		return "", err
+	}
+
+	return string(secret.Value), nil
+}
+
+// Delete deletes a secret, identified by service & user, from the keyring.
+func (s secretServiceProvider) Delete(service, user string) error {
+	svc, err := ss.NewSecretService()
+	if err != nil {
+		return err
+	}
+
+	item, err := s.findItem(svc, service, user)
+	if err != nil {
+		return err
+	}
+
+	return svc.Delete(item)
+}
+
+// DeleteAll deletes all secrets for a given service
+func (s secretServiceProvider) DeleteAll(service string) error {
+	// if service is empty, do nothing otherwise it might accidentally delete all secrets
+	if service == "" {
+		return ErrNotFound
+	}
+
+	svc, err := ss.NewSecretService()
+	if err != nil {
+		return err
+	}
+	// find all items for the service
+	items, err := s.findServiceItems(svc, service)
+	if err != nil {
+		if err == ErrNotFound {
+			return nil
+		}
+		return err
+	}
+	for _, item := range items {
+		err = svc.Delete(item)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	provider = secretServiceProvider{}
+}

--- a/vendor/github.com/zalando/go-keyring/keyring_windows.go
+++ b/vendor/github.com/zalando/go-keyring/keyring_windows.go
@@ -1,0 +1,103 @@
+package keyring
+
+import (
+	"strings"
+	"syscall"
+
+	"github.com/danieljoos/wincred"
+)
+
+type windowsKeychain struct{}
+
+// Get gets a secret from the keyring given a service name and a user.
+func (k windowsKeychain) Get(service, username string) (string, error) {
+	cred, err := wincred.GetGenericCredential(k.credName(service, username))
+	if err != nil {
+		if err == syscall.ERROR_NOT_FOUND {
+			return "", ErrNotFound
+		}
+		return "", err
+	}
+
+	return string(cred.CredentialBlob), nil
+}
+
+// Set stores stores user and pass in the keyring under the defined service
+// name.
+func (k windowsKeychain) Set(service, username, password string) error {
+	// password may not exceed 2560 bytes (https://github.com/jaraco/keyring/issues/540#issuecomment-968329967)
+	if len(password) > 2560 {
+		return ErrSetDataTooBig
+	}
+
+	// service may not exceed 512 bytes (might need more testing)
+	if len(service) >= 512 {
+		return ErrSetDataTooBig
+	}
+
+	// service may not exceed 32k but problems occur before that
+	// so we limit it to 30k
+	if len(service) > 1024*30 {
+		return ErrSetDataTooBig
+	}
+
+	cred := wincred.NewGenericCredential(k.credName(service, username))
+	cred.UserName = username
+	cred.CredentialBlob = []byte(password)
+	return cred.Write()
+}
+
+// Delete deletes a secret, identified by service & user, from the keyring.
+func (k windowsKeychain) Delete(service, username string) error {
+	cred, err := wincred.GetGenericCredential(k.credName(service, username))
+	if err != nil {
+		if err == syscall.ERROR_NOT_FOUND {
+			return ErrNotFound
+		}
+		return err
+	}
+
+	return cred.Delete()
+}
+
+func (k windowsKeychain) DeleteAll(service string) error {
+	// if service is empty, do nothing otherwise it might accidentally delete all secrets
+	if service == "" {
+		return ErrNotFound
+	}
+
+	creds, err := wincred.List()
+	if err != nil {
+		return err
+	}
+
+	prefix := k.credName(service, "")
+	deletedCount := 0
+
+	for _, cred := range creds {
+		if strings.HasPrefix(cred.TargetName, prefix) {
+			genericCred, err := wincred.GetGenericCredential(cred.TargetName)
+			if err != nil {
+				if err != syscall.ERROR_NOT_FOUND {
+					return err
+				}
+			} else {
+				err := genericCred.Delete()
+				if err != nil {
+					return err
+				}
+				deletedCount++
+			}
+		}
+	}
+	return nil
+}
+
+// credName combines service and username to a single string.
+func (k windowsKeychain) credName(service, username string) string {
+	return service + ":" + username
+}
+
+func init() {
+	provider = windowsKeychain{}
+}

--- a/vendor/github.com/zalando/go-keyring/secret_service/secret_service.go
+++ b/vendor/github.com/zalando/go-keyring/secret_service/secret_service.go
@@ -1,0 +1,257 @@
+package ss
+
+import (
+	"fmt"
+
+	"errors"
+
+	dbus "github.com/godbus/dbus/v5"
+)
+
+const (
+	serviceName          = "org.freedesktop.secrets"
+	servicePath          = "/org/freedesktop/secrets"
+	serviceInterface     = "org.freedesktop.Secret.Service"
+	collectionInterface  = "org.freedesktop.Secret.Collection"
+	collectionsInterface = "org.freedesktop.Secret.Service.Collections"
+	itemInterface        = "org.freedesktop.Secret.Item"
+	sessionInterface     = "org.freedesktop.Secret.Session"
+	promptInterface      = "org.freedesktop.Secret.Prompt"
+
+	loginCollectionAlias = "/org/freedesktop/secrets/aliases/default"
+	collectionBasePath   = "/org/freedesktop/secrets/collection/"
+)
+
+// Secret defines a org.freedesk.Secret.Item secret struct.
+type Secret struct {
+	Session     dbus.ObjectPath
+	Parameters  []byte
+	Value       []byte
+	ContentType string `dbus:"content_type"`
+}
+
+// NewSecret initializes a new Secret.
+func NewSecret(session dbus.ObjectPath, secret string) Secret {
+	return Secret{
+		Session:     session,
+		Parameters:  []byte{},
+		Value:       []byte(secret),
+		ContentType: "text/plain; charset=utf8",
+	}
+}
+
+// SecretService is an interface for the Secret Service dbus API.
+type SecretService struct {
+	*dbus.Conn
+	object dbus.BusObject
+}
+
+// NewSecretService inializes a new SecretService object.
+func NewSecretService() (*SecretService, error) {
+	conn, err := dbus.SessionBus()
+	if err != nil {
+		return nil, err
+	}
+
+	return &SecretService{
+		conn,
+		conn.Object(serviceName, servicePath),
+	}, nil
+}
+
+// OpenSession opens a secret service session.
+func (s *SecretService) OpenSession() (dbus.BusObject, error) {
+	var disregard dbus.Variant
+	var sessionPath dbus.ObjectPath
+	err := s.object.Call(serviceInterface+".OpenSession", 0, "plain", dbus.MakeVariant("")).Store(&disregard, &sessionPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Object(serviceName, sessionPath), nil
+}
+
+// CheckCollectionPath accepts dbus path and returns nil if the path is found
+// in the collection interface (and can be used).
+func (s *SecretService) CheckCollectionPath(path dbus.ObjectPath) error {
+	obj := s.Conn.Object(serviceName, servicePath)
+	val, err := obj.GetProperty(collectionsInterface)
+	if err != nil {
+		return err
+	}
+	paths := val.Value().([]dbus.ObjectPath)
+	for _, p := range paths {
+		if p == path {
+			return nil
+		}
+	}
+	return errors.New("path not found")
+}
+
+// GetCollection returns a collection from a name.
+func (s *SecretService) GetCollection(name string) dbus.BusObject {
+	return s.Object(serviceName, dbus.ObjectPath(collectionBasePath+name))
+}
+
+// GetLoginCollection decides and returns the dbus collection to be used for login.
+func (s *SecretService) GetLoginCollection() dbus.BusObject {
+	path := dbus.ObjectPath(collectionBasePath + "login")
+	if err := s.CheckCollectionPath(path); err != nil {
+		path = dbus.ObjectPath(loginCollectionAlias)
+	}
+	return s.Object(serviceName, path)
+}
+
+// Unlock unlocks a collection.
+func (s *SecretService) Unlock(collection dbus.ObjectPath) error {
+	var unlocked []dbus.ObjectPath
+	var prompt dbus.ObjectPath
+	err := s.object.Call(serviceInterface+".Unlock", 0, []dbus.ObjectPath{collection}).Store(&unlocked, &prompt)
+	if err != nil {
+		return err
+	}
+
+	_, v, err := s.handlePrompt(prompt)
+	if err != nil {
+		return err
+	}
+
+	collections := v.Value()
+	switch c := collections.(type) {
+	case []dbus.ObjectPath:
+		unlocked = append(unlocked, c...)
+	}
+
+	if len(unlocked) != 1 || (collection != loginCollectionAlias && unlocked[0] != collection) {
+		return fmt.Errorf("failed to unlock correct collection '%v'", collection)
+	}
+
+	return nil
+}
+
+// Close closes a secret service dbus session.
+func (s *SecretService) Close(session dbus.BusObject) error {
+	return session.Call(sessionInterface+".Close", 0).Err
+}
+
+// CreateCollection with the supplied label.
+func (s *SecretService) CreateCollection(label string) (dbus.BusObject, error) {
+	properties := map[string]dbus.Variant{
+		collectionInterface + ".Label": dbus.MakeVariant(label),
+	}
+	var collection, prompt dbus.ObjectPath
+	err := s.object.Call(serviceInterface+".CreateCollection", 0, properties, "").
+		Store(&collection, &prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	_, v, err := s.handlePrompt(prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	if v.String() != "" {
+		collection = dbus.ObjectPath(v.String())
+	}
+
+	return s.Object(serviceName, collection), nil
+}
+
+// CreateItem creates an item in a collection, with label, attributes and a
+// related secret.
+func (s *SecretService) CreateItem(collection dbus.BusObject, label string, attributes map[string]string, secret Secret) error {
+	properties := map[string]dbus.Variant{
+		itemInterface + ".Label":      dbus.MakeVariant(label),
+		itemInterface + ".Attributes": dbus.MakeVariant(attributes),
+	}
+
+	var item, prompt dbus.ObjectPath
+	err := collection.Call(collectionInterface+".CreateItem", 0,
+		properties, secret, true).Store(&item, &prompt)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = s.handlePrompt(prompt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// handlePrompt checks if a prompt should be handles and handles it by
+// triggering the prompt and waiting for the Secret service daemon to display
+// the prompt to the user.
+func (s *SecretService) handlePrompt(prompt dbus.ObjectPath) (bool, dbus.Variant, error) {
+	if prompt != dbus.ObjectPath("/") {
+		err := s.AddMatchSignal(dbus.WithMatchObjectPath(prompt),
+			dbus.WithMatchInterface(promptInterface),
+		)
+		if err != nil {
+			return false, dbus.MakeVariant(""), err
+		}
+
+		defer func(s *SecretService, options ...dbus.MatchOption) {
+			_ = s.RemoveMatchSignal(options...)
+		}(s, dbus.WithMatchObjectPath(prompt), dbus.WithMatchInterface(promptInterface))
+
+		promptSignal := make(chan *dbus.Signal, 1)
+		s.Signal(promptSignal)
+
+		err = s.Object(serviceName, prompt).Call(promptInterface+".Prompt", 0, "").Err
+		if err != nil {
+			return false, dbus.MakeVariant(""), err
+		}
+
+		signal := <-promptSignal
+		switch signal.Name {
+		case promptInterface + ".Completed":
+			dismissed := signal.Body[0].(bool)
+			result := signal.Body[1].(dbus.Variant)
+			return dismissed, result, nil
+		}
+
+	}
+
+	return false, dbus.MakeVariant(""), nil
+}
+
+// SearchItems returns a list of items matching the search object.
+func (s *SecretService) SearchItems(collection dbus.BusObject, search interface{}) ([]dbus.ObjectPath, error) {
+	var results []dbus.ObjectPath
+	err := collection.Call(collectionInterface+".SearchItems", 0, search).Store(&results)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetSecret gets secret from an item in a given session.
+func (s *SecretService) GetSecret(itemPath dbus.ObjectPath, session dbus.ObjectPath) (*Secret, error) {
+	var secret Secret
+	err := s.Object(serviceName, itemPath).Call(itemInterface+".GetSecret", 0, session).Store(&secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return &secret, nil
+}
+
+// Delete deletes an item from the collection.
+func (s *SecretService) Delete(itemPath dbus.ObjectPath) error {
+	var prompt dbus.ObjectPath
+	err := s.Object(serviceName, itemPath).Call(itemInterface+".Delete", 0).Store(&prompt)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = s.handlePrompt(prompt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -507,6 +507,9 @@ github.com/cpuguy83/dockercfg
 # github.com/cpuguy83/go-md2man/v2 v2.0.4
 ## explicit; go 1.11
 github.com/cpuguy83/go-md2man/v2/md2man
+# github.com/danieljoos/wincred v1.2.3
+## explicit; go 1.18
+github.com/danieljoos/wincred
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
@@ -617,6 +620,9 @@ github.com/go-openapi/swag
 ## explicit; go 1.18
 github.com/go-viper/mapstructure/v2
 github.com/go-viper/mapstructure/v2/internal/errors
+# github.com/godbus/dbus/v5 v5.2.2
+## explicit; go 1.20
+github.com/godbus/dbus/v5
 # github.com/gogo/protobuf v1.3.2
 ## explicit; go 1.15
 github.com/gogo/protobuf/gogoproto
@@ -1299,6 +1305,11 @@ github.com/yuin/gopher-lua/pm
 # github.com/yusufpapurcu/wmi v1.2.4
 ## explicit; go 1.16
 github.com/yusufpapurcu/wmi
+# github.com/zalando/go-keyring v0.2.8
+## explicit; go 1.18
+github.com/zalando/go-keyring
+github.com/zalando/go-keyring/internal/shellescape
+github.com/zalando/go-keyring/secret_service
 # go.opencensus.io v0.24.0
 ## explicit; go 1.13
 go.opencensus.io


### PR DESCRIPTION
## Summary
- add top-level login and logout commands with device authorization
- store credentials in the OS keyring with an explicit file fallback
- refresh and use OAuth sessions for v2 API commands
- add the dashboard approval screen and shared permission picker
- default CLI API requests to the production environment

## Verification
- focused auth, command, and API CLI tests
- dashboard typecheck and production build
- local end-to-end login, approval, credential storage, and get-apps request

## Stack
Based on poc-authz. The companion Cloud PR adds the OAuth server and v2 authentication.