### PR TITLE
refactor(metrics): consume dense nullable series

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/findSustainedMissingBuckets.ts
+++ b/ui/apps/dashboard/src/components/Functions/findSustainedMissingBuckets.ts
@@ -1,14 +1,14 @@
 type Metric = {
   bucket: string;
+  value: number | null;
 };
 
 const MISSING_DATA_THRESHOLD_MS = 3 * 60_000;
 
 /**
- * Returns the timestamps in contiguous gaps that lasted at least three
- * minutes. It scans the complete buckets in the requested range and ignores
- * partial edge buckets, which may simply not have reported yet. An empty
- * series remains empty.
+ * Returns the timestamps in contiguous runs of null values that lasted at
+ * least three minutes. It ignores partial edge buckets, which may simply not
+ * have reported yet. An empty series remains empty.
  */
 export function findSustainedMissingBuckets(
   observations: Metric[],
@@ -18,9 +18,6 @@ export function findSustainedMissingBuckets(
 ) {
   if (observations.length === 0) return [];
 
-  const observed = new Set(
-    observations.map(({ bucket }) => new Date(bucket).getTime()),
-  );
   const firstCompleteBucket =
     Math.ceil(new Date(rangeStart).getTime() / bucketWidth) * bucketWidth;
   const lastCompleteBucket =
@@ -29,26 +26,26 @@ export function findSustainedMissingBuckets(
   const inferred: number[] = [];
   let missing: number[] = [];
 
-  for (
-    let timestamp = firstCompleteBucket;
-    timestamp <= lastCompleteBucket;
-    timestamp += bucketWidth
-  ) {
-    if (!observed.has(timestamp)) {
-      missing.push(timestamp);
-    }
-
-    if (
-      (observed.has(timestamp) || timestamp === lastCompleteBucket) &&
-      missing.length * bucketWidth >= MISSING_DATA_THRESHOLD_MS
-    ) {
+  const flushMissing = () => {
+    if (missing.length * bucketWidth >= MISSING_DATA_THRESHOLD_MS) {
       inferred.push(...missing);
     }
+    missing = [];
+  };
 
-    if (observed.has(timestamp)) {
-      missing = [];
+  for (const { bucket, value } of observations) {
+    const timestamp = new Date(bucket).getTime();
+    if (timestamp < firstCompleteBucket || timestamp > lastCompleteBucket) {
+      continue;
+    }
+
+    if (value === null) {
+      missing.push(timestamp);
+    } else {
+      flushMissing();
     }
   }
+  flushMissing();
 
   return inferred;
 }

--- a/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.test.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.test.ts
@@ -2,153 +2,127 @@ import { describe, expect, test } from 'vitest';
 
 import { mergeBacklogMetrics } from './mergeBacklogMetrics';
 
+const buckets = [
+  '2026-08-23T03:16:00Z',
+  '2026-08-23T03:17:00Z',
+  '2026-08-23T03:18:00Z',
+  '2026-08-23T03:19:00Z',
+  '2026-08-23T03:20:00Z',
+];
+
+const series = (values: Array<number | null>) => {
+  return buckets.map((bucket, index) => ({ bucket, value: values[index]! }));
+};
+
 describe('mergeBacklogMetrics', () => {
-  test('joins sparse series by timestamp without inventing zeroes', () => {
+  test('combines dense series and preserves nulls and observed zeroes', () => {
     expect(
       mergeBacklogMetrics(
-        [
-          { bucket: '2026-08-23T03:16:00Z', value: 144650 },
-          { bucket: '2026-08-23T03:18:00Z', value: 144607 },
-          { bucket: '2026-08-23T03:20:00Z', value: 0 },
-        ],
-        [
-          { bucket: '2026-08-23T03:17:00Z', value: 12 },
-          { bucket: '2026-08-23T03:18:00Z', value: 10 },
-        ],
+        series([144650, null, 144607, null, 0]),
+        series([null, 12, 10, null, null]),
         '1m',
-        '2026-08-23T03:16:00Z',
+        buckets[0]!,
         '2026-08-23T03:21:00Z',
       ),
     ).toEqual([
       {
-        name: '2026-08-23T03:16:00Z',
-        values: { scheduled: 144650 },
+        name: buckets[0],
+        values: { scheduled: 144650, sleeping: null },
       },
       {
-        name: '2026-08-23T03:17:00Z',
-        values: { sleeping: 12 },
+        name: buckets[1],
+        values: { scheduled: null, sleeping: 12 },
       },
       {
-        name: '2026-08-23T03:18:00Z',
+        name: buckets[2],
         values: { scheduled: 144607, sleeping: 10 },
       },
       {
-        name: '2026-08-23T03:19:00.000Z',
-        values: {},
+        name: buckets[3],
+        values: { scheduled: null, sleeping: null },
       },
       {
-        name: '2026-08-23T03:20:00Z',
-        values: { scheduled: 0 },
+        name: buckets[4],
+        values: { scheduled: 0, sleeping: null },
       },
     ]);
   });
 
-  test('preserves null values as chart gaps', () => {
+  test('shows null runs lasting at least three minutes as inferred zeroes', () => {
     expect(
       mergeBacklogMetrics(
-        [
-          { bucket: '2026-08-23T03:16:00Z', value: null },
-          { bucket: '2026-08-23T03:17:00Z', value: 2 },
-        ],
-        [],
+        series([42, null, null, null, 0]),
+        series([1, 1, 1, 1, 1]),
         '1m',
-        '2026-08-23T03:16:00Z',
-        '2026-08-23T03:18:00Z',
+        buckets[0]!,
+        '2026-08-23T03:21:00Z',
       ),
     ).toEqual([
-      { name: '2026-08-23T03:16:00Z', values: { scheduled: null } },
-      { name: '2026-08-23T03:17:00Z', values: { scheduled: 2 } },
+      { name: buckets[0], values: { scheduled: 42, sleeping: 1 } },
+      {
+        name: buckets[1],
+        values: { scheduled: 0, sleeping: 1 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: buckets[2],
+        values: { scheduled: 0, sleeping: 1 },
+        inferred: ['scheduled'],
+      },
+      {
+        name: buckets[3],
+        values: { scheduled: 0, sleeping: 1 },
+        inferred: ['scheduled'],
+      },
+      { name: buckets[4], values: { scheduled: 0, sleeping: 1 } },
     ]);
   });
 
-  test('shows gaps lasting at least three minutes as inferred zeroes', () => {
+  test('does not infer nulls in partial edge buckets', () => {
     expect(
       mergeBacklogMetrics(
-        [
-          { bucket: '2026-08-23T03:16:00Z', value: 144650 },
-          { bucket: '2026-08-23T03:20:00Z', value: 144607 },
-        ],
-        [],
+        series([null, null, null, null, null]),
+        series([1, 1, 1, 1, 1]),
         '1m',
-        '2026-08-23T03:13:00Z',
-        '2026-08-23T03:24:30Z',
+        '2026-08-23T03:16:30Z',
+        '2026-08-23T03:20:30Z',
       ),
     ).toEqual([
+      { name: buckets[0], values: { scheduled: null, sleeping: 1 } },
       {
-        name: '2026-08-23T03:13:00.000Z',
-        values: { scheduled: 0 },
+        name: buckets[1],
+        values: { scheduled: 0, sleeping: 1 },
         inferred: ['scheduled'],
       },
       {
-        name: '2026-08-23T03:14:00.000Z',
-        values: { scheduled: 0 },
+        name: buckets[2],
+        values: { scheduled: 0, sleeping: 1 },
         inferred: ['scheduled'],
       },
       {
-        name: '2026-08-23T03:15:00.000Z',
-        values: { scheduled: 0 },
+        name: buckets[3],
+        values: { scheduled: 0, sleeping: 1 },
         inferred: ['scheduled'],
       },
-      {
-        name: '2026-08-23T03:16:00Z',
-        values: { scheduled: 144650 },
-      },
-      {
-        name: '2026-08-23T03:17:00.000Z',
-        values: { scheduled: 0 },
-        inferred: ['scheduled'],
-      },
-      {
-        name: '2026-08-23T03:18:00.000Z',
-        values: { scheduled: 0 },
-        inferred: ['scheduled'],
-      },
-      {
-        name: '2026-08-23T03:19:00.000Z',
-        values: { scheduled: 0 },
-        inferred: ['scheduled'],
-      },
-      {
-        name: '2026-08-23T03:20:00Z',
-        values: { scheduled: 144607 },
-      },
-      {
-        name: '2026-08-23T03:21:00.000Z',
-        values: { scheduled: 0 },
-        inferred: ['scheduled'],
-      },
-      {
-        name: '2026-08-23T03:22:00.000Z',
-        values: { scheduled: 0 },
-        inferred: ['scheduled'],
-      },
-      {
-        name: '2026-08-23T03:23:00.000Z',
-        values: { scheduled: 0 },
-        inferred: ['scheduled'],
-      },
+      { name: buckets[4], values: { scheduled: null, sleeping: 1 } },
     ]);
   });
 
-  test('leaves gaps shorter than three minutes and empty responses blank', () => {
+  test('leaves short null runs and empty responses blank', () => {
     expect(
       mergeBacklogMetrics(
-        [
-          { bucket: '2026-08-23T03:16:00Z', value: 4 },
-          { bucket: '2026-08-23T03:18:00Z', value: 3 },
-          { bucket: '2026-08-23T03:20:00Z', value: 2 },
-        ],
-        [],
+        series([4, null, 3, null, 2]),
+        series([null, null, 1, 1, 1]),
         '1m',
-        '2026-08-23T03:14:00Z',
-        '2026-08-23T03:23:30Z',
-      ).map(({ name, values }) => ({ name, values })),
+        buckets[0]!,
+        '2026-08-23T03:21:00Z',
+      ),
     ).toEqual([
-      { name: '2026-08-23T03:16:00Z', values: { scheduled: 4 } },
-      { name: '2026-08-23T03:17:00.000Z', values: {} },
-      { name: '2026-08-23T03:18:00Z', values: { scheduled: 3 } },
-      { name: '2026-08-23T03:19:00.000Z', values: {} },
-      { name: '2026-08-23T03:20:00Z', values: { scheduled: 2 } },
+      { name: buckets[0], values: { scheduled: 4, sleeping: null } },
+      { name: buckets[1], values: { scheduled: null, sleeping: null } },
+      { name: buckets[2], values: { scheduled: 3, sleeping: 1 } },
+      { name: buckets[3], values: { scheduled: null, sleeping: 1 } },
+      { name: buckets[4], values: { scheduled: 2, sleeping: 1 } },
     ]);
     expect(
       mergeBacklogMetrics(
@@ -162,25 +136,40 @@ describe('mergeBacklogMetrics', () => {
   });
 
   test('uses elapsed time rather than bucket count for the threshold', () => {
+    const fiveMinuteBuckets = [
+      '2026-08-23T03:10:00Z',
+      '2026-08-23T03:15:00Z',
+      '2026-08-23T03:20:00Z',
+    ];
+    const fiveMinuteSeries = (values: Array<number | null>) => {
+      return fiveMinuteBuckets.map((bucket, index) => ({
+        bucket,
+        value: values[index]!,
+      }));
+    };
+
     expect(
       mergeBacklogMetrics(
-        [
-          { bucket: '2026-08-23T03:10:00Z', value: 4 },
-          { bucket: '2026-08-23T03:20:00Z', value: 2 },
-        ],
-        [],
+        fiveMinuteSeries([4, null, 2]),
+        fiveMinuteSeries([1, 1, 1]),
         '5m',
         '2026-08-23T03:10:00Z',
         '2026-08-23T03:25:00Z',
       ),
     ).toEqual([
-      { name: '2026-08-23T03:10:00Z', values: { scheduled: 4 } },
       {
-        name: '2026-08-23T03:15:00.000Z',
-        values: { scheduled: 0 },
+        name: fiveMinuteBuckets[0],
+        values: { scheduled: 4, sleeping: 1 },
+      },
+      {
+        name: fiveMinuteBuckets[1],
+        values: { scheduled: 0, sleeping: 1 },
         inferred: ['scheduled'],
       },
-      { name: '2026-08-23T03:20:00Z', values: { scheduled: 2 } },
+      {
+        name: fiveMinuteBuckets[2],
+        values: { scheduled: 2, sleeping: 1 },
+      },
     ]);
   });
 });

--- a/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeBacklogMetrics.ts
@@ -2,11 +2,9 @@ import type { Metric } from './mergeMetricRows';
 import { mergeMetricRows } from './mergeMetricRows';
 
 /**
- * Converts the separate Queued and Sleeping results from the backend into
- * chart data with one row per timestamp. Both results are gauges whose numeric
- * values are plotted as lines, so the missing-data policy is applied to each:
- * short gaps remain absent for the chart to connect over, while gaps of at
- * least three minutes are represented as zero and marked as inferred.
+ * Combines the dense Queued and Sleeping results from the backend. Both are
+ * gauges, so short runs of nulls remain chart gaps while runs lasting at least
+ * three minutes are represented as zero and marked as inferred.
  */
 export function mergeBacklogMetrics(
   scheduled: Metric[],

--- a/ui/apps/dashboard/src/components/Functions/mergeMetricRows.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeMetricRows.ts
@@ -18,72 +18,52 @@ type MetricRow = {
   inferred?: string[];
 };
 
-/** Builds one chart row per timestamp from independently reported series. */
+/** Combines dense metric series that share the same ordered buckets. */
 export function mergeMetricRows(
   series: MetricSeries[],
   granularity: string,
   rangeStart: string,
   rangeEnd: string,
 ) {
-  const byBucket = new Map<number, MetricRow>();
-
-  for (const { key, data, mapValue } of series) {
-    for (const { bucket, value } of data) {
-      const timestamp = new Date(bucket).getTime();
-      const metric = byBucket.get(timestamp) ?? { name: bucket, values: {} };
-
-      // Preserve null as a chart gap and don't pass it to mappers; for example,
-      // Boolean(null) would conflate absence with a reported false value.
-      metric.values[key] = value === null ? null : (mapValue?.(value) ?? value);
-      byBucket.set(timestamp, metric);
-    }
-  }
-
   const amount = Number.parseInt(granularity, 10);
   const bucketWidth = amount * (granularity.endsWith('h') ? 60 : 1) * 60_000;
-
-  for (const { key, data, inferMissingAsZero } of series) {
-    if (!inferMissingAsZero) continue;
-
-    for (const timestamp of findSustainedMissingBuckets(
-      data,
-      bucketWidth,
-      rangeStart,
-      rangeEnd,
-    )) {
-      const metric = byBucket.get(timestamp) ?? {
-        name: new Date(timestamp).toISOString(),
-        values: {},
-      };
-      metric.values[key] = 0;
-      metric.inferred = [...(metric.inferred ?? []), key];
-      byBucket.set(timestamp, metric);
-    }
-  }
-
-  const observed = Array.from(byBucket.values()).sort((a, b) =>
-    a.name.localeCompare(b.name),
+  const inferredByKey = new Map(
+    series
+      .filter(({ inferMissingAsZero }) => inferMissingAsZero)
+      .map(({ key, data }) => [
+        key,
+        new Set(
+          findSustainedMissingBuckets(data, bucketWidth, rangeStart, rangeEnd),
+        ),
+      ]),
   );
-  if (observed.length < 2) {
-    return observed;
-  }
 
-  const firstBucket = new Date(observed[0].name).getTime();
-  const lastBucket = new Date(observed.at(-1)!.name).getTime();
-  const metrics: MetricRow[] = [];
+  // The backend contract guarantees that every response has the same dense,
+  // ordered buckets. Choosing the longest response is only defensive so one
+  // missing response does not hide another; this does not align sparse series.
+  const buckets = series.reduce<Metric[]>((longest, { data }) => {
+    return data.length > longest.length ? data : longest;
+  }, []);
 
-  for (
-    let timestamp = firstBucket;
-    timestamp <= lastBucket;
-    timestamp += bucketWidth
-  ) {
-    metrics.push(
-      byBucket.get(timestamp) ?? {
-        name: new Date(timestamp).toISOString(),
-        values: {},
-      },
-    );
-  }
+  return buckets.map(({ bucket }, index): MetricRow => {
+    const timestamp = new Date(bucket).getTime();
+    const metric: MetricRow = { name: bucket, values: {} };
 
-  return metrics;
+    for (const { key, data, mapValue } of series) {
+      const value = data[index]?.value;
+      if (value === undefined) continue;
+
+      if (inferredByKey.get(key)?.has(timestamp)) {
+        metric.values[key] = 0;
+        metric.inferred = [...(metric.inferred ?? []), key];
+      } else {
+        // Preserve null as a chart gap and don't pass it to mappers; for
+        // example, Boolean(null) would conflate absence with reported false.
+        metric.values[key] =
+          value === null ? null : (mapValue?.(value) ?? value);
+      }
+    }
+
+    return metric;
+  });
 }

--- a/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.test.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.test.ts
@@ -3,41 +3,52 @@ import { describe, expect, test } from 'vitest';
 import { mergeStepsRunningMetrics } from './mergeStepsRunningMetrics';
 
 describe('mergeStepsRunningMetrics', () => {
-  test('shows running gaps lasting at least three minutes as inferred zeroes', () => {
+  test('infers sustained running nulls without mapping absent limits to false', () => {
+    const buckets = [
+      '2026-08-23T03:16:00Z',
+      '2026-08-23T03:17:00Z',
+      '2026-08-23T03:18:00Z',
+      '2026-08-23T03:19:00Z',
+      '2026-08-23T03:20:00Z',
+    ];
+    const series = (values: Array<number | null>) => {
+      return buckets.map((bucket, index) => ({
+        bucket,
+        value: values[index]!,
+      }));
+    };
+
     expect(
       mergeStepsRunningMetrics(
-        [
-          { bucket: '2026-08-23T03:16:00Z', value: 12 },
-          { bucket: '2026-08-23T03:20:00Z', value: 10 },
-        ],
-        [{ bucket: '2026-08-23T03:18:00Z', value: 1 }],
+        series([12, null, null, null, 10]),
+        series([null, null, 1, null, null]),
         '1m',
-        '2026-08-23T03:16:00Z',
+        buckets[0]!,
         '2026-08-23T03:21:00Z',
       ),
     ).toEqual([
       {
-        name: '2026-08-23T03:16:00Z',
-        values: { running: 12 },
+        name: buckets[0],
+        values: { running: 12, concurrencyLimit: null },
       },
       {
-        name: '2026-08-23T03:17:00.000Z',
-        values: { running: 0 },
+        name: buckets[1],
+        values: { running: 0, concurrencyLimit: null },
         inferred: ['running'],
       },
       {
-        name: '2026-08-23T03:18:00Z',
-        values: { concurrencyLimit: true, running: 0 },
+        name: buckets[2],
+        values: { running: 0, concurrencyLimit: true },
         inferred: ['running'],
       },
       {
-        name: '2026-08-23T03:19:00.000Z',
-        values: { running: 0 },
+        name: buckets[3],
+        values: { running: 0, concurrencyLimit: null },
         inferred: ['running'],
       },
       {
-        name: '2026-08-23T03:20:00Z',
-        values: { running: 10 },
+        name: buckets[4],
+        values: { running: 10, concurrencyLimit: null },
       },
     ]);
   });

--- a/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.ts
+++ b/ui/apps/dashboard/src/components/Functions/mergeStepsRunningMetrics.ts
@@ -2,13 +2,11 @@ import type { Metric } from './mergeMetricRows';
 import { mergeMetricRows } from './mergeMetricRows';
 
 /**
- * Converts the separate Running and concurrency-limit results from the backend
- * into chart data with one row per timestamp. Running is a gauge whose numeric
- * values are plotted as a line, so short gaps remain absent and gaps of at
+ * Combines the dense Running and concurrency-limit results from the backend.
+ * Short runs of null Running values remain chart gaps, while runs lasting at
  * least three minutes are represented as inferred zeroes. Concurrency Limit is
- * instead a marker that changes the chart background; its numeric value is
- * converted to a boolean at the matching timestamp, and missing markers are
- * not inferred because absence means the limit was not hit.
+ * a marker that changes the chart background; its observed numeric value is
+ * converted to a boolean, while null remains absent.
  */
 export function mergeStepsRunningMetrics(
   running: Metric[],


### PR DESCRIPTION
## Description

https://github.com/inngest/inngest/pull/4786 taught the dashboard to distinguish missing metric observations from reported zeroes. It assumed the backend would return sparse series, so the frontend aligned series by timestamp, synthesized omitted buckets, and inferred missing observations from timestamp gaps.

The final backend contract is different:

- The metric responses used by these charts contain the same dense, ordered bucket sequence.
- Missing gauge observations are represented explicitly as `null`.
- Observed zeroes remain `0`.
- Counters remain dense and zero-filled.

This PR preserves the behavior introduced by #4786 while adapting its implementation to look at explicit `null` values instead of omitted timestamps:

- Short periods without observations remain chart gaps.
- Missing observations lasting at least three minutes are displayed as marked, inferred zeroes.
- Observed zeroes remain reported values rather than inferred values.

The implementation therefore removes timestamp alignment and client-side bucket synthesis.

Selecting the longest response as the shared bucket sequence is only defensive so one missing response does not hide another. It is not sparse-series alignment; the backend contract guarantees identical dense, ordered buckets.

## Related changes

- Nullable dashboard types and handling: [#4794](https://github.com/inngest/inngest/pull/4794)
- Backend dense-null responses: [monorepo #8460](https://github.com/inngest/monorepo/pull/8460)
- Superseded sparse backend prototype: [monorepo #8406](https://github.com/inngest/monorepo/pull/8406)

This UI change is safe to deploy before #8460 and should deploy first.

## Testing

- `pnpm exec vitest run src/components/Functions/mergeBacklogMetrics.test.ts src/components/Functions/mergeStepsRunningMetrics.test.ts`
- `pnpm type-check`

Tests cover:

- explicit null chart gaps;
- observed zeroes;
- sustained null inference;
- partial edge buckets;
- five-minute granularity;
- zero-valued concurrency-limit buckets.

## Release note

None.

## Migration note

None.