### PR TITLE
cloud(ui): give the concurrency banner two attributed CTAs

### DIFF
--- a/ui/apps/dashboard/src/components/Runs/AccountConcurrencyBanner.tsx
+++ b/ui/apps/dashboard/src/components/Runs/AccountConcurrencyBanner.tsx
@@ -15,12 +15,23 @@ import {
   isDismissalActive,
   markViewTracked,
   readDismissedAt,
+  resolveBillingCTA,
   writeDismissedAt,
+  type ConcurrencyBillingCTA,
 } from './accountConcurrency';
 import { useAccountConcurrencyPressure } from './useAccountConcurrencyPressure';
 
 const ANALYTICS_FEATURE = 'account-concurrency' as const;
 const BANNER_ID = 'account-concurrency';
+
+// Identifies the always-present CTA on the click event. The billing CTA
+// reports its own kind, which doubles as its analytics name.
+const USAGE_CTA = 'view-usage';
+
+const billingCTACopy: Record<ConcurrencyBillingCTA, string> = {
+  'increase-concurrency': 'Increase concurrency',
+  upgrade: 'Upgrade',
+};
 
 /**
  * Warns on the runs list when the account has repeatedly hit its concurrency
@@ -54,13 +65,18 @@ export function AccountConcurrencyBanner({ refreshNonce, scope }: Props) {
 
   // Don't fetch an answer we can't act on: nothing before we know the dismissal
   // state, and nothing for the 24h the banner stays dismissed.
-  const { isPressured, minutesWithHits, accountID } =
+  const { isPressured, minutesWithHits, accountID, isFreePlan, isMarketplace } =
     useAccountConcurrencyPressure({
       refreshNonce,
       skip: !isReady || isDismissed,
     });
 
   const isVisible = isReady && isPressured && !isDismissed;
+
+  // Null for marketplace accounts, and until the plan resolves. Deciding this
+  // here rather than in the JSX keeps the rendered CTA and the CTA reported on
+  // the view event from ever disagreeing.
+  const billingCTA = resolveBillingCTA({ isFreePlan, isMarketplace });
 
   // The impression event the click and dismiss rates are measured against.
   // Deduped per account and scope per session, since the banner re-resolves on
@@ -76,8 +92,10 @@ export function AccountConcurrencyBanner({ refreshNonce, scope }: Props) {
       scope,
       minutesWithHits,
       windowMinutes: CONCURRENCY_WINDOW_MINUTES,
+      cta: USAGE_CTA,
+      secondaryCta: billingCTA ?? undefined,
     });
-  }, [isVisible, accountID, scope, minutesWithHits]);
+  }, [isVisible, accountID, scope, minutesWithHits, billingCTA]);
 
   // Re-read when the account changes: dismissal is stored per account, so
   // switching orgs must consult that account's entry, not the previous one's.
@@ -103,15 +121,19 @@ export function AccountConcurrencyBanner({ refreshNonce, scope }: Props) {
     });
   }, [accountID, scope]);
 
-  // The CTA is an anchor, so this fires during the click that navigates away.
+  // Both CTAs navigate, so this fires during the click that leaves the page.
   // Segment's track call is fire-and-forget, which is why it isn't awaited.
-  const onCTAClick = useCallback(() => {
-    trackBannerCTAClicked({
-      feature: ANALYTICS_FEATURE,
-      bannerId: BANNER_ID,
-      scope,
-    });
-  }, [scope]);
+  const onCTAClick = useCallback(
+    (cta: string) => () => {
+      trackBannerCTAClicked({
+        feature: ANALYTICS_FEATURE,
+        bannerId: BANNER_ID,
+        scope,
+        cta,
+      });
+    },
+    [scope],
+  );
 
   if (!isVisible) {
     return null;
@@ -122,21 +144,54 @@ export function AccountConcurrencyBanner({ refreshNonce, scope }: Props) {
       severity="warning"
       onDismiss={onDismiss}
       cta={
-        <Button
-          appearance="outlined"
-          kind="secondary"
-          size="small"
-          label="View account concurrency"
-          onClick={onCTAClick}
-          href={pathCreator.metrics({
-            envSlug: env.slug,
-            ref: 'app-runs-concurrency-banner',
-          })}
-        />
+        <div className="flex shrink-0 items-center gap-3">
+          <Banner.Link
+            severity="warning"
+            onClick={onCTAClick(USAGE_CTA)}
+            // The ref rides in `to` rather than `search`: the router's search
+            // schema doesn't declare `ref`, and this matches how the rest of
+            // the app links with one (see OnboardingWidget).
+            to={pathCreator.metrics({
+              envSlug: env.slug,
+              ref: 'app-runs-concurrency-banner-usage',
+            })}
+          >
+            View usage
+          </Banner.Link>
+          {billingCTA && (
+            <Button
+              appearance="outlined"
+              kind="secondary"
+              size="small"
+              label={billingCTACopy[billingCTA]}
+              onClick={onCTAClick(billingCTA)}
+              href={billingCTAHref(billingCTA)}
+            />
+          )}
+        </div>
       }
     >
-      Your account reached its concurrency limit repeatedly in the last{' '}
-      {CONCURRENCY_WINDOW_MINUTES} minutes, delaying runs.
+      Runs delayed because your concurrency limit was reached.
     </Banner>
   );
+}
+
+/**
+ * Free accounts need a tier change, so they land on the plan picker. Paid
+ * accounts are buying more of one entitlement, so they land on the billing
+ * overview with the concurrency add-on highlighted — the same destination the
+ * metrics dashboard's concurrency CTA uses.
+ */
+function billingCTAHref(cta: ConcurrencyBillingCTA): string {
+  if (cta === 'upgrade') {
+    return pathCreator.billing({
+      tab: 'plans',
+      ref: 'app-runs-concurrency-banner-upgrade',
+    });
+  }
+
+  return pathCreator.billing({
+    highlight: 'concurrency',
+    ref: 'app-runs-concurrency-banner-increase-concurrency',
+  });
 }

--- a/ui/apps/dashboard/src/components/Runs/accountConcurrency.test.ts
+++ b/ui/apps/dashboard/src/components/Runs/accountConcurrency.test.ts
@@ -8,6 +8,7 @@ import {
   DISMISSAL_LIFETIME_MS,
   isConcurrencyPressured,
   isDismissalActive,
+  resolveBillingCTA,
   viewTrackedStorageKey,
 } from './accountConcurrency';
 
@@ -200,5 +201,38 @@ describe('isDismissalActive', () => {
 
   it('treats a malformed stamp as expired', () => {
     expect(isDismissalActive(NaN, now)).toBe(false);
+  });
+});
+
+describe('resolveBillingCTA', () => {
+  it('offers a tier change on a free plan', () => {
+    expect(resolveBillingCTA({ isFreePlan: true, isMarketplace: false })).toBe(
+      'upgrade',
+    );
+  });
+
+  it('offers an entitlement top-up on a paid plan', () => {
+    expect(resolveBillingCTA({ isFreePlan: false, isMarketplace: false })).toBe(
+      'increase-concurrency',
+    );
+  });
+
+  // Every billing route but /billing/usage redirects marketplace accounts
+  // away, so a billing CTA could only dead-end them.
+  it('offers nothing to a marketplace account, whatever its plan', () => {
+    expect(resolveBillingCTA({ isFreePlan: true, isMarketplace: true })).toBe(
+      null,
+    );
+    expect(resolveBillingCTA({ isFreePlan: false, isMarketplace: true })).toBe(
+      null,
+    );
+  });
+
+  // Withheld rather than guessed: a default would flash the wrong label on
+  // whichever plan it guessed against.
+  it('offers nothing until the plan is known', () => {
+    expect(
+      resolveBillingCTA({ isFreePlan: undefined, isMarketplace: false }),
+    ).toBe(null);
   });
 });

--- a/ui/apps/dashboard/src/components/Runs/accountConcurrency.ts
+++ b/ui/apps/dashboard/src/components/Runs/accountConcurrency.ts
@@ -9,8 +9,9 @@
 // 1-minute buckets, so this window is 10 buckets wide.
 export const CONCURRENCY_WINDOW_MS = 10 * 60 * 1000;
 
-// The banner copy names this window, so derive it rather than hardcoding the
-// number in the string — otherwise tuning the window silently makes the copy lie.
+// Reported on the banner's view event so reactions can be read against the
+// window the signal was measured over. Derived rather than hardcoded so tuning
+// the window can't silently desync the two.
 export const CONCURRENCY_WINDOW_MINUTES = CONCURRENCY_WINDOW_MS / 60_000;
 
 // How far behind "now" the window ends. The newest bucket is the least
@@ -94,6 +95,35 @@ export function countMinutesWithHits(buckets: Bucket[] | undefined): number {
  */
 export function isConcurrencyPressured(buckets: Bucket[] | undefined): boolean {
   return countMinutesWithHits(buckets) >= CONCURRENCY_HIT_MINUTES_THRESHOLD;
+}
+
+/**
+ * Which billing CTA the banner offers alongside "View usage", or null for no
+ * second CTA at all.
+ *
+ * Marketplace accounts (Vercel, AWS, DigitalOcean, partner) are billed by the
+ * provider, and every billing route but /billing/usage redirects them away
+ * (see MarketplaceAccessControl) — so any in-app upgrade CTA is a dead end.
+ * We have no installation-level URL to send them to instead, so they get none.
+ *
+ * Otherwise the label tracks what the user is actually buying: a free account
+ * changes tier ("Upgrade"), while a paid one is topping up a single
+ * entitlement, not moving tiers ("Increase concurrency").
+ */
+export type ConcurrencyBillingCTA = 'increase-concurrency' | 'upgrade';
+
+export function resolveBillingCTA({
+  isFreePlan,
+  isMarketplace,
+}: {
+  // Undefined until the account query resolves. Withholding the CTA until then
+  // is what keeps the wrong label from flashing on a paid account.
+  isFreePlan: boolean | undefined;
+  isMarketplace: boolean;
+}): ConcurrencyBillingCTA | null {
+  if (isMarketplace || isFreePlan === undefined) return null;
+
+  return isFreePlan ? 'upgrade' : 'increase-concurrency';
 }
 
 const VIEW_TRACKED_STORAGE_KEY_PREFIX = 'viewedAccountConcurrencyBanner';

--- a/ui/apps/dashboard/src/components/Runs/useAccountConcurrencyPressure.ts
+++ b/ui/apps/dashboard/src/components/Runs/useAccountConcurrencyPressure.ts
@@ -13,6 +13,11 @@ import {
 type AccountIdentityQuery = {
   account: {
     id: string;
+    // Non-null for accounts billed through a provider (Vercel, AWS, ...).
+    marketplace: string | null;
+    // Null on accounts without a resolved plan; the banner treats that the
+    // same as "not yet known" and withholds the billing CTA.
+    plan: { isFree: boolean } | null;
   };
 };
 
@@ -20,6 +25,9 @@ type AccountIdentityQuery = {
 // ClickHouse) and always runs, because the dismissal key needs the account ID
 // even while the expensive query is skipped. urql shares it with the other
 // `account` queries on the page.
+//
+// Only `plan.isFree` is selected, not the whole plan: the wider GetCurrentPlan
+// document also pulls entitlements, which reads the usage table.
 const AccountIdentityDocument: TypedDocumentNode<
   AccountIdentityQuery,
   Record<string, never>
@@ -27,6 +35,10 @@ const AccountIdentityDocument: TypedDocumentNode<
   query AccountConcurrencyIdentity {
     account {
       id
+      marketplace
+      plan {
+        isFree
+      }
     }
   }
 `;
@@ -69,6 +81,13 @@ type AccountConcurrencyPressure = {
   // Undefined until the identity query resolves. The banner can't key its
   // dismissal — or render at all — before this is known.
   accountID: string | undefined;
+  // Whether the account is billed through a marketplace provider. Assumed
+  // false until the identity query resolves; the banner only uses it to
+  // suppress a CTA, and the CTA is withheld while the plan is unknown anyway.
+  isMarketplace: boolean;
+  // Undefined until the identity query resolves, or when the account has no
+  // plan attached.
+  isFreePlan: boolean | undefined;
 };
 
 /**
@@ -122,6 +141,8 @@ export function useAccountConcurrencyPressure({
 
   return {
     accountID,
+    isFreePlan: identity?.account.plan?.isFree,
+    isMarketplace: Boolean(identity?.account.marketplace),
     isPressured: isConcurrencyPressured(data?.concurrencyLimitHits.data),
     minutesWithHits: countMinutesWithHits(data?.concurrencyLimitHits.data),
   };

--- a/ui/apps/dashboard/src/utils/analyticsEvents.ts
+++ b/ui/apps/dashboard/src/utils/analyticsEvents.ts
@@ -108,6 +108,11 @@ type BannerViewedArgs = {
   scope?: string;
   minutesWithHits?: number;
   windowMinutes?: number;
+  // Which CTAs the impression actually offered. A banner can vary its CTAs by
+  // account, so without these the clicks on a CTA only some viewers saw get
+  // divided by every impression, and the rate means nothing.
+  cta?: string;
+  secondaryCta?: string;
 };
 
 export function trackBannerViewed({
@@ -116,12 +121,16 @@ export function trackBannerViewed({
   scope,
   minutesWithHits,
   windowMinutes,
+  cta,
+  secondaryCta,
 }: BannerViewedArgs) {
   track('Banner Viewed', feature, {
     banner_id: bannerId,
     scope,
     minutes_with_hits: minutesWithHits,
     window_minutes: windowMinutes,
+    cta,
+    secondary_cta: secondaryCta,
   });
 }
 
@@ -146,16 +155,23 @@ type BannerCTAClickedArgs = {
   feature: AnalyticsFeature;
   bannerId: string;
   scope?: string;
+  // Which CTA was clicked, for banners offering more than one. Deliberately a
+  // property rather than a per-CTA event name: total click-through stays a
+  // single number that shares the `Banner Viewed` denominator, and per-CTA
+  // rates are a breakdown of it.
+  cta: string;
 };
 
 export function trackBannerCTAClicked({
   feature,
   bannerId,
   scope,
+  cta,
 }: BannerCTAClickedArgs) {
   track('Banner CTA Clicked', feature, {
     banner_id: bannerId,
     scope,
+    cta,
   });
 }
 


### PR DESCRIPTION
## Description

- Previously, [we put up a banner on the runs pages](https://github.com/inngest/inngest/pull/4725) when a user rails against account concurrency limit

Before:

<img width="2362" height="778" alt="image" src="https://github.com/user-attachments/assets/a641114c-7e5a-4828-9ab8-628b925321dd" />

- We would like to update the copy and provide two buttons: one to see usage and one to upgrade/increase concurrency
- Notably, we don't include a upgrade button for [marketplace users](https://inngest.slack.com/archives/C05QSAYPEG0/p1788289289498069), because we don't have a page on our dashboard that does that for them.
- This is for Cloud only.

After variants:

<img width="5760" height="160" alt="banner-paid-increase-concurrency" src="https://github.com/user-attachments/assets/b4694319-0fed-4f2d-b9c2-3bb76b6bcf16" />
<img width="5760" height="160" alt="banner-marketplace-no-billing-cta" src="https://github.com/user-attachments/assets/638d9345-8cb5-4f36-972c-3749705b78cc" />
<img width="5760" height="160" alt="banner-paid-increase-concurrency" src="https://github.com/user-attachments/assets/402639f5-d03d-4df7-8c9e-57ac81cc093d" />


## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
