### PR TITLE
fix(debounce): handle removed config during execution

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -1043,7 +1043,7 @@ func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn innge
 }
 
 func (d debouncer) debounceKey(ctx context.Context, evt event.TrackedEvent, fn inngest.Function) (string, error) {
-	if fn.Debounce.Key == nil {
+	if fn.Debounce == nil || fn.Debounce.Key == nil {
 		return fn.ID.String(), nil
 	}
 

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -47,6 +47,50 @@ func requireDebounce(t *testing.T, debouncer Debouncer, ctx context.Context, di 
 	return debounceID
 }
 
+func TestStartExecutionWithRemovedDebounceConfig(t *testing.T) {
+	ctx := context.Background()
+	functionID := uuid.New()
+	shard := &startExecutionQueueShard{name: "debounce"}
+	registry, err := queue.NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	manager := debouncer{
+		shards:           registry,
+		primaryShardName: shard.name,
+		shouldMigrate:    func(context.Context, uuid.UUID) bool { return false },
+	}
+	item := DebounceItem{
+		AccountID:   uuid.New(),
+		WorkspaceID: uuid.New(),
+		FunctionID:  functionID,
+	}
+	fn := inngest.Function{ID: functionID}
+
+	require.NoError(t, manager.StartExecution(ctx, item, fn, ulid.Make()))
+	require.Equal(t, functionID.String(), shard.debounceKey)
+}
+
+type startExecutionQueueShard struct {
+	queue.QueueShard
+
+	name        string
+	debounceKey string
+}
+
+func (s *startExecutionQueueShard) Name() string {
+	return s.name
+}
+
+func (s *startExecutionQueueShard) DebounceStartExecution(
+	_ context.Context,
+	_ queue.Scope,
+	key string,
+	_, _ ulid.ULID,
+) (queue.DebounceStartStatus, error) {
+	s.debounceKey = key
+	return queue.DebounceStartStarted, nil
+}
+
 type setPointerFailingShard struct {
 	queue.QueueShard
 	err                  error


### PR DESCRIPTION
## Description

Prevent debounce timeout execution from panicking when the function has been updated and its debounce configuration was removed after the debounce item was queued.

StartExecution still needs a key while rotating the stored debounce pointer. Treat a missing debounce config like an omitted debounce key and fall back to the function ID.

Adds a regression test that exercises StartExecution with a persisted debounce item and a current function definition without debounce configuration.

## Testing

Before the fix:

    go test -count=1 -run ^TestStartExecutionWithRemovedDebounceConfig$ ./pkg/execution/debounce

Failed with a nil-pointer panic in debouncer.debounceKey, reached from debouncer.StartExecution.

After the fix:

    go test -count=1 -run ^TestStartExecutionWithRemovedDebounceConfig$ ./pkg/execution/debounce
    go test -count=1 ./pkg/execution/debounce

Both pass.

## Release note

Prevent debounce timeout execution from crashing after debounce configuration is removed from a function.

## Migration note

None.