### PR TITLE
fix(api): serialize sandbox bytes written as a number

### DIFF
--- a/proto/api/v2/sandbox.proto
+++ b/proto/api/v2/sandbox.proto
@@ -147,7 +147,7 @@ message WriteSandboxFileRequest {
 
 message WriteSandboxFileData {
   string path = 1;
-  uint64 bytes_written = 2;
+  uint32 bytes_written = 2;
 }
 
 message WriteSandboxFileResponse {

--- a/proto/gen/api/v2/sandbox.pb.go
+++ b/proto/gen/api/v2/sandbox.pb.go
@@ -1324,7 +1324,7 @@ func (x *WriteSandboxFileRequest) GetBody() *httpbody.HttpBody {
 type WriteSandboxFileData struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
-	BytesWritten  uint64                 `protobuf:"varint,2,opt,name=bytes_written,json=bytesWritten,proto3" json:"bytes_written,omitempty"`
+	BytesWritten  uint32                 `protobuf:"varint,2,opt,name=bytes_written,json=bytesWritten,proto3" json:"bytes_written,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1366,7 +1366,7 @@ func (x *WriteSandboxFileData) GetPath() string {
 	return ""
 }
 
-func (x *WriteSandboxFileData) GetBytesWritten() uint64 {
+func (x *WriteSandboxFileData) GetBytesWritten() uint32 {
 	if x != nil {
 		return x.BytesWritten
 	}
@@ -2509,7 +2509,7 @@ const file_api_v2_sandbox_proto_rawDesc = "" +
 	"\x05_mode\"O\n" +
 	"\x14WriteSandboxFileData\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12#\n" +
-	"\rbytes_written\x18\x02 \x01(\x04R\fbytesWritten\"\x89\x01\n" +
+	"\rbytes_written\x18\x02 \x01(\rR\fbytesWritten\"\x89\x01\n" +
 	"\x18WriteSandboxFileResponse\x120\n" +
 	"\x04data\x18\x01 \x01(\v2\x1c.api.v2.WriteSandboxFileDataR\x04data\x12;\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x1f.api.v2.SandboxResponseMetadataR\bmetadata\"K\n" +

--- a/proto/gen/api/v2/sandbox_test.go
+++ b/proto/gen/api/v2/sandbox_test.go
@@ -1,0 +1,17 @@
+package apiv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestWriteSandboxFileDataUsesNumericBytesWritten(t *testing.T) {
+	encoded, err := protojson.Marshal(&WriteSandboxFileData{
+		Path:         "/tmp/message.txt",
+		BytesWritten: 5,
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"path":"/tmp/message.txt","bytesWritten":5}`, string(encoded))
+}


### PR DESCRIPTION
## Description

Return sandbox file upload bytesWritten as a JSON number. The upload limit is 100 MiB, so uint32 is sufficient; the protobuf field number and wire type stay unchanged.

## Release note

Sandbox file upload responses now serialize bytesWritten as a number instead of a string.

## Migration note

None