### PR TITLE
fix(metrics): handle absent values explicitly in backlog and steps-running charts

### DIFF
--- a/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
@@ -31,6 +31,7 @@ type SimpleLineChartProps = {
     values: {
       [key: string]: number | boolean | undefined;
     };
+    inferred?: string[];
   }[];
   legend: {
     dataKey: string;
@@ -101,7 +102,7 @@ export default function SimpleLineChart({
   const flattenData = useMemo(() => {
     return data.map((d) => {
       const values = omit(d.values, referenceAreaKeys);
-      return { ...values, name: d.name };
+      return { ...values, name: d.name, inferred: d.inferred };
     });
   }, [data, referenceAreaKeys]);
 
@@ -224,6 +225,9 @@ export default function SimpleLineChart({
                       ) : (
                         metricPayload.map((p, idx) => {
                           const l = legend.find((l) => l.dataKey == p.name);
+                          const inferred =
+                            Array.isArray(p.payload?.inferred) &&
+                            p.payload.inferred.includes(p.name);
                           return (
                             <div
                               key={idx}
@@ -233,7 +237,12 @@ export default function SimpleLineChart({
                                 className="mr-2 inline-flex h-3 w-3 rounded"
                                 style={{ backgroundColor: l?.color || p.color }}
                               ></span>
-                              {p.value == null ? (
+                              {inferred ? (
+                                <>
+                                  {l?.name || p.name}: No data recorded —
+                                  displayed as 0
+                                </>
+                              ) : p.value == null ? (
                                 <>{l?.name || p.name}: No data recorded</>
                               ) : (
                                 <>

--- a/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
@@ -29,7 +29,7 @@ type SimpleLineChartProps = {
   data?: {
     name: string;
     values: {
-      [key: string]: number | boolean;
+      [key: string]: number | boolean | undefined;
     };
   }[];
   legend: {
@@ -39,6 +39,7 @@ type SimpleLineChartProps = {
     default?: boolean;
     referenceArea?: boolean;
   }[];
+  connectNulls?: boolean;
   isLoading: boolean;
   error?: Error;
 };
@@ -88,6 +89,7 @@ export default function SimpleLineChart({
   desc,
   data = [],
   legend = [],
+  connectNulls = false,
   isLoading,
   error,
 }: SimpleLineChartProps) {
@@ -198,36 +200,56 @@ export default function SimpleLineChart({
                 }),
               )}
               <ChartTooltip
+                filterNull={false}
                 content={(props) => {
                   const { label, payload } = props;
+                  const metricPayload =
+                    payload?.filter((item) => {
+                      return !legend.find(
+                        (entry) => entry.dataKey === item.name,
+                      )?.referenceArea;
+                    }) ?? [];
+                  const hasReportedData = metricPayload.some(
+                    (item) => item.value != null,
+                  );
                   return (
                     <div className="shadow-tooltip bg-canvasBase rounded-md px-3 pb-2 pt-1 text-sm shadow-md">
                       <div className="text-muted pb-2">
                         {new Date(label).toLocaleString()}
                       </div>
-                      {payload?.map((p, idx) => {
-                        // @ts-ignore
-                        if (p.value === false) return;
-                        const l = legend.find((l) => l.dataKey == p.name);
-                        return (
-                          <div
-                            key={idx}
-                            className="text-muted flex items-center text-sm font-medium"
-                          >
-                            <span
-                              className="mr-2 inline-flex h-3 w-3 rounded"
-                              style={{ backgroundColor: l?.color || p.color }}
-                            ></span>
-                            {typeof p.value === 'number'
-                              ? p.value.toLocaleString(undefined, {
-                                  notation: 'compact',
-                                  compactDisplay: 'short',
-                                })
-                              : ''}{' '}
-                            {l?.name || p.name}
-                          </div>
-                        );
-                      }) || ''}
+                      {!hasReportedData ? (
+                        <div className="text-muted text-sm font-medium">
+                          No data recorded
+                        </div>
+                      ) : (
+                        metricPayload.map((p, idx) => {
+                          const l = legend.find((l) => l.dataKey == p.name);
+                          return (
+                            <div
+                              key={idx}
+                              className="text-muted flex items-center text-sm font-medium"
+                            >
+                              <span
+                                className="mr-2 inline-flex h-3 w-3 rounded"
+                                style={{ backgroundColor: l?.color || p.color }}
+                              ></span>
+                              {p.value == null ? (
+                                <>{l?.name || p.name}: No data recorded</>
+                              ) : (
+                                <>
+                                  {typeof p.value === 'number'
+                                    ? p.value.toLocaleString(undefined, {
+                                        notation: 'compact',
+                                        compactDisplay: 'short',
+                                      })
+                                    : ''}{' '}
+                                  {l?.name || p.name}
+                                </>
+                              )}
+                            </div>
+                          );
+                        })
+                      )}
                     </div>
                   );
                 }}
@@ -236,6 +258,7 @@ export default function SimpleLineChart({
               />
               {legend.map((l) => (
                 <Line
+                  connectNulls={connectNulls}
                   dot={false}
                   key={l.name}
                   type="monotone"

--- a/ui/apps/dashboard/src/components/Functions/StepBacklogChart.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StepBacklogChart.tsx
@@ -69,7 +69,18 @@ export default function StepBacklogChart({
     data?.environment.function?.scheduled.granularity ??
     data?.environment.function?.sleeping.granularity ??
     '1m';
-  const metrics = mergeBacklogMetrics(scheduled, sleeping, granularity);
+  // Both responses cover the same requested range, so use either one for the bounds.
+  const rangeStart =
+    data?.environment.function?.scheduled.from ?? startTime;
+  const rangeEnd =
+    data?.environment.function?.scheduled.to ?? endTime;
+  const metrics = mergeBacklogMetrics(
+    scheduled,
+    sleeping,
+    granularity,
+    rangeStart,
+    rangeEnd,
+  );
 
   return (
     <SimpleLineChart

--- a/ui/apps/dashboard/src/components/Functions/StepBacklogChart.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StepBacklogChart.tsx
@@ -4,6 +4,7 @@ import { useQuery } from 'urql';
 import SimpleLineChart from '@/components/Charts/SimpleLineChart';
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { graphql } from '@/gql';
+import { mergeBacklogMetrics } from './mergeBacklogMetrics';
 
 const GetStepBacklogDocument = graphql(`
   query GetStepBacklogMetrics(
@@ -64,16 +65,11 @@ export default function StepBacklogChart({
 
   const scheduled = data?.environment.function?.scheduled.data ?? [];
   const sleeping = data?.environment.function?.sleeping.data ?? [];
-
-  const maxLength = Math.max(scheduled.length, sleeping.length);
-
-  const metrics = Array.from({ length: maxLength }).map((_, idx) => ({
-    name: scheduled[idx]?.bucket || sleeping[idx]?.bucket || '',
-    values: {
-      scheduled: scheduled[idx]?.value ?? 0,
-      sleeping: sleeping[idx]?.value ?? 0,
-    },
-  }));
+  const granularity =
+    data?.environment.function?.scheduled.granularity ??
+    data?.environment.function?.sleeping.granularity ??
+    '1m';
+  const metrics = mergeBacklogMetrics(scheduled, sleeping, granularity);
 
   return (
     <SimpleLineChart
@@ -84,6 +80,7 @@ export default function StepBacklogChart({
         { name: 'Queued', dataKey: 'scheduled', color: colors.slate['500'] },
         { name: 'Sleeping', dataKey: 'sleeping', color: colors.teal['500'] },
       ]}
+      connectNulls
       isLoading={isFetchingMetrics}
       error={metricsError}
     />

--- a/ui/apps/dashboard/src/components/Functions/StepsRunningChart.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StepsRunningChart.tsx
@@ -4,6 +4,7 @@ import { useQuery } from 'urql';
 import SimpleLineChart from '@/components/Charts/SimpleLineChart';
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { graphql } from '@/gql';
+import { mergeStepsRunningMetrics } from './mergeStepsRunningMetrics';
 
 const GetStepsRunningDocument = graphql(`
   query GetStepsRunningMetrics(
@@ -68,16 +69,15 @@ export default function StepsRunningChart({
   const running = data?.environment.function?.running.data ?? [];
   const concurrencyLimit =
     data?.environment.function?.concurrencyLimit.data ?? [];
-
-  const maxLength = Math.max(running.length, concurrencyLimit.length);
-
-  const metrics = Array.from({ length: maxLength }).map((_, idx) => ({
-    name: running[idx]?.bucket || concurrencyLimit[idx]?.bucket || '',
-    values: {
-      running: running[idx]?.value ?? 0,
-      concurrencyLimit: Boolean(concurrencyLimit[idx]?.value),
-    },
-  }));
+  const granularity =
+    data?.environment.function?.running.granularity ??
+    data?.environment.function?.concurrencyLimit.granularity ??
+    '1m';
+  const metrics = mergeStepsRunningMetrics(
+    running,
+    concurrencyLimit,
+    granularity,
+  );
 
   return (
     <SimpleLineChart
@@ -93,6 +93,7 @@ export default function StepsRunningChart({
         },
         { name: 'Running', dataKey: 'running', color: colors.blue['500'] },
       ]}
+      connectNulls
       isLoading={isFetchingMetrics}
       error={metricsError}
     />

--- a/ui/apps/dashboard/src/components/Functions/StepsRunningChart.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StepsRunningChart.tsx
@@ -73,10 +73,15 @@ export default function StepsRunningChart({
     data?.environment.function?.running.granularity ??
     data?.environment.function?.concurrencyLimit.granularity ??
     '1m';
+  // Both responses cover the same requested range, so use either one for the bounds.
+  const rangeStart = data?.environment.function?.running.from ?? startTime;
+  const rangeEnd = data?.environment.function?.running.to ?? endTime;
   const metrics = mergeStepsRunningMetrics(
     running,
     concurrencyLimit,
     granularity,
+    rangeStart,
+    rangeEnd,
   );
 
   return (

--- a/ui/apps/dashboard/src/components/Functions/findSustainedMissingBuckets.ts
+++ b/ui/apps/dashboard/src/components/Functions/findSustainedMissingBuckets.ts
@@ -1,0 +1,54 @@
+type Metric = {
+  bucket: string;
+};
+
+const MISSING_DATA_THRESHOLD_MS = 3 * 60_000;
+
+/**
+ * Returns the timestamps in contiguous gaps that lasted at least three
+ * minutes. It scans the complete buckets in the requested range and ignores
+ * partial edge buckets, which may simply not have reported yet. An empty
+ * series remains empty.
+ */
+export function findSustainedMissingBuckets(
+  observations: Metric[],
+  bucketWidth: number,
+  rangeStart: string,
+  rangeEnd: string,
+) {
+  if (observations.length === 0) return [];
+
+  const observed = new Set(
+    observations.map(({ bucket }) => new Date(bucket).getTime()),
+  );
+  const firstCompleteBucket =
+    Math.ceil(new Date(rangeStart).getTime() / bucketWidth) * bucketWidth;
+  const lastCompleteBucket =
+    Math.floor(new Date(rangeEnd).getTime() / bucketWidth) * bucketWidth -
+    bucketWidth;
+  const inferred: number[] = [];
+  let missing: number[] = [];
+
+  for (
+    let timestamp = firstCompleteBucket;
+    timestamp <= lastCompleteBucket;
+    timestamp += bucketWidth
+  ) {
+    if (!observed.has(timestamp)) {
+      missing.push(timestamp);
+    }
+
+    if (
+      (observed.has(timestamp) || timestamp === lastCompleteBucket) &&
+      missing.length * bucketWidth >= MISSING_DATA_THRESHOLD_MS
+    ) {
+      inferred.push(...missing);
+    }
+
+    if (observed.has(timestamp)) {
+      missing = [];
+    }
+  }
+
+  return inferred;
+}

--- a/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.test.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.test.ts
@@ -16,6 +16,8 @@ describe('mergeBacklogMetrics', () => {
           { bucket: '2026-08-23T03:18:00Z', value: 10 },
         ],
         '1m',
+        '2026-08-23T03:16:00Z',
+        '2026-08-23T03:21:00Z',
       ),
     ).toEqual([
       {
@@ -38,6 +40,129 @@ describe('mergeBacklogMetrics', () => {
         name: '2026-08-23T03:20:00Z',
         values: { scheduled: 0 },
       },
+    ]);
+  });
+
+  test('shows gaps lasting at least three minutes as inferred zeroes', () => {
+    expect(
+      mergeBacklogMetrics(
+        [
+          { bucket: '2026-08-23T03:16:00Z', value: 144650 },
+          { bucket: '2026-08-23T03:20:00Z', value: 144607 },
+        ],
+        [],
+        '1m',
+        '2026-08-23T03:13:00Z',
+        '2026-08-23T03:24:30Z',
+      ),
+    ).toEqual([
+      {
+        name: '2026-08-23T03:13:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: '2026-08-23T03:14:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: '2026-08-23T03:15:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: '2026-08-23T03:16:00Z',
+        values: { scheduled: 144650 },
+      },
+      {
+        name: '2026-08-23T03:17:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: '2026-08-23T03:18:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: '2026-08-23T03:19:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: '2026-08-23T03:20:00Z',
+        values: { scheduled: 144607 },
+      },
+      {
+        name: '2026-08-23T03:21:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: '2026-08-23T03:22:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: '2026-08-23T03:23:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+    ]);
+  });
+
+  test('leaves gaps shorter than three minutes and empty responses blank', () => {
+    expect(
+      mergeBacklogMetrics(
+        [
+          { bucket: '2026-08-23T03:16:00Z', value: 4 },
+          { bucket: '2026-08-23T03:18:00Z', value: 3 },
+          { bucket: '2026-08-23T03:20:00Z', value: 2 },
+        ],
+        [],
+        '1m',
+        '2026-08-23T03:14:00Z',
+        '2026-08-23T03:23:30Z',
+      ).map(({ name, values }) => ({ name, values })),
+    ).toEqual([
+      { name: '2026-08-23T03:16:00Z', values: { scheduled: 4 } },
+      { name: '2026-08-23T03:17:00.000Z', values: {} },
+      { name: '2026-08-23T03:18:00Z', values: { scheduled: 3 } },
+      { name: '2026-08-23T03:19:00.000Z', values: {} },
+      { name: '2026-08-23T03:20:00Z', values: { scheduled: 2 } },
+    ]);
+    expect(
+      mergeBacklogMetrics(
+        [],
+        [],
+        '1m',
+        '2026-08-23T03:00:00Z',
+        '2026-08-23T04:00:00Z',
+      ),
+    ).toEqual([]);
+  });
+
+  test('uses elapsed time rather than bucket count for the threshold', () => {
+    expect(
+      mergeBacklogMetrics(
+        [
+          { bucket: '2026-08-23T03:10:00Z', value: 4 },
+          { bucket: '2026-08-23T03:20:00Z', value: 2 },
+        ],
+        [],
+        '5m',
+        '2026-08-23T03:10:00Z',
+        '2026-08-23T03:25:00Z',
+      ),
+    ).toEqual([
+      { name: '2026-08-23T03:10:00Z', values: { scheduled: 4 } },
+      {
+        name: '2026-08-23T03:15:00.000Z',
+        values: { scheduled: 0 },
+        inferred: ['scheduled'],
+      },
+      { name: '2026-08-23T03:20:00Z', values: { scheduled: 2 } },
     ]);
   });
 });

--- a/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.test.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+
+import { mergeBacklogMetrics } from './mergeBacklogMetrics';
+
+describe('mergeBacklogMetrics', () => {
+  test('joins sparse series by timestamp without inventing zeroes', () => {
+    expect(
+      mergeBacklogMetrics(
+        [
+          { bucket: '2026-08-23T03:16:00Z', value: 144650 },
+          { bucket: '2026-08-23T03:18:00Z', value: 144607 },
+          { bucket: '2026-08-23T03:20:00Z', value: 0 },
+        ],
+        [
+          { bucket: '2026-08-23T03:17:00Z', value: 12 },
+          { bucket: '2026-08-23T03:18:00Z', value: 10 },
+        ],
+        '1m',
+      ),
+    ).toEqual([
+      {
+        name: '2026-08-23T03:16:00Z',
+        values: { scheduled: 144650 },
+      },
+      {
+        name: '2026-08-23T03:17:00Z',
+        values: { sleeping: 12 },
+      },
+      {
+        name: '2026-08-23T03:18:00Z',
+        values: { scheduled: 144607, sleeping: 10 },
+      },
+      {
+        name: '2026-08-23T03:19:00.000Z',
+        values: {},
+      },
+      {
+        name: '2026-08-23T03:20:00Z',
+        values: { scheduled: 0 },
+      },
+    ]);
+  });
+});

--- a/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.ts
@@ -1,17 +1,27 @@
 import type { Metric } from './mergeMetricRows';
 import { mergeMetricRows } from './mergeMetricRows';
 
-/** Converts separate Queued and Sleeping results into one row per timestamp. */
+/**
+ * Converts the separate Queued and Sleeping results from the backend into
+ * chart data with one row per timestamp. Both results are gauges whose numeric
+ * values are plotted as lines, so the missing-data policy is applied to each:
+ * short gaps remain absent for the chart to connect over, while gaps of at
+ * least three minutes are represented as zero and marked as inferred.
+ */
 export function mergeBacklogMetrics(
   scheduled: Metric[],
   sleeping: Metric[],
   granularity: string,
+  rangeStart: string,
+  rangeEnd: string,
 ) {
   return mergeMetricRows(
     [
-      { key: 'scheduled', data: scheduled },
-      { key: 'sleeping', data: sleeping },
+      { key: 'scheduled', data: scheduled, inferMissingAsZero: true },
+      { key: 'sleeping', data: sleeping, inferMissingAsZero: true },
     ],
     granularity,
+    rangeStart,
+    rangeEnd,
   );
 }

--- a/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.ts
@@ -1,0 +1,17 @@
+import type { Metric } from './mergeMetricRows';
+import { mergeMetricRows } from './mergeMetricRows';
+
+/** Converts separate Queued and Sleeping results into one row per timestamp. */
+export function mergeBacklogMetrics(
+  scheduled: Metric[],
+  sleeping: Metric[],
+  granularity: string,
+) {
+  return mergeMetricRows(
+    [
+      { key: 'scheduled', data: scheduled },
+      { key: 'sleeping', data: sleeping },
+    ],
+    granularity,
+  );
+}

--- a/ui/apps/dashboard/src/components/Functions/mergeMetricRows.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeMetricRows.ts
@@ -1,0 +1,60 @@
+export type Metric = {
+  bucket: string;
+  value: number;
+};
+
+export type MetricSeries = {
+  key: string;
+  data: Metric[];
+  mapValue?: (value: number) => number | boolean;
+};
+
+type MetricRow = {
+  name: string;
+  values: Record<string, number | boolean | undefined>;
+};
+
+/** Builds one chart row per timestamp from independently reported series. */
+export function mergeMetricRows(
+  series: MetricSeries[],
+  granularity: string,
+) {
+  const byBucket = new Map<number, MetricRow>();
+
+  for (const { key, data, mapValue } of series) {
+    for (const { bucket, value } of data) {
+      const timestamp = new Date(bucket).getTime();
+      const metric = byBucket.get(timestamp) ?? { name: bucket, values: {} };
+      metric.values[key] = mapValue ? mapValue(value) : value;
+      byBucket.set(timestamp, metric);
+    }
+  }
+
+  const observed = Array.from(byBucket.values()).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
+  if (observed.length < 2) {
+    return observed;
+  }
+
+  const amount = Number.parseInt(granularity, 10);
+  const bucketWidth = amount * (granularity.endsWith('h') ? 60 : 1) * 60_000;
+  const firstBucket = new Date(observed[0].name).getTime();
+  const lastBucket = new Date(observed.at(-1)!.name).getTime();
+  const metrics: MetricRow[] = [];
+
+  for (
+    let timestamp = firstBucket;
+    timestamp <= lastBucket;
+    timestamp += bucketWidth
+  ) {
+    metrics.push(
+      byBucket.get(timestamp) ?? {
+        name: new Date(timestamp).toISOString(),
+        values: {},
+      },
+    );
+  }
+
+  return metrics;
+}

--- a/ui/apps/dashboard/src/components/Functions/mergeMetricRows.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeMetricRows.ts
@@ -1,3 +1,5 @@
+import { findSustainedMissingBuckets } from './findSustainedMissingBuckets';
+
 export type Metric = {
   bucket: string;
   value: number;
@@ -7,17 +9,21 @@ export type MetricSeries = {
   key: string;
   data: Metric[];
   mapValue?: (value: number) => number | boolean;
+  inferMissingAsZero?: boolean;
 };
 
 type MetricRow = {
   name: string;
   values: Record<string, number | boolean | undefined>;
+  inferred?: string[];
 };
 
 /** Builds one chart row per timestamp from independently reported series. */
 export function mergeMetricRows(
   series: MetricSeries[],
   granularity: string,
+  rangeStart: string,
+  rangeEnd: string,
 ) {
   const byBucket = new Map<number, MetricRow>();
 
@@ -30,6 +36,28 @@ export function mergeMetricRows(
     }
   }
 
+  const amount = Number.parseInt(granularity, 10);
+  const bucketWidth = amount * (granularity.endsWith('h') ? 60 : 1) * 60_000;
+
+  for (const { key, data, inferMissingAsZero } of series) {
+    if (!inferMissingAsZero) continue;
+
+    for (const timestamp of findSustainedMissingBuckets(
+      data,
+      bucketWidth,
+      rangeStart,
+      rangeEnd,
+    )) {
+      const metric = byBucket.get(timestamp) ?? {
+        name: new Date(timestamp).toISOString(),
+        values: {},
+      };
+      metric.values[key] = 0;
+      metric.inferred = [...(metric.inferred ?? []), key];
+      byBucket.set(timestamp, metric);
+    }
+  }
+
   const observed = Array.from(byBucket.values()).sort((a, b) =>
     a.name.localeCompare(b.name),
   );
@@ -37,8 +65,6 @@ export function mergeMetricRows(
     return observed;
   }
 
-  const amount = Number.parseInt(granularity, 10);
-  const bucketWidth = amount * (granularity.endsWith('h') ? 60 : 1) * 60_000;
   const firstBucket = new Date(observed[0].name).getTime();
   const lastBucket = new Date(observed.at(-1)!.name).getTime();
   const metrics: MetricRow[] = [];

--- a/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.test.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { mergeStepsRunningMetrics } from './mergeStepsRunningMetrics';
 
 describe('mergeStepsRunningMetrics', () => {
-  test('joins sparse series by timestamp without inventing zeroes', () => {
+  test('shows running gaps lasting at least three minutes as inferred zeroes', () => {
     expect(
       mergeStepsRunningMetrics(
         [
@@ -12,6 +12,8 @@ describe('mergeStepsRunningMetrics', () => {
         ],
         [{ bucket: '2026-08-23T03:18:00Z', value: 1 }],
         '1m',
+        '2026-08-23T03:16:00Z',
+        '2026-08-23T03:21:00Z',
       ),
     ).toEqual([
       {
@@ -20,15 +22,18 @@ describe('mergeStepsRunningMetrics', () => {
       },
       {
         name: '2026-08-23T03:17:00.000Z',
-        values: {},
+        values: { running: 0 },
+        inferred: ['running'],
       },
       {
         name: '2026-08-23T03:18:00Z',
-        values: { concurrencyLimit: true },
+        values: { concurrencyLimit: true, running: 0 },
+        inferred: ['running'],
       },
       {
         name: '2026-08-23T03:19:00.000Z',
-        values: {},
+        values: { running: 0 },
+        inferred: ['running'],
       },
       {
         name: '2026-08-23T03:20:00Z',

--- a/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.test.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+
+import { mergeStepsRunningMetrics } from './mergeStepsRunningMetrics';
+
+describe('mergeStepsRunningMetrics', () => {
+  test('joins sparse series by timestamp without inventing zeroes', () => {
+    expect(
+      mergeStepsRunningMetrics(
+        [
+          { bucket: '2026-08-23T03:16:00Z', value: 12 },
+          { bucket: '2026-08-23T03:20:00Z', value: 10 },
+        ],
+        [{ bucket: '2026-08-23T03:18:00Z', value: 1 }],
+        '1m',
+      ),
+    ).toEqual([
+      {
+        name: '2026-08-23T03:16:00Z',
+        values: { running: 12 },
+      },
+      {
+        name: '2026-08-23T03:17:00.000Z',
+        values: {},
+      },
+      {
+        name: '2026-08-23T03:18:00Z',
+        values: { concurrencyLimit: true },
+      },
+      {
+        name: '2026-08-23T03:19:00.000Z',
+        values: {},
+      },
+      {
+        name: '2026-08-23T03:20:00Z',
+        values: { running: 10 },
+      },
+    ]);
+  });
+});

--- a/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.ts
@@ -1,17 +1,29 @@
 import type { Metric } from './mergeMetricRows';
 import { mergeMetricRows } from './mergeMetricRows';
 
-/** Converts separate Running and concurrency-limit results into chart rows. */
+/**
+ * Converts the separate Running and concurrency-limit results from the backend
+ * into chart data with one row per timestamp. Running is a gauge whose numeric
+ * values are plotted as a line, so short gaps remain absent and gaps of at
+ * least three minutes are represented as inferred zeroes. Concurrency Limit is
+ * instead a marker that changes the chart background; its numeric value is
+ * converted to a boolean at the matching timestamp, and missing markers are
+ * not inferred because absence means the limit was not hit.
+ */
 export function mergeStepsRunningMetrics(
   running: Metric[],
   concurrencyLimit: Metric[],
   granularity: string,
+  rangeStart: string,
+  rangeEnd: string,
 ) {
   return mergeMetricRows(
     [
-      { key: 'running', data: running },
+      { key: 'running', data: running, inferMissingAsZero: true },
       { key: 'concurrencyLimit', data: concurrencyLimit, mapValue: Boolean },
     ],
     granularity,
+    rangeStart,
+    rangeEnd,
   );
 }

--- a/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.ts
@@ -1,0 +1,17 @@
+import type { Metric } from './mergeMetricRows';
+import { mergeMetricRows } from './mergeMetricRows';
+
+/** Converts separate Running and concurrency-limit results into chart rows. */
+export function mergeStepsRunningMetrics(
+  running: Metric[],
+  concurrencyLimit: Metric[],
+  granularity: string,
+) {
+  return mergeMetricRows(
+    [
+      { key: 'running', data: running },
+      { key: 'concurrencyLimit', data: concurrencyLimit, mapValue: Boolean },
+    ],
+    granularity,
+  );
+}

--- a/ui/apps/dashboard/src/components/Metrics/Backlog.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Backlog.tsx
@@ -17,7 +17,8 @@ export const Backlog = ({
   entities: EntityLookup;
 }) => {
   const metrics =
-    workspace && mapEntityLines(workspace.backlog.metrics, entities);
+    workspace &&
+    mapEntityLines(workspace.backlog.metrics, entities, { connectNulls: true });
 
   return (
     <div className="bg-canvasBase border-subtle relative flex h-[384px] w-full flex-col overflow-x-hidden rounded-md border p-5">

--- a/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
@@ -36,7 +36,7 @@ export const mapConcurrency = (
         lineStyle: { color: resolveColor(borderColor.subtle, dark, '#E2E2E2') },
       },
     },
-    xAxis: getXAxis(runningMetrics),
+    xAxis: getXAxis(runningMetrics[0]?.data),
     series: [
       ...visibleMetrics.map((f, i) => ({
         ...seriesOptions,

--- a/ui/apps/dashboard/src/components/Metrics/SdkThroughput.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/SdkThroughput.tsx
@@ -56,7 +56,9 @@ export const mapSdkThroughput = ({
     scopedMetric(ended, sum(sdkThroughputEnded.metrics)),
   ];
 
-  return mapEntityLines(metrics, entityLookup, { opacity: 0.1 });
+  return mapEntityLines(metrics, entityLookup, {
+    areaStyle: { opacity: 0.1 },
+  });
 };
 
 export const SdkThroughput = ({

--- a/ui/apps/dashboard/src/components/Metrics/utils.ts
+++ b/ui/apps/dashboard/src/components/Metrics/utils.ts
@@ -11,7 +11,7 @@ import {
 } from '@inngest/components/utils/date';
 import { isDark } from '@inngest/components/utils/theme';
 
-import type { MetricsData, MetricsResponse, ScopedMetric } from '@/gql/graphql';
+import type { MetricsData, ScopedMetric } from '@/gql/graphql';
 import {
   backgroundColor,
   colors,
@@ -34,7 +34,7 @@ export type LineChartData = {
     data?: string[];
   };
   series: Array<{
-    data: number[];
+    data: Array<number | null>;
     name?: string;
     itemStyle: { color: string };
   }>;
@@ -67,8 +67,8 @@ export const dateFormat = (dateString: string, diff: number) => {
   return d < 6000 // a minute
     ? lightFormat(date, 'HH:mm:ss:SSS')
     : d <= 8.64e7 // a day
-    ? lightFormat(date, 'HH:mm')
-    : lightFormat(date, 'MM/dd:HH');
+      ? lightFormat(date, 'HH:mm')
+      : lightFormat(date, 'MM/dd:HH');
 };
 
 export const timeDiff = (start?: string, end?: string) =>
@@ -124,10 +124,14 @@ export const formatDimension = (param: any) => {
 };
 
 const tooltipFormatter = (params: any) => {
-  return Array.isArray(params) && params[0]
+  const observed = Array.isArray(params)
+    ? params.filter((param: any) => typeof param.value === 'number')
+    : [];
+
+  return observed[0]
     ? `<div class="my-1"><div class="mb-1 mx-2 text-sm">${
-        params[0].axisValue
-      }</div>${params
+        observed[0].axisValue
+      }</div>${observed
         .sort((a: any, b: any) => b.value - a.value)
         .map((p: any) => formatDimension(p))
         .join('')}</div>`
@@ -194,23 +198,10 @@ export const getLineChartOptions = (
   };
 };
 
-type MetricWithBuckets = {
-  data: Array<Pick<MetricsData, 'bucket'>>;
-};
-
 export const getXAxis = (
-  metrics: MetricWithBuckets[] | Pick<MetricsResponse, 'data'> | undefined,
+  series: Array<Pick<MetricsData, 'bucket'>> | undefined,
 ) => {
   const dark = isDark();
-
-  let series: Array<Pick<MetricsData, 'bucket'>> | undefined;
-  if (Array.isArray(metrics)) {
-    if (metrics[0]?.data) {
-      series = metrics[0].data;
-    }
-  } else if (metrics) {
-    series = metrics.data;
-  }
 
   const diff = timeDiff(series?.[0]?.bucket, series?.at(-1)?.bucket);
   const dataLength = series?.length || 30;
@@ -249,9 +240,20 @@ export const getXAxis = (
 export const mapEntityLines = (
   metrics: ScopedMetric[],
   entities: EntityLookup,
-  areaStyle?: { opacity: number },
+  {
+    areaStyle,
+    connectNulls = false,
+  }: {
+    areaStyle?: { opacity: number };
+    connectNulls?: boolean;
+  } = {},
 ) => {
   const dark = isDark();
+  const buckets = Array.from(
+    new Set(
+      metrics.flatMap((metric) => metric.data.map(({ bucket }) => bucket)),
+    ),
+  ).sort();
 
   // Create series with names first
   const seriesWithNames = metrics.map((f, index) => {
@@ -270,10 +272,15 @@ export const mapEntityLines = (
 
   // Create series with sorted color assignment
   const series = seriesWithNames.map((item, i) => {
+    const valuesByBucket = new Map(
+      item.metric.data.map(({ bucket, value }) => [bucket, value]),
+    );
+
     return {
       ...seriesOptions,
       name: item.name,
-      data: item.metric.data.map(({ value }) => value),
+      data: buckets.map((bucket) => valuesByBucket.get(bucket) ?? null),
+      connectNulls,
       itemStyle: {
         color: resolveColor(
           lineColors[i % lineColors.length][0],
@@ -289,7 +296,9 @@ export const mapEntityLines = (
   const legendData = series.map((s) => s.name);
 
   return {
-    xAxis: getXAxis(metrics),
+    xAxis: getXAxis(
+      buckets.length > 0 ? buckets.map((bucket) => ({ bucket })) : undefined,
+    ),
     series,
     legendData,
   };

--- a/ui/apps/dashboard/src/components/Scores/ScoreCard.tsx
+++ b/ui/apps/dashboard/src/components/Scores/ScoreCard.tsx
@@ -13,7 +13,7 @@ import {
   seriesOptions,
 } from '@/components/Metrics/utils';
 import { borderColor } from '@/utils/tailwind';
-import { ScoreKind, type MetricsResponse } from '@/gql/graphql';
+import { ScoreKind } from '@/gql/graphql';
 import type { ScoreSeries } from './types';
 
 const AGGREGATIONS = [
@@ -53,11 +53,9 @@ export const ScoreCard = ({ name, series, isLoading, color, error }: Props) => {
         lineColors[0]?.[1],
       );
 
-    // getXAxis only reads bucket timestamps, so the score buckets can stand
-    // in for a metrics response.
-    const xAxis = getXAxis({
-      data: buckets.map((b) => ({ bucket: b.bucketStart, value: 0 })),
-    } as MetricsResponse);
+    const xAxis = getXAxis(
+      buckets.map(({ bucketStart }) => ({ bucket: bucketStart })),
+    );
 
     const numericData = buckets.map((b) => b[aggregation]);
     const nonNullCount = numericData.filter((v) => v != null).length;


### PR DESCRIPTION
## Description

Changes backlog and steps-running charts to handle sparse metric responses correctly.

- Gaps shorter than three minutes are treated as missing, not as 0. Lines connect across them without plotting a zero-valued point, and the tooltip reports that no data was recorded.
- Displays gaps lasting at least three minutes as inferred zeroes. This handles some of our edge cases when we stop publishing metrics from the backend, which is most often when a backlog has been canceled so it actually should be 0 but has not explicitly recorded as one. Separately we should look into recording a 0 officially at this point so that we're reporting true data.
- Updates tooltips to distinguish missing observations and inferred zeroes from observed zeroes.

This should work with current backend that does `WITH FILL INTERPOLATE` and after backend is updated to return absent values (since `WITH FILL INTERPOLATE` is equivalent to there being no absent data)

### Real examples
We could have false 0s in the middle of a curve or at beginning or end
<img width="1009" height="232" alt="false zero at front" src="https://github.com/user-attachments/assets/5dee0879-c8b3-4809-99db-8a599ae8e979" />
<img width="1019" height="246" alt="false zero at end2" src="https://github.com/user-attachments/assets/3f9a30af-6e53-4ac2-8333-fd0e83f1e614" />
<img width="1010" height="243" alt="intermittent absent value" src="https://github.com/user-attachments/assets/d14a1bbc-936b-4feb-84a0-b7335f08964c" />

### Before (synthetic data)
<img width="1003" height="510" alt="1 - no backend no frontend" src="https://github.com/user-attachments/assets/2f14b049-9ee0-45ea-8ec2-b92bdace3675" />

### After (synthetic data)

We've connected over intervals of missing data that are shorter than 3 minutes, but longer ones we still infer as 0
<img width="1005" height="508" alt="4 - infer zeros for 3 min of no data" src="https://github.com/user-attachments/assets/2eb62aec-eb21-4d9b-821c-dacd32eadb56" />

We show a tooltip for no data recorded. For charts with more than one line, we show the value for the one that is present along with absent for the other.
<img width="1008" height="505" alt="5a - tooltip for absent" src="https://github.com/user-attachments/assets/757145b9-6ab6-4607-a58c-e7de98a15755" />

<img width="1005" height="518" alt="5b - tooltip for absent" src="https://github.com/user-attachments/assets/f3974149-4653-4689-aac6-1873fb0a76cd" />

If there's a trailing absent value, we just don't graph beyond the last present value
<img width="1019" height="250" alt="Screenshot 2026-08-26 at 2 15 50 PM" src="https://github.com/user-attachments/assets/f77fb51f-6796-47ea-9a1f-70a33f5f0fa2" />

## Test plan

- Unit tests cover timestamp alignment, short gaps, sustained internal and edge gaps, empty responses, coarse granularities, and Running metrics.

## Release note

None.

## Migration note

None.