### PR TITLE
chore: remove former owners from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,7 @@
 /ui @amh4r @djfarrelly @jacobheric
 
 # Execution
-/pkg/execution @tonyhb @BrunoScheufler @KiKoS0 @jpwilliams @lkasinathan
+/pkg/execution @tonyhb @BrunoScheufler @KiKoS0 @lkasinathan
 /pkg/constraintapi @BrunoScheufler @lkasinathan
 /pkg/execution/state @tonyhb @BrunoScheufler @KiKoS0 @lkasinathan
 /pkg/telemetry @BrunoScheufler
-/pkg/run @jpwilliams

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,8 @@
 /ui @amh4r @djfarrelly @jacobheric
 
 # Execution
-/pkg/execution @tonyhb @darwin67 @BrunoScheufler @KiKoS0 @jpwilliams @lkasinathan
+/pkg/execution @tonyhb @BrunoScheufler @KiKoS0 @jpwilliams @lkasinathan
 /pkg/constraintapi @BrunoScheufler @lkasinathan
-/pkg/execution/state @tonyhb @darwin67 @BrunoScheufler @KiKoS0 @lkasinathan
-/pkg/telemetry @darwin67 @BrunoScheufler
-/pkg/run @darwin67 @jpwilliams
+/pkg/execution/state @tonyhb @BrunoScheufler @KiKoS0 @lkasinathan
+/pkg/telemetry @BrunoScheufler
+/pkg/run @jpwilliams

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # UI
-/ui @amh4r @djfarrelly @jacobheric
+/ui @amh4r @jacobheric
 
 # Execution
 /pkg/execution @tonyhb @BrunoScheufler @KiKoS0 @lkasinathan


### PR DESCRIPTION
## Description

Removes @darwin67, @jpwilliams, and @djfarrelly from CODEOWNERS.

## Release note

None

## Migration note

None