### PR TITLE
feat(duckdb): Implement extended trace spans on duckdb

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -96,6 +96,13 @@ type Opts struct {
 
 	// MetadataOpts represents the required opts for the metadadata API
 	MetadataOpts MetadataOpts
+
+	// SyncLifecycleListeners are notified synchronously (see
+	// execution.SyncLifecycleListener) when a userland (extended-trace) span
+	// is committed via OTLP ingestion -- see traces.go's commitSpan. Nil/empty
+	// is a no-op; only a caller wiring DuckDB dual-write
+	// (pkg/execution/dualwrite) sets this today.
+	SyncLifecycleListeners []execution.SyncLifecycleListener
 }
 
 type checkpointQueue struct {

--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -18,6 +18,7 @@ import (
 	"github.com/inngest/inngest/pkg/api/apiv1/apiv1auth"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
@@ -404,6 +405,8 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 		return fmt.Errorf("failed to create span: %w", err)
 	}
 
+	a.emitUserlandSpan(ctx, runID, functionID, fn.AppID, auth, parent, s, attrs)
+
 	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
 		cfg.Attrs = cfg.Attrs.Merge(tenantAttrs)
 	}
@@ -438,6 +441,36 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 	}
 
 	return nil
+}
+
+// emitUserlandSpan fans a committed userland (extended-trace) span out to
+// every registered execution.SyncLifecycleListener -- currently only DuckDB
+// dual-write (pkg/execution/dualwrite), which creates its own equivalent
+// span through its private TracerProvider rather than reusing this one
+// (this endpoint's span is created through the real, SQLite-backed
+// TracerProvider).
+func (a router) emitUserlandSpan(ctx context.Context, runID ulid.ULID, functionID, appID uuid.UUID, auth apiv1auth.V1Auth, parent *meta.SpanReference, s *tracev1.Span, attrs []attribute.KeyValue) {
+	if len(a.opts.SyncLifecycleListeners) == 0 {
+		return
+	}
+
+	span := execution.ExtendedTraceSpan{
+		AccountID:  auth.AccountID(),
+		EnvID:      auth.WorkspaceID(),
+		AppID:      appID,
+		FunctionID: functionID,
+		RunID:      runID,
+		Parent:     parent,
+		SpanID:     trace.SpanID(s.SpanId),
+		Name:       s.Name,
+		StartTime:  time.Unix(0, int64(s.StartTimeUnixNano)),
+		EndTime:    time.Unix(0, int64(s.EndTimeUnixNano)),
+		Attributes: attrs,
+	}
+
+	for _, l := range a.opts.SyncLifecycleListeners {
+		l.OnExtendedTraceSpan(ctx, span)
+	}
 }
 
 func getInngestTraceRef(s *tracev1.Span) (*meta.SpanReference, error) {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -37,8 +37,8 @@ import (
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/coreapi"
 	"github.com/inngest/inngest/pkg/cqrs"
-	"github.com/inngest/inngest/pkg/cqrs/duckdbquery"
 	"github.com/inngest/inngest/pkg/cqrs/base_cqrs"
+	"github.com/inngest/inngest/pkg/cqrs/duckdbquery"
 	cqrsmanager "github.com/inngest/inngest/pkg/cqrs/manager"
 	dbpkg "github.com/inngest/inngest/pkg/db"
 	"github.com/inngest/inngest/pkg/db/driverhelp"
@@ -743,12 +743,13 @@ func start(ctx context.Context, opts StartOpts) error {
 			Broadcaster:       broadcaster,
 			TraceReader:       gqlData,
 
-			AppCreator:        dbcqrs,
-			FunctionCreator:   dbcqrs,
-			EventPublisher:    runner,
-			TracerProvider:    tp,
-			State:             smv2,
-			RealtimeJWTSecret: consts.DevServerRealtimeJWTSecret,
+			AppCreator:             dbcqrs,
+			FunctionCreator:        dbcqrs,
+			EventPublisher:         runner,
+			TracerProvider:         tp,
+			SyncLifecycleListeners: syncListeners,
+			State:                  smv2,
+			RealtimeJWTSecret:      consts.DevServerRealtimeJWTSecret,
 
 			CheckpointOpts: apiv1.CheckpointAPIOpts{
 				RunOutputReader: devutil.NewLocalOutputReader(core.Resolver(), gqlData, gqlData),

--- a/pkg/execution/dualwrite/listener.go
+++ b/pkg/execution/dualwrite/listener.go
@@ -41,6 +41,7 @@ import (
 	tracingv3 "github.com/inngest/inngest/pkg/tracing/v3"
 	"github.com/inngest/inngest/pkg/util/interval"
 	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // listener implements execution.SyncLifecycleListener. Every hook body does
@@ -614,6 +615,36 @@ func (l *listener) OnEventReceived(ctx context.Context, evt event.TrackedEvent) 
 	}
 
 	l.sendEvent(row)
+}
+
+// OnExtendedTraceSpan creates the userland (extended-trace) span through
+// this listener's own private tracingv3.TracerProvider, the same as every
+// other span-producing hook in this file (see createSpan/spanExporter) --
+// so the resulting inngest.run_trace_spans row is built by the same
+// spanExportRow conversion those hooks already rely on, rather than a
+// second, hand-rolled row-building path. Tenant/run identity is set
+// explicitly from span's own typed fields (like every other hook does via
+// addTenantAndDebugAttrs, which is a no-op here since there's no
+// statev2.Metadata) rather than relying on span.Attributes already
+// containing it -- spanExportRow reads these back off the created span's
+// attributes regardless of source.
+func (l *listener) OnExtendedTraceSpan(ctx context.Context, span execution.ExtendedTraceSpan) {
+	attrs := meta.NewAttrSet()
+	meta.AddAttr(attrs, meta.Attrs.AccountID, &span.AccountID)
+	meta.AddAttr(attrs, meta.Attrs.EnvID, &span.EnvID)
+	meta.AddAttr(attrs, meta.Attrs.AppID, &span.AppID)
+	meta.AddAttr(attrs, meta.Attrs.FunctionID, &span.FunctionID)
+	meta.AddAttr(attrs, meta.Attrs.RunID, &span.RunID)
+
+	_, _ = l.createSpan(ctx, tracingv3.SpanNameExtendedTrace, &tracing.CreateSpanOptions{
+		Debug:              &tracing.SpanDebugData{Location: "dualwrite.listener.OnExtendedTraceSpan"},
+		Attributes:         attrs,
+		StartTime:          span.StartTime,
+		EndTime:            span.EndTime,
+		Parent:             span.Parent,
+		RawOtelSpanOptions: []trace.SpanStartOption{trace.WithAttributes(span.Attributes...)},
+		SpanID:             span.SpanID,
+	})
 }
 
 // OnDeferAdd writes the run's own executor.defer span (a new row, seeded

--- a/pkg/execution/dualwrite/listener_test.go
+++ b/pkg/execution/dualwrite/listener_test.go
@@ -19,8 +19,11 @@ import (
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
+	tracingv3 "github.com/inngest/inngest/pkg/tracing/v3"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestListenerOnEventReceivedNonBlockingWhenBufferFull(t *testing.T) {
@@ -836,6 +839,59 @@ func TestListenerOnDeferAbortReusesSameSpanID(t *testing.T) {
 		}
 	}
 	require.True(t, sawAborted, "one of the two rows should carry status=Aborted")
+}
+
+// TestListenerOnExtendedTraceSpanWritesSpan proves OnExtendedTraceSpan --
+// unlike every other hook in this file, invoked from
+// pkg/api/apiv1/traces.go's commitSpan rather than the executor/runner --
+// still lands a row in inngest.run_trace_spans via the same
+// createSpan/spanExporter path, under the package's own
+// tracingv3.SpanNameExtendedTrace name, carrying the caller-supplied
+// tenant/run identity and attributes.
+func TestListenerOnExtendedTraceSpanWritesSpan(t *testing.T) {
+	db, cleanup := newTestDuckDB(t)
+	defer cleanup()
+	l := NewListener(db, func(o *setupOpts) { o.batchInterval = 20 * time.Millisecond })
+
+	accountID, envID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	runID := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader)
+	md := sv2.Metadata{ID: sv2.ID{
+		RunID:      runID,
+		FunctionID: functionID,
+		Tenant:     sv2.Tenant{AccountID: accountID, EnvID: envID, AppID: appID},
+	}}
+	sv2.InitConfig(&md.Config)
+
+	span := execution.ExtendedTraceSpan{
+		AccountID:  accountID,
+		EnvID:      envID,
+		AppID:      appID,
+		FunctionID: functionID,
+		RunID:      runID,
+		Parent:     tracing.RunSpanRefFromMetadata(&md),
+		SpanID:     trace.SpanID{1, 2, 3, 4, 5, 6, 7, 8},
+		Name:       "my.userland.operation",
+		StartTime:  time.Now().Add(-time.Second),
+		EndTime:    time.Now(),
+		Attributes: []attribute.KeyValue{attribute.String("custom.attr", "hello")},
+	}
+	l.OnExtendedTraceSpan(context.Background(), span)
+
+	require.Eventually(t, func() bool {
+		var count int
+		row := db.QueryRowContext(context.Background(), "SELECT count(*) FROM inngest.run_trace_spans WHERE name = ?;", tracingv3.SpanNameExtendedTrace)
+		_ = row.Scan(&count)
+		return count == 1
+	}, 2*time.Second, 20*time.Millisecond, "extended-trace span should land after a batch flush")
+
+	rows := selectRows(t, db, "SELECT run_id, span_id, attributes FROM inngest.run_trace_spans WHERE name = ?;", tracingv3.SpanNameExtendedTrace)
+	require.Len(t, rows, 1)
+	require.Equal(t, runID.String(), rows[0]["run_id"])
+	require.Equal(t, span.SpanID.String(), rows[0]["span_id"])
+
+	attrs, ok := rows[0]["attributes"].(map[string]any)
+	require.True(t, ok, "attributes column should decode to a map, got %T", rows[0]["attributes"])
+	require.Equal(t, "hello", attrs["custom.attr"])
 }
 
 // deferScheduleEventJSON builds the raw JSON of an inngest/deferred.schedule

--- a/pkg/execution/sync_lifecycle.go
+++ b/pkg/execution/sync_lifecycle.go
@@ -6,11 +6,16 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	statev1 "github.com/inngest/inngest/pkg/execution/state"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // SyncLifecycleListener listens to the same run/step lifecycle events as
@@ -232,6 +237,44 @@ type SyncLifecycleListener interface {
 	// pkg/execution/defers.AbortFromOp). now is the caller's own "this just
 	// happened" timestamp -- see OnFunctionFinished.
 	OnDeferAbort(ctx context.Context, md statev2.Metadata, hashedID string, now time.Time)
+
+	// OnExtendedTraceSpan is called synchronously when a userland (extended-trace)
+	// span is committed via OTLP ingestion
+	// (pkg/api/apiv1/traces.go's commitSpan, POST /v1/traces/userland).
+	// Unlike every other hook, there is no statev2.Metadata available at this
+	// call site -- tenant/run identity comes from request auth plus a
+	// function lookup, not executor state -- so identifiers are carried
+	// individually on span instead. There is also no "now" parameter, unlike
+	// every other hook: span already carries its own StartTime/EndTime (the
+	// span is historical, reported after the fact via OTLP), so there's
+	// nothing here that would need the caller's clock read.
+	OnExtendedTraceSpan(ctx context.Context, span ExtendedTraceSpan)
+}
+
+// ExtendedTraceSpan carries everything OnExtendedTraceSpan needs to record a
+// userland (extended-trace) span. Every other hook derives its identifiers
+// from a statev2.Metadata plus a queue.Item/GeneratorOpcode; neither exists
+// at the OTLP ingestion call site, so this bundles the equivalent fields by
+// hand. Parent is the traceref this span was created under -- its trace ID
+// and span ID (the OTel parent span ID) are recoverable via
+// tracing.SpanContextFromMetadata, the same helper the real TracerProvider
+// uses.
+type ExtendedTraceSpan struct {
+	AccountID  uuid.UUID
+	EnvID      uuid.UUID
+	AppID      uuid.UUID
+	FunctionID uuid.UUID
+	RunID      ulid.ULID
+	Parent     *meta.SpanReference
+	SpanID     trace.SpanID
+	Name       string
+	StartTime  time.Time
+	EndTime    time.Time
+	// Attributes is the span's final, fully-merged attribute set (SDK/OTLP
+	// attributes plus the inngest-added tenant/step attributes) -- the same
+	// raw shape pkg/execution/dualwrite/tracing.go's spanExportRow reads off
+	// a real sdktrace.ReadOnlySpan via span.Attributes().
+	Attributes []attribute.KeyValue
 }
 
 // NoopSyncLifecycleListener does nothing. Embed this into a custom
@@ -293,3 +336,5 @@ func (NoopSyncLifecycleListener) OnDeferAdd(context.Context, statev2.Metadata, s
 
 func (NoopSyncLifecycleListener) OnDeferAbort(context.Context, statev2.Metadata, string, time.Time) {
 }
+
+func (NoopSyncLifecycleListener) OnExtendedTraceSpan(context.Context, ExtendedTraceSpan) {}

--- a/pkg/tracing/v3/consts.go
+++ b/pkg/tracing/v3/consts.go
@@ -44,4 +44,9 @@ const (
 	// ever inserts and reusing the eventual finished step span's identity
 	// here would collide with it once that real span is inserted.
 	SpanNameStepPlanned = "executor.step.planned"
+
+	// SpanNameExtendedTrace marks a userland (extended-trace) span written by
+	// OnExtendedTraceSpan (pkg/api/apiv1/traces.go's commitSpan, via OTLP
+	// ingestion).
+	SpanNameExtendedTrace = "sdk.extended_trace"
 )


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This implements extended trace spans for the duckdb dual-write path.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
