### PR TITLE
cloud(ui): count concurrency banner reactions per impression

### DIFF
--- a/ui/apps/dashboard/src/components/Runs/AccountConcurrencyBanner.tsx
+++ b/ui/apps/dashboard/src/components/Runs/AccountConcurrencyBanner.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Banner } from '@inngest/components/Banner';
 import { Button } from '@inngest/components/Button';
+import { ulid } from 'ulid';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
 import {
@@ -10,13 +11,12 @@ import {
 } from '@/utils/analyticsEvents';
 import { pathCreator } from '@/utils/urls';
 import {
-  CONCURRENCY_WINDOW_MINUTES,
-  hasTrackedView,
   isDismissalActive,
-  markViewTracked,
+  nextImpression,
   readDismissedAt,
   resolveBillingCTA,
   writeDismissedAt,
+  type BannerImpression,
   type ConcurrencyBillingCTA,
 } from './accountConcurrency';
 import { useAccountConcurrencyPressure } from './useAccountConcurrencyPressure';
@@ -73,29 +73,59 @@ export function AccountConcurrencyBanner({ refreshNonce, scope }: Props) {
 
   const isVisible = isReady && isPressured && !isDismissed;
 
-  // Null for marketplace accounts, and until the plan resolves. Deciding this
-  // here rather than in the JSX keeps the rendered CTA and the CTA reported on
-  // the view event from ever disagreeing.
+  // Null for marketplace accounts, and until the plan resolves. Settled by the
+  // time the banner is visible: the plan rides on the same identity query as
+  // the account id, and nothing renders before that resolves.
   const billingCTA = resolveBillingCTA({ isFreePlan, isMarketplace });
 
-  // The impression event the click and dismiss rates are measured against.
-  // Deduped per account and scope per session, since the banner re-resolves on
-  // every mount and every Refresh.
+  // The current appearance of the banner. Every event this appearance produces
+  // is stamped with its id and reports its snapshot, so clicks and dismissals
+  // divide by the impressions they actually came from. Held in state rather
+  // than derived, because minting an id is not something render may do twice.
+  const [impression, setImpression] = useState<BannerImpression | null>(null);
+
   useEffect(() => {
-    if (!isVisible || !accountID || hasTrackedView(accountID, scope)) {
+    setImpression((prev) =>
+      nextImpression(
+        prev,
+        {
+          isVisible,
+          accountID,
+          scope,
+          minutesWithHits,
+          cta: USAGE_CTA,
+          billingCTA,
+        },
+        ulid,
+      ),
+    );
+  }, [isVisible, accountID, scope, minutesWithHits, billingCTA]);
+
+  // The impression event the click and dismiss rates are measured against.
+  // Fires on every appearance — deduping it while leaving the actions undeduped
+  // is what made the old rates meaningless. The ref bounds it to once per id
+  // regardless of how often the effect re-runs (StrictMode double-invokes it in
+  // dev), without putting storage on the denominator's path: a browser that
+  // refuses storage must still be able to emit a view, or its clicks land with
+  // no denominator at all.
+  const trackedImpressionID = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!impression || trackedImpressionID.current === impression.id) {
       return;
     }
-    markViewTracked(accountID, scope);
+    trackedImpressionID.current = impression.id;
     trackBannerViewed({
       feature: ANALYTICS_FEATURE,
       bannerId: BANNER_ID,
-      scope,
-      minutesWithHits,
-      windowMinutes: CONCURRENCY_WINDOW_MINUTES,
-      cta: USAGE_CTA,
-      secondaryCta: billingCTA ?? undefined,
+      impressionId: impression.id,
+      scope: impression.scope,
+      minutesWithHits: impression.minutesWithHits,
+      windowMinutes: impression.windowMinutes,
+      cta: impression.cta,
+      secondaryCta: impression.billingCTA ?? undefined,
     });
-  }, [isVisible, accountID, scope, minutesWithHits, billingCTA]);
+  }, [impression]);
 
   // Re-read when the account changes: dismissal is stored per account, so
   // switching orgs must consult that account's entry, not the previous one's.
@@ -112,32 +142,46 @@ export function AccountConcurrencyBanner({ refreshNonce, scope }: Props) {
       return;
     }
     const now = Date.now();
+    // Hiding the banner runs off React state below, not off this write, so a
+    // storage failure still hides it for the rest of the session.
     writeDismissedAt(accountID, now);
     setDismissedAt(now);
     trackBannerDismissed({
       feature: ANALYTICS_FEATURE,
       bannerId: BANNER_ID,
-      scope,
+      impressionId: impression?.id,
+      scope: impression?.scope ?? scope,
+      minutesWithHits: impression?.minutesWithHits,
+      windowMinutes: impression?.windowMinutes,
     });
-  }, [accountID, scope]);
+  }, [accountID, scope, impression]);
 
-  // Both CTAs navigate, so this fires during the click that leaves the page.
-  // Segment's track call is fire-and-forget, which is why it isn't awaited.
+  // Both CTAs route client-side, so the page isn't torn down mid-flight and
+  // Segment's fire-and-forget track call still lands. Sending either of them
+  // through a plain `href` would unload the document and cancel the request,
+  // silently deflating that one CTA's click count against the other's.
   const onCTAClick = useCallback(
     (cta: string) => () => {
       trackBannerCTAClicked({
         feature: ANALYTICS_FEATURE,
         bannerId: BANNER_ID,
-        scope,
+        impressionId: impression?.id,
+        scope: impression?.scope ?? scope,
+        minutesWithHits: impression?.minutesWithHits,
+        windowMinutes: impression?.windowMinutes,
         cta,
       });
     },
-    [scope],
+    [scope, impression],
   );
 
-  if (!isVisible) {
+  // Rendering off the impression rather than `isVisible` is what guarantees the
+  // CTAs a viewer saw are the CTAs the view event reported.
+  if (!impression) {
     return null;
   }
+
+  const { billingCTA: renderedBillingCTA } = impression;
 
   return (
     <Banner
@@ -158,14 +202,14 @@ export function AccountConcurrencyBanner({ refreshNonce, scope }: Props) {
           >
             View usage
           </Banner.Link>
-          {billingCTA && (
+          {renderedBillingCTA && (
             <Button
               appearance="outlined"
               kind="secondary"
               size="small"
-              label={billingCTACopy[billingCTA]}
-              onClick={onCTAClick(billingCTA)}
-              href={billingCTAHref(billingCTA)}
+              label={billingCTACopy[renderedBillingCTA]}
+              onClick={onCTAClick(renderedBillingCTA)}
+              to={billingCTAPath(renderedBillingCTA)}
             />
           )}
         </div>
@@ -181,8 +225,13 @@ export function AccountConcurrencyBanner({ refreshNonce, scope }: Props) {
  * accounts are buying more of one entitlement, so they land on the billing
  * overview with the concurrency add-on highlighted — the same destination the
  * metrics dashboard's concurrency CTA uses.
+ *
+ * Passed to the button's `to`, not its `href`: `href` renders a bare anchor and
+ * full-page navigation would cancel the in-flight click event. As with the
+ * usage CTA, the ref rides in the path because the router's search schema
+ * doesn't declare it.
  */
-function billingCTAHref(cta: ConcurrencyBillingCTA): string {
+function billingCTAPath(cta: ConcurrencyBillingCTA): string {
   if (cta === 'upgrade') {
     return pathCreator.billing({
       tab: 'plans',

--- a/ui/apps/dashboard/src/components/Runs/accountConcurrency.test.ts
+++ b/ui/apps/dashboard/src/components/Runs/accountConcurrency.test.ts
@@ -3,13 +3,14 @@ import { describe, expect, it } from 'vitest';
 import {
   buildConcurrencyWindow,
   CONCURRENCY_END_OFFSET_MS,
+  CONCURRENCY_WINDOW_MINUTES,
   countMinutesWithHits,
   dismissalStorageKey,
   DISMISSAL_LIFETIME_MS,
   isConcurrencyPressured,
   isDismissalActive,
+  nextImpression,
   resolveBillingCTA,
-  viewTrackedStorageKey,
 } from './accountConcurrency';
 
 const bucket = (value: number) => ({ value });
@@ -121,34 +122,6 @@ describe('countMinutesWithHits', () => {
   });
 });
 
-describe('viewTrackedStorageKey', () => {
-  const accountA = '5d258962-2c37-4a5d-b875-ebe72792c47f';
-  const accountB = 'e8ea18c4-dbb4-4e98-a6a4-8ff8b3801765';
-
-  it('gives different accounts different keys', () => {
-    expect(viewTrackedStorageKey(accountA)).not.toBe(
-      viewTrackedStorageKey(accountB),
-    );
-  });
-
-  // Click/dismiss events carry the scope they fired from, so impressions have
-  // to be counted per scope too — otherwise the second scope visited in a
-  // session records reactions with no matching view.
-  it('gives different scopes different keys', () => {
-    expect(viewTrackedStorageKey(accountA, 'env')).not.toBe(
-      viewTrackedStorageKey(accountA, 'fn'),
-    );
-  });
-
-  // Distinct namespaces: dismissal is durable and per-account, the view marker
-  // is session-scoped. Sharing a key would make dismissing suppress impressions.
-  it('does not collide with the dismissal key', () => {
-    expect(viewTrackedStorageKey(accountA)).not.toBe(
-      dismissalStorageKey(accountA),
-    );
-  });
-});
-
 describe('dismissalStorageKey', () => {
   const accountA = '5d258962-2c37-4a5d-b875-ebe72792c47f';
   const accountB = 'e8ea18c4-dbb4-4e98-a6a4-8ff8b3801765';
@@ -234,5 +207,115 @@ describe('resolveBillingCTA', () => {
     expect(
       resolveBillingCTA({ isFreePlan: undefined, isMarketplace: false }),
     ).toBe(null);
+  });
+});
+
+describe('nextImpression', () => {
+  const visible = {
+    isVisible: true,
+    accountID: 'acct-1',
+    scope: 'env',
+    minutesWithHits: 4,
+    cta: 'view-usage',
+    billingCTA: 'upgrade' as const,
+  };
+
+  // Deterministic ids, so a test can assert "a new one" without matching ULIDs.
+  function counter() {
+    let n = 0;
+    return () => `imp-${++n}`;
+  }
+
+  it('has no impression while the banner is hidden', () => {
+    expect(
+      nextImpression(null, { ...visible, isVisible: false }, counter()),
+    ).toBe(null);
+  });
+
+  // The dismissal key and every event need it, so an impression without one
+  // would be unattributable.
+  it('has no impression before the account resolves', () => {
+    expect(
+      nextImpression(null, { ...visible, accountID: undefined }, counter()),
+    ).toBe(null);
+  });
+
+  it('mints one when the banner becomes visible', () => {
+    const impression = nextImpression(null, visible, counter());
+
+    expect(impression).toMatchObject({
+      id: 'imp-1',
+      accountID: 'acct-1',
+      scope: 'env',
+      minutesWithHits: 4,
+      cta: 'view-usage',
+      billingCTA: 'upgrade',
+    });
+  });
+
+  it('records the window the signal was measured over', () => {
+    expect(nextImpression(null, visible, counter())?.windowMinutes).toBe(
+      CONCURRENCY_WINDOW_MINUTES,
+    );
+  });
+
+  // Identity, not just equality: the caller's tracking effect keys on the
+  // impression object, so a fresh object would re-fire the view event.
+  it('keeps the same impression across re-renders', () => {
+    const first = nextImpression(null, visible, counter());
+
+    expect(nextImpression(first, visible, counter())).toBe(first);
+  });
+
+  // A Refresh can refetch under a banner that never left the screen. That's a
+  // new reading, not a new appearance, and the snapshot stays frozen so a later
+  // click reports the same numbers as the view it belongs to.
+  it('does not re-mint when the pressure reading changes underneath it', () => {
+    const first = nextImpression(null, visible, counter());
+    const next = nextImpression(
+      first,
+      { ...visible, minutesWithHits: 9 },
+      counter(),
+    );
+
+    expect(next).toBe(first);
+    expect(next?.minutesWithHits).toBe(4);
+  });
+
+  // The case the old session-scoped dedup silently dropped: pressure clears and
+  // returns, or a dismissal lapses, without the tab ever reloading.
+  it('mints a new impression when the banner reappears', () => {
+    const mint = counter();
+    const first = nextImpression(null, visible, mint);
+    const hidden = nextImpression(
+      first,
+      { ...visible, isVisible: false },
+      mint,
+    );
+    const second = nextImpression(hidden, visible, mint);
+
+    expect(hidden).toBe(null);
+    expect(second?.id).toBe('imp-2');
+  });
+
+  it('mints a new impression when the scope changes', () => {
+    const mint = counter();
+    const first = nextImpression(null, visible, mint);
+    const second = nextImpression(first, { ...visible, scope: 'fn' }, mint);
+
+    expect(second?.id).toBe('imp-2');
+    expect(second?.scope).toBe('fn');
+  });
+
+  it('mints a new impression when the account changes', () => {
+    const mint = counter();
+    const first = nextImpression(null, visible, mint);
+    const second = nextImpression(
+      first,
+      { ...visible, accountID: 'acct-2' },
+      mint,
+    );
+
+    expect(second?.id).toBe('imp-2');
   });
 });

--- a/ui/apps/dashboard/src/components/Runs/accountConcurrency.ts
+++ b/ui/apps/dashboard/src/components/Runs/accountConcurrency.ts
@@ -126,45 +126,76 @@ export function resolveBillingCTA({
   return isFreePlan ? 'upgrade' : 'increase-concurrency';
 }
 
-const VIEW_TRACKED_STORAGE_KEY_PREFIX = 'viewedAccountConcurrencyBanner';
+/**
+ * One appearance of the banner, minted when it becomes visible and carried on
+ * every event that appearance produces.
+ *
+ * The `id` is what lets a click or a dismissal be attributed to the exact
+ * impression it came from, so click and dismiss rates share a denominator
+ * counted in the same unit they are. Everything else is a snapshot taken at
+ * mint time rather than read live at click time: a Refresh can refetch while
+ * the banner sits on screen, and without the snapshot a click would report a
+ * different signal strength than the view it belongs to.
+ *
+ * The snapshot is also what the banner renders from, so the CTAs a viewer saw
+ * and the CTAs reported on the view event cannot disagree.
+ */
+export type BannerImpression = {
+  id: string;
+  // Held to detect an org switch as a new appearance. Not reported — Segment
+  // already carries the account on every event via identify().
+  accountID: string;
+  minutesWithHits: number;
+  windowMinutes: number;
+  scope: string | undefined;
+  cta: string;
+  billingCTA: ConcurrencyBillingCTA | null;
+};
+
+type ImpressionInput = {
+  isVisible: boolean;
+  accountID: string | undefined;
+  scope: string | undefined;
+  minutesWithHits: number;
+  cta: string;
+  billingCTA: ConcurrencyBillingCTA | null;
+};
 
 /**
- * Session-scoped so the view event fires at most once per account per browser
- * session. The banner re-resolves on every mount and every Refresh, so without
- * this the impression count inflates and the click/dismiss rates it exists to
- * anchor come out too low.
+ * The impression that should be current, given the one that already is.
  *
- * Keyed by scope as well as account: the banner renders on both the
- * environment-wide and per-function runs lists, and click/dismiss events carry
- * the scope they fired from. An account-only key would let a view on one scope
- * suppress the impression for the other, leaving those events without a
- * matching denominator.
+ * Returns `prev` by identity whenever the banner is still the same appearance,
+ * so the caller's tracking effect stays a no-op. A new impression is minted
+ * only on a genuine new appearance: the banner becoming visible, or the
+ * account or scope changing underneath it. Notably `minutesWithHits` changing
+ * does NOT mint one — the pressure reading moved, the appearance did not.
+ *
+ * `mintID` is injected so tests get deterministic ids without mocking ulid.
  */
-export function viewTrackedStorageKey(
-  accountID: string,
-  scope?: string,
-): string {
-  return `${VIEW_TRACKED_STORAGE_KEY_PREFIX}:${accountID}:${scope ?? 'none'}`;
-}
+export function nextImpression(
+  prev: BannerImpression | null,
+  input: ImpressionInput,
+  mintID: () => string,
+): BannerImpression | null {
+  if (!input.isVisible || !input.accountID) return null;
 
-export function hasTrackedView(accountID: string, scope?: string): boolean {
-  try {
-    const key = viewTrackedStorageKey(accountID, scope);
-    return window.sessionStorage.getItem(key) !== null;
-  } catch (error) {
-    // Treat an unreadable store as "already tracked" so a failure here can
-    // only ever under-count, never spam duplicate impressions.
-    console.warn('error reading sessionStorage for banner view:', error);
-    return true;
+  if (
+    prev &&
+    prev.accountID === input.accountID &&
+    prev.scope === input.scope
+  ) {
+    return prev;
   }
-}
 
-export function markViewTracked(accountID: string, scope?: string): void {
-  try {
-    window.sessionStorage.setItem(viewTrackedStorageKey(accountID, scope), '1');
-  } catch (error) {
-    console.warn('error writing sessionStorage for banner view:', error);
-  }
+  return {
+    id: mintID(),
+    accountID: input.accountID,
+    minutesWithHits: input.minutesWithHits,
+    windowMinutes: CONCURRENCY_WINDOW_MINUTES,
+    scope: input.scope,
+    cta: input.cta,
+    billingCTA: input.billingCTA,
+  };
 }
 
 /**

--- a/ui/apps/dashboard/src/utils/analyticsEvents.ts
+++ b/ui/apps/dashboard/src/utils/analyticsEvents.ts
@@ -99,12 +99,28 @@ function track(
 }
 
 // Banner events are intentionally generic so any warning/info banner can reuse
-// them; `feature` and `bannerId` say which one fired. `Banner Viewed` is the
-// denominator — without it the click and dismiss counts have no rate to sit on,
-// so callers should emit it whenever a banner actually renders.
+// them; `feature` and `bannerId` say which one fired.
+//
+// `Banner Viewed` is the denominator, and `impressionId` is what makes it one:
+// callers mint an id per appearance of the banner, emit `Banner Viewed` once
+// with it, and stamp it on the click and dismiss events that appearance
+// produces. Click and dismiss rates are then a straight count of impressions
+// that ended in that action, over impressions — the same unit on both sides.
+//
+// Two rules follow, and both matter:
+//   - Emit `Banner Viewed` on EVERY appearance. Deduping the view without
+//     deduping the actions inflates the rates without bound; if you want a
+//     per-user rate, group on Segment's userId downstream instead.
+//   - Send the impression's own snapshot of any context (signal strength, which
+//     CTAs it offered) on all three events, not a value re-read at click time,
+//     so a click can never describe a different state than the view it belongs
+//     to.
 type BannerViewedArgs = {
   feature: AnalyticsFeature;
   bannerId: string;
+  // Identifies this appearance of the banner. The click and dismiss events for
+  // the same appearance carry it too, which is what joins them to this view.
+  impressionId?: string;
   scope?: string;
   minutesWithHits?: number;
   windowMinutes?: number;
@@ -118,6 +134,7 @@ type BannerViewedArgs = {
 export function trackBannerViewed({
   feature,
   bannerId,
+  impressionId,
   scope,
   minutesWithHits,
   windowMinutes,
@@ -126,6 +143,7 @@ export function trackBannerViewed({
 }: BannerViewedArgs) {
   track('Banner Viewed', feature, {
     banner_id: bannerId,
+    impression_id: impressionId,
     scope,
     minutes_with_hits: minutesWithHits,
     window_minutes: windowMinutes,
@@ -137,24 +155,39 @@ export function trackBannerViewed({
 type BannerDismissedArgs = {
   feature: AnalyticsFeature;
   bannerId: string;
+  impressionId?: string;
   scope?: string;
+  // The impression's own snapshot, repeated here so a dismiss rate can be cut
+  // by signal strength without joining back to `Banner Viewed`.
+  minutesWithHits?: number;
+  windowMinutes?: number;
 };
 
 export function trackBannerDismissed({
   feature,
   bannerId,
+  impressionId,
   scope,
+  minutesWithHits,
+  windowMinutes,
 }: BannerDismissedArgs) {
   track('Banner Dismissed', feature, {
     banner_id: bannerId,
+    impression_id: impressionId,
     scope,
+    minutes_with_hits: minutesWithHits,
+    window_minutes: windowMinutes,
   });
 }
 
 type BannerCTAClickedArgs = {
   feature: AnalyticsFeature;
   bannerId: string;
+  impressionId?: string;
   scope?: string;
+  // The impression's own snapshot — see BannerDismissedArgs.
+  minutesWithHits?: number;
+  windowMinutes?: number;
   // Which CTA was clicked, for banners offering more than one. Deliberately a
   // property rather than a per-CTA event name: total click-through stays a
   // single number that shares the `Banner Viewed` denominator, and per-CTA
@@ -165,12 +198,18 @@ type BannerCTAClickedArgs = {
 export function trackBannerCTAClicked({
   feature,
   bannerId,
+  impressionId,
   scope,
+  minutesWithHits,
+  windowMinutes,
   cta,
 }: BannerCTAClickedArgs) {
   track('Banner CTA Clicked', feature, {
     banner_id: bannerId,
+    impression_id: impressionId,
     scope,
+    minutes_with_hits: minutesWithHits,
+    window_minutes: windowMinutes,
     cta,
   });
 }


### PR DESCRIPTION
## Description

Segment events on the concurrency banner had inaccuracies. We improve them here.

- `Banner Viewed` was deduped per session but clicks and dismisses were not, so every rate it anchored was unbounded
- Each appearance now mints a ulid: the view reports it, and the click or dismiss it produces is stamped with it
- Rates are now impressions-that-acted over impressions — same unit both sides, and no storage sits on the view path
- A banner that hid and returned in the same tab emitted no new view, so clicks on it had no impression behind them
- Click and dismiss carry the impression's frozen snapshot, so rates cut by signal strength or CTA need no join
- The billing CTA links with `to`, not `href`: full-page unload was cancelling its in-flight Segment track call

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*