### PR TITLE
internal(components): type-check under React 19 as well as 18

### DIFF
--- a/ui/packages/components/src/Button/Button.tsx
+++ b/ui/packages/components/src/Button/Button.tsx
@@ -115,8 +115,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const spinnerStyles = getSpinnerStyles({ kind, appearance });
     const iconSizes = getIconSizeStyles({ size });
 
-    const iconElement = React.isValidElement(icon)
-      ? React.cloneElement(icon as React.ReactElement, {
+    const iconElement = React.isValidElement<{ className?: string }>(icon)
+      ? React.cloneElement(icon, {
           className: cn(iconSizes, icon.props.className, loading && 'invisible'),
         })
       : null;

--- a/ui/packages/components/src/Button/SplitButton.tsx
+++ b/ui/packages/components/src/Button/SplitButton.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 
 import { cn } from '../utils/classNames';
 
+type ClassNameProps = { className?: string };
+
 type SplitButtonProps = {
-  left: React.ReactElement;
-  right: React.ReactElement;
+  left: React.ReactElement<ClassNameProps>;
+  right: React.ReactElement<ClassNameProps>;
 };
 
 export const SplitButton = ({ left, right }: SplitButtonProps) => {

--- a/ui/packages/components/src/CodeSearch/CodeSearch.tsx
+++ b/ui/packages/components/src/CodeSearch/CodeSearch.tsx
@@ -112,7 +112,7 @@ export default function CodeSearch({
   const [dark, setDark] = useState(isDark());
   const editorRef = useRef<MonacoEditorType>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const monacoRef = useRef<Monaco>();
+  const monacoRef = useRef<Monaco | undefined>(undefined);
 
   const monaco = useMonaco();
 

--- a/ui/packages/components/src/Metadata/MetadataItem.tsx
+++ b/ui/packages/components/src/Metadata/MetadataItem.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import { Pill } from '@inngest/components/Pill';
 import { Skeleton } from '@inngest/components/Skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';

--- a/ui/packages/components/src/Modal/Modal.tsx
+++ b/ui/packages/components/src/Modal/Modal.tsx
@@ -21,7 +21,7 @@ type ModalProps = {
   alignTop?: boolean;
 
   /** Ref to the element to focus when the modal opens */
-  initialFocus?: React.RefObject<HTMLElement>;
+  initialFocus?: React.RefObject<HTMLElement | null>;
 };
 
 export function Modal({

--- a/ui/packages/components/src/Pill/Pill.tsx
+++ b/ui/packages/components/src/Pill/Pill.tsx
@@ -74,7 +74,8 @@ export function Pill({
     return Children.toArray(node)
       .map((child) => {
         if (typeof child === 'string') return child;
-        if (isValidElement(child)) return extractText(child.props.children);
+        if (isValidElement<{ children?: React.ReactNode }>(child))
+          return extractText(child.props.children);
         return '';
       })
       .join('')

--- a/ui/packages/components/src/Popover/Popover.tsx
+++ b/ui/packages/components/src/Popover/Popover.tsx
@@ -8,7 +8,7 @@ export const PopoverTrigger = PopoverPrimitive.Trigger;
 export const PopoverClose = PopoverPrimitive.Close;
 
 export const PopoverContent = forwardRef<
-  React.ElementRef<typeof PopoverPrimitive.Portal>,
+  React.ComponentRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ children, className, ...props }, forwardedRef) => {
   const container = typeof document !== 'undefined' ? document.getElementById('modals') : undefined;

--- a/ui/packages/components/src/Resizable/Notch.tsx
+++ b/ui/packages/components/src/Resizable/Notch.tsx
@@ -6,7 +6,7 @@ import { addSplitListeners, makeOnMove, makeOnStopDrag } from './split';
 import type { Orientation } from './types';
 
 type NotchProps = {
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   maxSplitPercentage: number;
   minSplitPercentage: number;
   orientation: Orientation;

--- a/ui/packages/components/src/RunDetailsShared/InlineSpans.tsx
+++ b/ui/packages/components/src/RunDetailsShared/InlineSpans.tsx
@@ -20,7 +20,7 @@ type Props = {
 export function InlineSpans({ className, minTime, maxTime, trace, depth }: Props) {
   const [open, setOpen] = useState(false);
   const spanRef = useRef<HTMLDivElement | null>(null);
-  const hoverTimeoutRef = useRef<NodeJS.Timeout>();
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
   const spanName = getSpanName(trace.name);
 
   const handleMouseEnter = useCallback(() => {

--- a/ui/packages/components/src/RunDetailsShared/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsShared/StepInfo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import { Button as NewButton } from '@inngest/components/Button';
 import { Button } from '@inngest/components/Button/Button';
 import { RiArrowRightSLine } from '@remixicon/react';

--- a/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import { RiArrowRightSLine } from '@remixicon/react';
 
 import { looksLikeAIOutput } from '../AI/utils';

--- a/ui/packages/components/src/RunDetailsV4/TimeBrush.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TimeBrush.tsx
@@ -10,7 +10,7 @@
  * - Reset button when selection differs from default
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type JSX } from 'react';
 
 import { cn } from '../utils/classNames';
 

--- a/ui/packages/components/src/RunDetailsV4/Timeline.tsx
+++ b/ui/packages/components/src/RunDetailsV4/Timeline.tsx
@@ -9,7 +9,7 @@
  * - Column resize handling
  */
 
-import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type JSX, type ReactNode } from 'react';
 import { RiContractUpDownLine, RiExpandUpDownLine } from '@remixicon/react';
 
 import { Button } from '../Button';

--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
@@ -8,7 +8,7 @@
  * - Optional expansion to show nested children
  */
 
-import { memo, useMemo, useState, type CSSProperties } from 'react';
+import { memo, useMemo, useState, type CSSProperties, type JSX } from 'react';
 import {
   RiArrowRightFill,
   RiArrowRightLine,

--- a/ui/packages/components/src/RunDetailsV4/TimelineHeader.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TimelineHeader.tsx
@@ -8,7 +8,7 @@
  * - Timing markers at 0%, 25%, 50%, 75%, 100% with duration labels
  */
 
-import { useCallback, useLayoutEffect, useRef } from 'react';
+import { useCallback, useLayoutEffect, useRef, type JSX } from 'react';
 
 import { getStatusBackgroundClass } from '../Status/statusClasses';
 import { cn } from '../utils/classNames';

--- a/ui/packages/components/src/SQLEditor/hooks/useMonacoWithTheme.ts
+++ b/ui/packages/components/src/SQLEditor/hooks/useMonacoWithTheme.ts
@@ -5,7 +5,7 @@ import { createColors, createRules } from '../../utils/monaco';
 import { isDark } from '../../utils/theme';
 
 // TODO: Remove this hook and use the NewCodeBlock component when it's ready.
-export function useMonacoWithTheme(wrapperRef: React.RefObject<HTMLDivElement>) {
+export function useMonacoWithTheme(wrapperRef: React.RefObject<HTMLDivElement | null>) {
   const [dark, setDark] = useState(isDark());
   const monaco = useMonaco();
 

--- a/ui/packages/components/src/SegmentedControl/SegmentedControl.tsx
+++ b/ui/packages/components/src/SegmentedControl/SegmentedControl.tsx
@@ -38,8 +38,8 @@ type SegmentedButtonProps = {
 
 const Button = forwardRef<HTMLButtonElement, React.PropsWithChildren<SegmentedButtonProps>>(
   ({ children, value, isActive, icon, iconSide, onClick, ...props }, ref) => {
-    const iconElement = isValidElement(icon)
-      ? cloneElement(icon as React.ReactElement, {
+    const iconElement = isValidElement<{ className?: string }>(icon)
+      ? cloneElement(icon, {
           className: cn('h-4 w-4 ', children ? 'mx-0' : 'mx-[5px]', icon.props.className),
         })
       : null;

--- a/ui/packages/components/src/Table/OldTable.tsx
+++ b/ui/packages/components/src/Table/OldTable.tsx
@@ -8,7 +8,7 @@ type TableProps<T> = {
   options: TableOptions<T>;
   blankState: React.ReactNode;
   customRowProps?: (row: Row<T>) => void;
-  tableContainerRef: React.RefObject<HTMLDivElement>;
+  tableContainerRef: React.RefObject<HTMLDivElement | null>;
 };
 
 /**

--- a/ui/packages/components/src/Table/TableBlankState.tsx
+++ b/ui/packages/components/src/Table/TableBlankState.tsx
@@ -8,8 +8,8 @@ type TableBlankStateProps = {
 };
 
 export function TableBlankState({ actions, title, description, icon }: TableBlankStateProps) {
-  const iconElement = React.isValidElement(icon)
-    ? React.cloneElement(icon as React.ReactElement, {
+  const iconElement = React.isValidElement<{ className?: string }>(icon)
+    ? React.cloneElement(icon, {
         className: 'h-7 w-7',
       })
     : null;


### PR DESCRIPTION
## Description

- We would like to use the timeline component in admin, which runs on React 19, but dashboard runs on React 18
- Makes `@inngest/components` satisfy **both** `@types/react` 18 and 19, so the admin dashboard in `inngest/monorepo` can vendor it while staying on React 19 — without this repo upgrading.
- Nothing here runs on React 19. The apps stay on 18, and there are no dependency changes. Every edit is type-level and erases at build time: **no emitted JS differs.** 22 lines are edited in place, 4 added, none deleted.
- This is much lighter than downgrading admin to React 19 -> 18

### The five React 19 typing changes involved

| Change | Fix | Files |
|---|---|---|
| Global `JSX` namespace removed | `import type { JSX } from 'react'` — exported by `@types/react` since 18.3, so it compiles on both | 6 |
| `ReactElement` props default to `unknown` | narrow with `isValidElement<{ className?: string }>(x)` instead of casting | 4 |
| `useRef` requires an argument | pass `undefined` explicitly | 2 |
| `useRef<T>(null)` yields `RefObject<T \| null>` | widen the consuming signatures | 5 |
| `ElementRef` constraint is stricter | `Popover` pointed at `Portal` (an FC, no ref) where it meant `Content` | 1 |

That last one is a latent bug fix on its own.

### Testing

- `tsc --noEmit` clean in `apps/dashboard`, `apps/dev-server-ui`, `apps/support` on our own `@types/react` 18.3 — unchanged from `main`.
- The same source is clean under `@types/react` 19.2, verified via a temporary pnpm override (not committed).
- `packages/components` tests: **335/335 pass**, identical to `main`.
- `apps/dashboard` tests: 164/165, with the same two pre-existing failures as `main` (`lib/experiments/score.test.ts`, `APIKeys/errorMessage.test.ts`). Neither is related to this change.
- End to end: vendored into `monorepo` on React 19 alongside its trace-viewer PR — `tsc` clean, `vite build` passes. Without this change, that same setup produces 11 errors.

### Known gap

`Modal.tsx` and `AlertModal.tsx` still fail under React 19 types, through **framer-motion 10's** typings rather than our source. Not fixable here and it doesn't need to be: it clears on framer-motion 12, which a React 19 consumer installs on its own side. Neither file is on the trace-viewer import path.

### Note for reviewers

Nothing in this repo's CI exercises the React 19 side, so this property can regress silently — a new `JSX.Element` next month would break admin's build without failing anything here. `monorepo` already runs `tsc` over the vendored tree, so that is where it would surface. Worth knowing rather than solving now.

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*