### PR TITLE
fix(queue): reduce semaphore requeue churn

### DIFF
--- a/pkg/execution/queue/consts.go
+++ b/pkg/execution/queue/consts.go
@@ -37,7 +37,7 @@ const (
 	// NOTE: This is the maximum latency introduced into concurrnecy limited partitions in the
 	//       worst case.
 	PartitionConcurrencyLimitRequeueExtension = 5 * time.Second
-	PartitionSemaphoreLimitRequeueExtension   = 1 * time.Second
+	PartitionSemaphoreLimitRequeueExtension   = 3 * time.Second
 	PartitionThrottleLimitRequeueExtension    = 1 * time.Second
 	PartitionPausedRequeueExtension           = 5 * time.Minute
 	PartitionDeletedAccountRequeueExtension   = 7 * 24 * time.Hour

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -225,6 +225,22 @@ func (o QueueOptions) PausedRequeueExtension() time.Duration {
 	return o.pausedRequeueExtension
 }
 
+// WithSemaphoreRequeueExtension overrides how far into the future a partition
+// is requeued when only the local semaphore limit is reached. When not set (or
+// non-positive), PartitionSemaphoreLimitRequeueExtension is used.
+func WithSemaphoreRequeueExtension(d time.Duration) QueueOpt {
+	return func(q *QueueOptions) {
+		q.semaphoreRequeueExtension = d
+	}
+}
+
+func (o QueueOptions) SemaphoreRequeueExtension() time.Duration {
+	if o.semaphoreRequeueExtension <= 0 {
+		return PartitionSemaphoreLimitRequeueExtension
+	}
+	return o.semaphoreRequeueExtension
+}
+
 func WithPeekConcurrencyMultiplier(m int64) QueueOpt {
 	return func(q *QueueOptions) {
 		q.peekCurrMultiplier = m
@@ -529,6 +545,10 @@ type QueueOptions struct {
 	// requeued when it is confirmed paused in the database. Falls back to
 	// PartitionPausedRequeueExtension when unset.
 	pausedRequeueExtension time.Duration
+	// semaphoreRequeueExtension is how far into the future a partition is
+	// requeued when only the local semaphore limit is reached. Falls back to
+	// PartitionSemaphoreLimitRequeueExtension when unset.
+	semaphoreRequeueExtension time.Duration
 
 	NormalizeRefreshItemCustomConcurrencyKeys NormalizeRefreshItemCustomConcurrencyKeysFn
 	RefreshItemThrottle                       RefreshItemThrottleFn

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -350,7 +350,7 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 			// Semaphore-blocked items stay in the ready queue and can be picked up
 			// quickly once capacity is freed. Use a shorter requeue to reduce latency
 			// between run completion and the next run starting.
-			requeue = PartitionSemaphoreLimitRequeueExtension
+			requeue = q.SemaphoreRequeueExtension()
 		}
 
 		// Requeue this partition as we hit concurrency limits.

--- a/pkg/execution/queue/queue_test.go
+++ b/pkg/execution/queue/queue_test.go
@@ -33,6 +33,26 @@ func TestPartitionBacklogSizeConcurrencyOption(t *testing.T) {
 	})
 }
 
+func TestSemaphoreRequeueExtensionOption(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		opts := NewQueueOptions()
+		require.Equal(t, PartitionSemaphoreLimitRequeueExtension, opts.SemaphoreRequeueExtension())
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		opts := NewQueueOptions(WithSemaphoreRequeueExtension(2 * time.Second))
+		require.Equal(t, 2*time.Second, opts.SemaphoreRequeueExtension())
+	})
+
+	t.Run("non-positive falls back to default", func(t *testing.T) {
+		opts := NewQueueOptions(WithSemaphoreRequeueExtension(0))
+		require.Equal(t, PartitionSemaphoreLimitRequeueExtension, opts.SemaphoreRequeueExtension())
+
+		opts = NewQueueOptions(WithSemaphoreRequeueExtension(-time.Second))
+		require.Equal(t, PartitionSemaphoreLimitRequeueExtension, opts.SemaphoreRequeueExtension())
+	})
+}
+
 func (r retryableError) Retryable() bool {
 	return r.retry
 }


### PR DESCRIPTION
## Description

Increase the semaphore-only partition requeue delay from 1 second to 3 seconds and make it configurable through a queue option.

## Why

When all concurrency-limited items in a partition are blocked by semaphores, the partition is currently requeued every second.

We noticed this because workerless apps can keep cycling through these partitions without making progress. This change tests whether a longer requeue interval meaningfully reduces that churn while we consider a more complete way to handle workerless apps.