### PR TITLE
fix: preserve newer debounce events during queue item recovery

### DIFF
--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -1287,6 +1287,101 @@ func TestDebounceExplicitMigration(t *testing.T) {
 	})
 }
 
+func TestDebounceUpdateMissingQueueItemPreservesNewerEvent(t *testing.T) {
+	unshardedCluster := miniredis.RunT(t)
+
+	unshardedRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{unshardedCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+
+	unshardedClient := redis_state.NewUnshardedClient(unshardedRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	debounceClient := unshardedClient.Debounce()
+
+	opts := []queue.QueueOpt{
+		queue.WithKindToQueueMapping(map[string]string{
+			queue.KindDebounce: queue.KindDebounce,
+		}),
+	}
+
+	shard := redis_state.NewQueueShard(consts.DefaultQueueShardName, unshardedClient.Queue(), opts...)
+
+	shardRegistry, err := queue.NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	q, err := queue.New(context.Background(), "debounce-test", shardRegistry, opts...)
+	require.NoError(t, err)
+	kg := shard.Client().KeyGenerator()
+
+	fakeClock := clockwork.NewFakeClock()
+
+	deb, err := NewDebouncerWithMigration(DebouncerOpts{
+		Shards:           shardRegistry,
+		PrimaryShardName: shard.Name(),
+		Queue:            q,
+		Clock:            fakeClock,
+	})
+	require.NoError(t, err)
+	redisDebouncer := deb.(debouncer)
+
+	ctx := context.Background()
+	accountId, workspaceId, appId, functionId := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	fn := inngest.Function{
+		ID: functionId,
+		Debounce: &inngest.Debounce{
+			Key:    nil,
+			Period: "10s",
+		},
+	}
+
+	newerEventTime := fakeClock.Now().Add(2 * time.Second)
+	newerEventId := ulid.MustNew(ulid.Timestamp(newerEventTime), rand.Reader)
+	newerDi := DebounceItem{
+		AccountID:   accountId,
+		WorkspaceID: workspaceId,
+		AppID:       appId,
+		FunctionID:  functionId,
+		EventID:     newerEventId,
+		Event: event.Event{
+			Name:      "future",
+			ID:        newerEventId.String(),
+			Timestamp: newerEventTime.UnixMilli(),
+		},
+	}
+
+	debounceID := requireDebounce(t, redisDebouncer, ctx, newerDi, fn)
+	unshardedCluster.HDel(kg.QueueItem(), queue.HashID(ctx, debounceID.String()))
+
+	olderEventTime := fakeClock.Now()
+	olderEventId := ulid.MustNew(ulid.Timestamp(olderEventTime), rand.Reader)
+	olderDi := DebounceItem{
+		AccountID:   accountId,
+		WorkspaceID: workspaceId,
+		AppID:       appId,
+		FunctionID:  functionId,
+		EventID:     olderEventId,
+		Event: event.Event{
+			Name:      "now",
+			ID:        olderEventId.String(),
+			Timestamp: olderEventTime.UnixMilli(),
+		},
+	}
+
+	require.NoError(t, redisDebouncer.updateDebounce(ctx, olderDi, fn, 10*time.Second, *debounceID, false))
+
+	var di DebounceItem
+	err = json.Unmarshal([]byte(unshardedCluster.HGet(debounceClient.KeyGenerator().Debounce(ctx), debounceID.String())), &di)
+	require.NoError(t, err)
+	di.Event.ClearSize()
+	require.Equal(t, newerDi, di)
+
+	queueItemIDs, err := unshardedCluster.HKeys(kg.QueueItem())
+	require.NoError(t, err)
+	require.Empty(t, queueItemIDs)
+}
+
 func TestDebouncePrimaryChooser(t *testing.T) {
 	unshardedCluster := miniredis.RunT(t)
 	unshardedRc, err := rueidis.NewClient(rueidis.ClientOption{

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -1297,7 +1297,6 @@ func TestDebounceUpdateMissingQueueItemPreservesNewerEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	unshardedClient := redis_state.NewUnshardedClient(unshardedRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
-	debounceClient := unshardedClient.Debounce()
 
 	opts := []queue.QueueOpt{
 		queue.WithKindToQueueMapping(map[string]string{
@@ -1371,15 +1370,23 @@ func TestDebounceUpdateMissingQueueItemPreservesNewerEvent(t *testing.T) {
 
 	require.NoError(t, redisDebouncer.updateDebounce(ctx, olderDi, fn, 10*time.Second, *debounceID, false))
 
-	var di DebounceItem
-	err = json.Unmarshal([]byte(unshardedCluster.HGet(debounceClient.KeyGenerator().Debounce(ctx), debounceID.String())), &di)
+	queueItemID := queue.HashID(ctx, debounceID.String())
+	recoveredQueueItem, err := shard.LoadQueueItem(ctx, queueItemID)
+	require.NoError(t, err)
+	require.Equal(t, queue.KindDebounce, recoveredQueueItem.Data.Kind)
+
+	rawPayload, ok := recoveredQueueItem.Data.Payload.(json.RawMessage)
+	require.True(t, ok)
+	var payload DebouncePayload
+	require.NoError(t, json.Unmarshal(rawPayload, &payload))
+	require.Equal(t, *debounceID, payload.DebounceID)
+
+	di, err := redisDebouncer.GetDebounceItem(ctx, testScope(accountId, workspaceId, functionId), *debounceID)
 	require.NoError(t, err)
 	di.Event.ClearSize()
-	require.Equal(t, newerDi, di)
+	require.Equal(t, newerDi, *di)
 
-	queueItemIDs, err := unshardedCluster.HKeys(kg.QueueItem())
-	require.NoError(t, err)
-	require.Empty(t, queueItemIDs)
+	require.NoError(t, redisDebouncer.StartExecution(ctx, *di, fn, payload.DebounceID))
 }
 
 func TestDebouncePrimaryChooser(t *testing.T) {

--- a/pkg/execution/state/redis_state/lua/debounce/updateDebounce.lua
+++ b/pkg/execution/state/redis_state/lua/debounce/updateDebounce.lua
@@ -52,6 +52,19 @@ local function get_queue_item(queueKey, queueID)
 	return nil
 end
 
+-- Get the debounce
+local existing = redis.call("HGET", keyDbc, debounceID)
+local existingItem = nil
+if existing ~= false then
+	-- Decode the debounce, and check whether the existing event ID is > the current event ID.  If so,
+	-- don't update the debounce.
+	existingItem = cjson.decode(existing)
+	if existingItem ~= nil and existingItem.e ~= nil and existingItem.e.ts > eventTime then
+		-- The stored event occurs after the event we're updating, so do nothing.
+		return -2
+	end
+end
+
 -- Check that the queue item is not leased (ie. this debounce is not in progress)
 local item = get_queue_item(keyQueueHash, queueJobID)
 if item == nil then
@@ -67,25 +80,15 @@ if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.
 	return -1
 end
 
--- Get the debounce
-local existing = redis.call("HGET", keyDbc, debounceID)
-if existing ~= false then
-	-- Decode the debounce, and check whether the existing event ID is > the current event ID.  If so,
-	-- don't update the debounce.
-	local item = cjson.decode(existing)
-	if item ~= nil and item.e ~= nil and item.e.ts > eventTime then
-		-- The stored event occurs after the event we're updating, so do nothing.
-		return -2
-	end
-
+if existingItem ~= nil then
 	-- Also, if there's an existing debounce, ensure that we respect the max timeout
 	-- for the debounce.  We don't want to keep pushing a debounce out indefinitely,
 	-- so if (now + new TTL in seconds) > the debounce's max time, use the debounce's
 	-- max time instead.
-	if item ~= nil and item.t ~= nil and item.t > 0 then
+	if existingItem.t ~= nil and existingItem.t > 0 then
 		local nextTTL = currentTime + (ttl  * 1000)
-		if nextTTL > item.t then
-			ttl = math.floor((item.t - currentTime) / 1000)
+		if nextTTL > existingItem.t then
+			ttl = math.floor((existingItem.t - currentTime) / 1000)
 			if ttl <= 0 then
 				-- Ensure we always use a minimum.
 				ttl = 1
@@ -99,7 +102,7 @@ if existing ~= false then
 		--
 		-- This makes updates transactional.
 		local next = cjson.decode(debounce)
-		next.t = item.t
+		next.t = existingItem.t
 		debounce = cjson.encode(next)
 	end
 end

--- a/pkg/execution/state/redis_state/lua/debounce/updateDebounce.lua
+++ b/pkg/execution/state/redis_state/lua/debounce/updateDebounce.lua
@@ -55,24 +55,31 @@ end
 -- Get the debounce
 local existing = redis.call("HGET", keyDbc, debounceID)
 local existingItem = nil
+local eventIsOutOfOrder = false
 if existing ~= false then
 	-- Decode the debounce, and check whether the existing event ID is > the current event ID.  If so,
-	-- don't update the debounce.
+	-- preserve the existing debounce data.
 	existingItem = cjson.decode(existing)
 	if existingItem ~= nil and existingItem.e ~= nil and existingItem.e.ts > eventTime then
-		-- The stored event occurs after the event we're updating, so do nothing.
-		return -2
+		eventIsOutOfOrder = true
 	end
 end
 
 -- Check that the queue item is not leased (ie. this debounce is not in progress)
 local item = get_queue_item(keyQueueHash, queueJobID)
 if item == nil then
-	-- The queue item was not found. return not found but set the debounce in the hash map
-  -- for lookup
+	-- Return not found so the caller repairs the missing timeout item.  An older
+	-- event must not replace newer debounce data while taking that recovery path.
   redis.call("SETEX", keyPtr, ttl, debounceID)
-  redis.call("HSET", keyDbc, debounceID, debounce)
+	if not eventIsOutOfOrder then
+		redis.call("HSET", keyDbc, debounceID, debounce)
+	end
   return -3
+end
+
+if eventIsOutOfOrder then
+	-- The stored event occurs after the event we're updating, so do nothing.
+	return -2
 end
 
 if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.leaseID) > currentTime then


### PR DESCRIPTION
## Summary
- preserve the existing newer debounce event before handling the missing timeout queue-item recovery path
- avoid letting an older out-of-order event overwrite debounce state when the pointer/hash exists but the timeout queue item is not visible yet
- add a regression test for the missing queue-item window

## Context
The CI failure in TestDebounce_OutOfOrderTS was a failed flaky test that found a bug in the debounce code. The function ran with the older “now” event instead of the newer “future” event. After that assertion failed, the test waited until its outer timeout expired, which made the failure look like a timeout.

The race is possible because debounce creation writes the pointer/hash before enqueueing the timeout job. During that gap, updateDebounce.lua previously checked for the missing queue item before checking whether the stored event was newer, so an older event could overwrite the stored debounce item.

## Testing
- go test ./pkg/execution/debounce -run ^TestDebounceUpdateMissingQueueItemPreservesNewerEvent$ -count=1 -v
- go test ./pkg/execution/debounce -count=1
- SDK_URL=http://localhost:3000/api/inngest API_URL=http://localhost:8288 go test ./tests/golang -run ^TestDebounce_OutOfOrderTS$ -count=10 -v

Also attempted local repro before the fix:
- isolated TestDebounce_OutOfOrderTS passed 50/50
- the CI log for run 33378436977 showed expected future, actual now