### PR TITLE
fix(metrics): handle nullable metric values

### DIFF
--- a/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
@@ -29,7 +29,7 @@ type SimpleLineChartProps = {
   data?: {
     name: string;
     values: {
-      [key: string]: number | boolean | undefined;
+      [key: string]: number | boolean | null;
     };
     inferred?: string[];
   }[];

--- a/ui/apps/dashboard/src/components/Functions/SDKRequestThroughput.tsx
+++ b/ui/apps/dashboard/src/components/Functions/SDKRequestThroughput.tsx
@@ -88,9 +88,9 @@ export default function SDKRequestThroughputChart({
     metrics = queued.data.map((d, idx) => ({
       name: d.bucket,
       values: {
-        queued: d.value,
-        started: started.data[idx]?.value || 0,
-        ended: ended.data[idx]?.value || 0,
+        queued: d.value ?? 0,
+        started: started.data[idx]?.value ?? 0,
+        ended: ended.data[idx]?.value ?? 0,
       },
     }));
   }

--- a/ui/apps/dashboard/src/components/Functions/concurrency.ts
+++ b/ui/apps/dashboard/src/components/Functions/concurrency.ts
@@ -1,5 +1,5 @@
 type UsageSlot = { slot: string };
-type MetricBucket = { bucket: string; value: number };
+type MetricBucket = { bucket: string; value: number | null };
 
 export function concurrencyLimitReachedBySlot(
   slots: UsageSlot[],
@@ -7,7 +7,7 @@ export function concurrencyLimitReachedBySlot(
 ): boolean[] {
   const reachedBuckets = new Set(
     metrics
-      ?.filter(({ value }) => value > 0)
+      ?.filter(({ value }) => (value ?? 0) > 0)
       .map(({ bucket }) => new Date(bucket).getTime()),
   );
 

--- a/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.test.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.test.ts
@@ -43,6 +43,24 @@ describe('mergeBacklogMetrics', () => {
     ]);
   });
 
+  test('preserves null values as chart gaps', () => {
+    expect(
+      mergeBacklogMetrics(
+        [
+          { bucket: '2026-08-23T03:16:00Z', value: null },
+          { bucket: '2026-08-23T03:17:00Z', value: 2 },
+        ],
+        [],
+        '1m',
+        '2026-08-23T03:16:00Z',
+        '2026-08-23T03:18:00Z',
+      ),
+    ).toEqual([
+      { name: '2026-08-23T03:16:00Z', values: { scheduled: null } },
+      { name: '2026-08-23T03:17:00Z', values: { scheduled: 2 } },
+    ]);
+  });
+
   test('shows gaps lasting at least three minutes as inferred zeroes', () => {
     expect(
       mergeBacklogMetrics(

--- a/ui/apps/dashboard/src/components/Functions/mergeMetricRows.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeMetricRows.ts
@@ -2,7 +2,7 @@ import { findSustainedMissingBuckets } from './findSustainedMissingBuckets';
 
 export type Metric = {
   bucket: string;
-  value: number;
+  value: number | null;
 };
 
 export type MetricSeries = {
@@ -14,7 +14,7 @@ export type MetricSeries = {
 
 type MetricRow = {
   name: string;
-  values: Record<string, number | boolean | undefined>;
+  values: Record<string, number | boolean | null>;
   inferred?: string[];
 };
 
@@ -31,7 +31,10 @@ export function mergeMetricRows(
     for (const { bucket, value } of data) {
       const timestamp = new Date(bucket).getTime();
       const metric = byBucket.get(timestamp) ?? { name: bucket, values: {} };
-      metric.values[key] = mapValue ? mapValue(value) : value;
+
+      // Preserve null as a chart gap and don't pass it to mappers; for example,
+      // Boolean(null) would conflate absence with a reported false value.
+      metric.values[key] = value === null ? null : (mapValue?.(value) ?? value);
       byBucket.set(timestamp, metric);
     }
   }

--- a/ui/apps/dashboard/src/components/InfraDashboard/utils.ts
+++ b/ui/apps/dashboard/src/components/InfraDashboard/utils.ts
@@ -885,7 +885,7 @@ export function latestBucketMetricTotal(
       total +
       metric.data.reduce((metricTotal, point) => {
         return point.bucket === latestBucket
-          ? metricTotal + point.value
+          ? metricTotal + (point.value ?? 0)
           : metricTotal;
       }, 0)
     );
@@ -910,7 +910,7 @@ export function sumTimeSeriesValues(
 export function sumDataValues(
   data: Array<Pick<MetricsData, 'value'>> | undefined,
 ): number {
-  return data?.reduce((total, point) => total + point.value, 0) ?? 0;
+  return data?.reduce((total, point) => total + (point.value ?? 0), 0) ?? 0;
 }
 
 export function calculateUsageShare(value: number, total: number): number {

--- a/ui/apps/dashboard/src/components/Metrics/FailedRate.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/FailedRate.tsx
@@ -55,7 +55,7 @@ const mapRateList = (
   functions: EntityLookup,
 ): Rate[] => {
   return failed.slice(0, 6).map((f) => {
-    const failures = f.data.filter((d) => d.value > 0);
+    const failures = f.data.filter((d) => (d.value ?? 0) > 0);
     const totalFailures = sum(failures);
     const lastOccurence = failures.at(-1)?.bucket;
     return {

--- a/ui/apps/dashboard/src/components/Metrics/SdkThroughput.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/SdkThroughput.tsx
@@ -20,7 +20,7 @@ const sum = (metrics: ScopedMetric[]) =>
   metrics.reduce(
     (acc, metric: ScopedMetric) =>
       metric.data.map((item, index) => ({
-        value: (acc[index]?.value || 0) + item.value,
+        value: (acc[index]?.value ?? 0) + (item.value ?? 0),
         bucket: item.bucket,
       })),
     accumulator,

--- a/ui/apps/dashboard/src/components/Metrics/metricAggregation.ts
+++ b/ui/apps/dashboard/src/components/Metrics/metricAggregation.ts
@@ -47,7 +47,7 @@ export const sumScopedMetricsByGroup = (
         buckets.push(bucket);
       }
 
-      totals.set(bucket, (totals.get(bucket) ?? 0) + value);
+      totals.set(bucket, (totals.get(bucket) ?? 0) + (value ?? 0));
     }
   }
 

--- a/ui/apps/dashboard/src/components/Metrics/utils.ts
+++ b/ui/apps/dashboard/src/components/Metrics/utils.ts
@@ -67,8 +67,8 @@ export const dateFormat = (dateString: string, diff: number) => {
   return d < 6000 // a minute
     ? lightFormat(date, 'HH:mm:ss:SSS')
     : d <= 8.64e7 // a day
-      ? lightFormat(date, 'HH:mm')
-      : lightFormat(date, 'MM/dd:HH');
+    ? lightFormat(date, 'HH:mm')
+    : lightFormat(date, 'MM/dd:HH');
 };
 
 export const timeDiff = (start?: string, end?: string) =>
@@ -93,7 +93,7 @@ export const convertLookup = (entities?: EntityType[]): EntityLookup | {} =>
     : {};
 
 export const sum = (data?: MetricsData[]) =>
-  data ? data.reduce((acc, { value }) => acc + value, 0) : 0;
+  data ? data.reduce((acc, { value }) => acc + (value ?? 0), 0) : 0;
 
 export const formatNumber = (number?: number | bigint) =>
   (number || 0).toLocaleString(undefined);

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -87,12 +87,14 @@ export type Account = {
   activeBanners: Array<Banner>;
   addons: Addons;
   apiKeys: Array<ApiKey>;
+  /** @deprecated Field no longer supported */
   appliedAddons: AppliedAddons;
   billingEmail: Scalars['String']['output'];
   constraintAPIEnrolled: Scalars['Boolean']['output'];
   createdAt: Scalars['Time']['output'];
   datadogConnections: Array<DatadogConnectionStatus>;
   datadogOrganizations: Array<DatadogOrganization>;
+  /** @deprecated Field no longer supported */
   entitlementUsage: EntitlementUsage;
   entitlements: Entitlements;
   id: Scalars['ID']['output'];
@@ -357,6 +359,7 @@ export type BillingPlan = {
   __typename?: 'BillingPlan';
   addons: Addons;
   amount: Scalars['Int']['output'];
+  /** @deprecated Field no longer supported */
   availableAddons: AvailableAddons;
   billingPeriod: Scalars['BillingPeriod']['output'];
   entitlements: Entitlements;
@@ -1097,6 +1100,7 @@ export type FunctionRun = {
   status: FunctionRunStatus;
   workflowID: Scalars['UUID']['output'];
   workflowVersion: Maybe<WorkflowVersion>;
+  /** @deprecated Field no longer supported */
   workflowVersionInt: Scalars['Int']['output'];
   workspaceID: Scalars['UUID']['output'];
 };
@@ -1121,6 +1125,7 @@ export enum FunctionRunStatus {
 
 export enum FunctionRunTimeField {
   EndedAt = 'ENDED_AT',
+  /** @deprecated Field no longer supported */
   Mixed = 'MIXED',
   StartedAt = 'STARTED_AT'
 }
@@ -1296,7 +1301,7 @@ export enum Marketplace {
 export type MetricsData = {
   __typename?: 'MetricsData';
   bucket: Scalars['Time']['output'];
-  value: Scalars['Float']['output'];
+  value: Maybe<Scalars['Float']['output']>;
 };
 
 export type MetricsOpts = {
@@ -2545,6 +2550,7 @@ export type StripeSubscriptionInput = {
 
 export type StripeSubscriptionItemsInput = {
   amount: Scalars['Int']['input'];
+  /** @deprecated Use planSlug instead */
   planID?: InputMaybe<Scalars['ID']['input']>;
   planSlug?: InputMaybe<Scalars['String']['input']>;
   quantity: Scalars['Int']['input'];
@@ -2642,6 +2648,7 @@ export type Usage = {
 export type UsageInput = {
   from?: InputMaybe<Scalars['Time']['input']>;
   period?: InputMaybe<Scalars['Period']['input']>;
+  /** @deprecated Field no longer supported */
   range?: InputMaybe<Scalars['Timerange']['input']>;
   to?: InputMaybe<Scalars['Time']['input']>;
 };
@@ -2769,6 +2776,7 @@ export type Workflow = {
   slug: Scalars['String']['output'];
   triggers: Array<FunctionTrigger>;
   url: Scalars['String']['output'];
+  /** @deprecated Field no longer supported */
   usage: Usage;
 };
 
@@ -2837,12 +2845,14 @@ export type Workspace = {
   cdcConnections: Array<CdcConnection>;
   connectWorkerMetrics: ScopedMetricsResponse;
   createdAt: Scalars['Time']['output'];
+  /** @deprecated Field no longer supported */
   event: Maybe<Event>;
   eventByNames: Array<EventType>;
   eventType: EventTypeV2;
   eventTypes: PaginatedEventTypes;
   eventTypesV2: EventTypesConnection;
   eventV2: EventV2;
+  /** @deprecated Field no longer supported */
   events: PaginatedEvents;
   eventsV2: EventsConnection;
   functionCount: Scalars['Int']['output'];
@@ -3502,7 +3512,7 @@ export type GetFunctionRateLimitDocumentQueryVariables = Exact<{
 }>;
 
 
-export type GetFunctionRateLimitDocumentQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', ratelimit: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> } } | null } };
+export type GetFunctionRateLimitDocumentQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', ratelimit: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> } } | null } };
 
 export type GetFunctionRunsMetricsQueryVariables = Exact<{
   environmentID: Scalars['ID']['input'];
@@ -3522,7 +3532,7 @@ export type GetFnMetricsQueryVariables = Exact<{
 }>;
 
 
-export type GetFnMetricsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', queued: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }, started: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }, ended: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> } } | null } };
+export type GetFnMetricsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', queued: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }, started: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }, ended: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> } } | null } };
 
 export type PauseFunctionMutationVariables = Exact<{
   fnID: Scalars['ID']['input'];
@@ -3547,7 +3557,7 @@ export type GetSdkRequestMetricsQueryVariables = Exact<{
 }>;
 
 
-export type GetSdkRequestMetricsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', queued: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }, started: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }, ended: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> } } | null } };
+export type GetSdkRequestMetricsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', queued: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }, started: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }, ended: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> } } | null } };
 
 export type GetStepBacklogMetricsQueryVariables = Exact<{
   environmentID: Scalars['ID']['input'];
@@ -3557,7 +3567,7 @@ export type GetStepBacklogMetricsQueryVariables = Exact<{
 }>;
 
 
-export type GetStepBacklogMetricsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', scheduled: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }, sleeping: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> } } | null } };
+export type GetStepBacklogMetricsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', scheduled: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }, sleeping: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> } } | null } };
 
 export type GetStepsRunningMetricsQueryVariables = Exact<{
   environmentID: Scalars['ID']['input'];
@@ -3567,7 +3577,7 @@ export type GetStepsRunningMetricsQueryVariables = Exact<{
 }>;
 
 
-export type GetStepsRunningMetricsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', running: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }, concurrencyLimit: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> } } | null } };
+export type GetStepsRunningMetricsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', running: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }, concurrencyLimit: { __typename?: 'MetricsResponse', from: string, to: string, granularity: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> } } | null } };
 
 export type GetFnCancellationsQueryVariables = Exact<{
   after: InputMaybe<Scalars['String']['input']>;
@@ -3594,7 +3604,7 @@ export type InfraDashboardConcurrencyLimitQueryVariables = Exact<{
 }>;
 
 
-export type InfraDashboardConcurrencyLimitQuery = { __typename?: 'Query', workspace: { __typename?: 'Workspace', concurrencyLimitReached: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }> } } };
+export type InfraDashboardConcurrencyLimitQuery = { __typename?: 'Query', workspace: { __typename?: 'Workspace', concurrencyLimitReached: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }> } } };
 
 export type InsightsResultsQueryVariables = Exact<{
   query: Scalars['String']['input'];
@@ -3734,7 +3744,7 @@ export type FunctionStatusMetricsQueryVariables = Exact<{
 }>;
 
 
-export type FunctionStatusMetricsQuery = { __typename?: 'Query', workspace: { __typename?: 'Workspace', scheduled: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, started: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, completed: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, completedByFunction: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, totals: { __typename?: 'ScopedFunctionStatusResponse', queued: number, running: number, completed: number, failed: number, cancelled: number, skipped: number } } };
+export type FunctionStatusMetricsQuery = { __typename?: 'Query', workspace: { __typename?: 'Workspace', scheduled: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, started: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, completed: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, completedByFunction: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, totals: { __typename?: 'ScopedFunctionStatusResponse', queued: number, running: number, completed: number, failed: number, cancelled: number, skipped: number } } };
 
 export type VolumeMetricsQueryVariables = Exact<{
   workspaceId: Scalars['ID']['input'];
@@ -3746,7 +3756,7 @@ export type VolumeMetricsQueryVariables = Exact<{
 }>;
 
 
-export type VolumeMetricsQuery = { __typename?: 'Query', accountConcurrency: { __typename?: 'MetricsResponse', data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }, workspace: { __typename?: 'Workspace', allFunctionConcurrency: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, runsThroughput: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, sdkThroughputEnded: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, sdkThroughputStarted: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, sdkThroughputScheduled: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, stepThroughput: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, backlog: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, stepRunning: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, concurrency: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, workerPercentageUsed: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> }, workerTotalCapacity: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number, bucket: string }> }> } } };
+export type VolumeMetricsQuery = { __typename?: 'Query', accountConcurrency: { __typename?: 'MetricsResponse', data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }, workspace: { __typename?: 'Workspace', allFunctionConcurrency: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, runsThroughput: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, sdkThroughputEnded: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, sdkThroughputStarted: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, sdkThroughputScheduled: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, stepThroughput: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, backlog: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, stepRunning: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, concurrency: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, workerPercentageUsed: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> }, workerTotalCapacity: { __typename?: 'ScopedMetricsResponse', metrics: Array<{ __typename?: 'ScopedMetric', id: string, tagName: string | null, tagValue: string | null, data: Array<{ __typename?: 'MetricsData', value: number | null, bucket: string }> }> } } };
 
 export type QuickSearchQueryVariables = Exact<{
   term: Scalars['String']['input'];
@@ -3905,7 +3915,7 @@ export type AccountConcurrencyPressureQueryVariables = Exact<{
 }>;
 
 
-export type AccountConcurrencyPressureQuery = { __typename?: 'Query', concurrencyLimitHits: { __typename?: 'MetricsResponse', data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> } };
+export type AccountConcurrencyPressureQuery = { __typename?: 'Query', concurrencyLimitHits: { __typename?: 'MetricsResponse', data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> } };
 
 export type ScoresLookupQueryVariables = Exact<{
   envSlug: Scalars['String']['input'];
@@ -4089,7 +4099,7 @@ export type GetFunctionUsageQueryVariables = Exact<{
 }>;
 
 
-export type GetFunctionUsageQuery = { __typename?: 'Query', workspace: { __typename?: 'Workspace', workflow: { __typename?: 'Workflow', concurrencyLimitReached: { __typename?: 'MetricsResponse', data: Array<{ __typename?: 'MetricsData', bucket: string, value: number }> }, dailyStarts: { __typename?: 'Usage', period: unknown, total: number, data: Array<{ __typename?: 'UsageSlot', slot: string, count: number }> }, dailyCancelled: { __typename?: 'Usage', period: unknown, total: number, data: Array<{ __typename?: 'UsageSlot', slot: string, count: number }> }, dailyCompleted: { __typename?: 'Usage', period: unknown, total: number, data: Array<{ __typename?: 'UsageSlot', slot: string, count: number }> }, dailyFailures: { __typename?: 'Usage', period: unknown, total: number, data: Array<{ __typename?: 'UsageSlot', slot: string, count: number }> } } | null } };
+export type GetFunctionUsageQuery = { __typename?: 'Query', workspace: { __typename?: 'Workspace', workflow: { __typename?: 'Workflow', concurrencyLimitReached: { __typename?: 'MetricsResponse', data: Array<{ __typename?: 'MetricsData', bucket: string, value: number | null }> }, dailyStarts: { __typename?: 'Usage', period: unknown, total: number, data: Array<{ __typename?: 'UsageSlot', slot: string, count: number }> }, dailyCancelled: { __typename?: 'Usage', period: unknown, total: number, data: Array<{ __typename?: 'UsageSlot', slot: string, count: number }> }, dailyCompleted: { __typename?: 'Usage', period: unknown, total: number, data: Array<{ __typename?: 'UsageSlot', slot: string, count: number }> }, dailyFailures: { __typename?: 'Usage', period: unknown, total: number, data: Array<{ __typename?: 'UsageSlot', slot: string, count: number }> } } | null } };
 
 export type ActiveBannersQueryVariables = Exact<{ [key: string]: never; }>;
 


### PR DESCRIPTION
Blocked on API change: https://github.com/inngest/monorepo/pull/8456.

## Description

- Regenerate dashboard GraphQL types for nullable metric values.
- Coalesce absent values to zero at numeric aggregation and comparison sites, preserving previous behavior and present zero values.
- Keep the chart value contract nullable so absent values remain null chart gaps instead of being converted to undefined.

Testing:
- `pnpm type-check`
- Dashboard production build

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*