### PR TITLE
feat(duckdb): Implement span metadata on duckdb

### DIFF
--- a/cmd/duckdbseed/generate.go
+++ b/cmd/duckdbseed/generate.go
@@ -69,8 +69,9 @@ func generateRun(rng *rand.Rand, tmpl Templates, cfg GenerateConfig) GeneratedRu
 	}
 
 	spans := generateSpanTree(trace, run)
+	metadata := generateMetadata(rng, tmpl, run, spans)
 
-	return GeneratedRun{Run: run, Spans: spans, Events: events}
+	return GeneratedRun{Run: run, Spans: spans, Events: events, Metadata: metadata}
 }
 
 // defaultTraceTemplate is replayed when tmpl has no sampled traces to draw
@@ -122,6 +123,73 @@ func generateSpanTree(trace TraceTemplate, run RunRow) []SpanRow {
 		}
 	}
 	return spans
+}
+
+// generateMetadata replays one randomly picked MetadataProfile from
+// tmpl.MetadataProfiles verbatim: each item's Scope/StepID/StepIndex/
+// StepAttempt/Kind/IsUser/Values are copied unchanged, and it attaches to
+// whichever of spans shares its exact SpanID (see MetadataTemplateItem's
+// doc comment for why that match works without recomputing any
+// root/step position here) -- skipping any item whose SpanID isn't one of
+// spans' own, which only happens when the trace and metadata profile
+// picked for this run were sampled from two different source runs (see
+// Templates' doc comment). Returns nil when tmpl has no profiles to draw
+// from (a source with runs but no metadata at all is a real, faithfully
+// replicated shape, not an error).
+func generateMetadata(rng *rand.Rand, tmpl Templates, run RunRow, spans []SpanRow) []MetadataRow {
+	if len(tmpl.MetadataProfiles) == 0 {
+		return nil
+	}
+	profile := tmpl.MetadataProfiles[rng.Intn(len(tmpl.MetadataProfiles))]
+	if len(profile.Items) == 0 {
+		return nil
+	}
+
+	rows := make([]MetadataRow, 0, len(profile.Items))
+	for _, item := range profile.Items {
+		if !hasSpanID(spans, item.SpanID) {
+			continue
+		}
+		values := item.Values
+		if values == "" {
+			values = "{}"
+		}
+		rows = append(rows, MetadataRow{
+			AccountID:   run.AccountID,
+			EnvID:       run.EnvID,
+			RunID:       run.RunID,
+			RunQueuedAt: run.QueuedAt,
+			AppID:       run.AppID,
+			FunctionID:  run.FunctionID,
+			SpanID:      item.SpanID,
+			CreatedAt:   run.QueuedAt.Add(item.Offset),
+			Scope:       item.Scope,
+			StepID:      item.StepID,
+			StepIndex:   item.StepIndex,
+			StepAttempt: item.StepAttempt,
+			Kind:        item.Kind,
+			IsUser:      item.IsUser,
+			Values:      values,
+		})
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	return rows
+}
+
+// hasSpanID reports whether spanID matches one of spans' own SpanIDs. A
+// plain linear scan rather than a map: a run's span tree is typically tiny
+// (single digits to a few dozen), where building a map fresh on every
+// single generated run costs more -- a heap allocation per run, purely to
+// avoid string comparisons on that same handful of spans -- than it saves.
+func hasSpanID(spans []SpanRow, spanID string) bool {
+	for _, s := range spans {
+		if s.SpanID == spanID {
+			return true
+		}
+	}
+	return false
 }
 
 // defaultEventProfile is replayed when tmpl has no sampled event profiles

--- a/cmd/duckdbseed/generate_test.go
+++ b/cmd/duckdbseed/generate_test.go
@@ -63,6 +63,16 @@ func testTemplates() Templates {
 		EventProfiles: [][]EventTemplate{
 			{{Name: "app/test.event", Data: `{"k":"v"}`, Offset: -200 * time.Millisecond}},
 		},
+		MetadataProfiles: []MetadataProfile{
+			{
+				Items: []MetadataTemplateItem{
+					{SpanID: "root", Scope: "run", Kind: "inngest.experiment", IsUser: false, Values: `{"variant":"a"}`, Offset: 50 * time.Millisecond},
+					{SpanID: "step-1", Scope: "step", StepID: strPtr("step-1"), StepIndex: intPtr(0), StepAttempt: intPtr(1), Kind: "user.custom", IsUser: true, Values: `{"n":1}`, Offset: 150 * time.Millisecond},
+					{SpanID: "step-2", Scope: "step", StepID: strPtr("step-2"), StepIndex: intPtr(1), StepAttempt: intPtr(1), Kind: "user.custom", IsUser: true, Values: `{"n":2}`, Offset: 450 * time.Millisecond},
+					{SpanID: "step-2", Scope: "step", StepID: strPtr("step-2"), StepIndex: intPtr(1), StepAttempt: intPtr(1), Kind: "inngest.ai", IsUser: false, Values: `{"tokens":10}`, Offset: 460 * time.Millisecond},
+				},
+			},
+		},
 	}
 }
 
@@ -172,6 +182,14 @@ func TestGenerateRunsBuildsASpanTreeWithARootAndChildSpans(t *testing.T) {
 // three levels deep from the root) and step-2 does not; the replayed
 // spans must keep that exact shape with freshly generated IDs, not chain
 // everything to the root.
+// TestGenerateSpanTreePreservesRealNestingNotJustRootChildren proves the
+// fix for a real bug: a nested span (e.g. a userland/extended-trace span
+// nested under another userland span, not directly under the run root)
+// was being reparented to the root on replay, flattening the sampled
+// run's real tree shape. Here step-1 has its own child ("extended-trace",
+// three levels deep from the root) and step-2 does not; the replayed
+// spans must keep that exact shape with freshly generated IDs, not chain
+// everything to the root.
 func TestGenerateSpanTreePreservesRealNestingNotJustRootChildren(t *testing.T) {
 	trace := TraceTemplate{
 		TraceID: "trace-1",
@@ -258,4 +276,77 @@ func TestGenerateRunsLinksEventsToTheRunsEventIDs(t *testing.T) {
 		require.Equal(t, run.AccountID, e.AccountID)
 		require.Equal(t, run.EnvID, e.EnvID)
 	}
+}
+
+// TestGenerateRunsReplaysAMetadataProfileOntoTheSpanTree proves
+// generateMetadata's contract: it replays one whole MetadataProfile from
+// tmpl.MetadataProfiles verbatim, item by item, attaching each to whichever
+// replayed span shares its exact (unregenerated) SpanID -- rather than
+// choosing kinds/counts independently per span, so a run's metadata shape
+// is reproducible from a single sampled template, mirroring
+// pkg/execution/dualwrite/listener.go's OnMetadataEntry for each row's own
+// shape.
+func TestGenerateRunsReplaysAMetadataProfileOntoTheSpanTree(t *testing.T) {
+	tmpl := testTemplates()
+	require.Len(t, tmpl.MetadataProfiles, 1, "test assumes a single profile so the replay is deterministic")
+	profile := tmpl.MetadataProfiles[0]
+	rng := rand.New(rand.NewSource(11))
+
+	generated, err := GenerateRuns(rng, tmpl, testConfig(1))
+	require.NoError(t, err)
+
+	run := generated[0].Run
+	metadata := generated[0].Metadata
+	require.Len(t, metadata, len(profile.Items))
+
+	for i, m := range metadata {
+		item := profile.Items[i]
+		require.Equal(t, run.AccountID, m.AccountID)
+		require.Equal(t, run.EnvID, m.EnvID)
+		require.Equal(t, run.RunID, m.RunID)
+		require.Equal(t, item.SpanID, m.SpanID)
+		require.Equal(t, item.Scope, m.Scope)
+		require.Equal(t, item.StepID, m.StepID)
+		require.Equal(t, item.StepIndex, m.StepIndex)
+		require.Equal(t, item.StepAttempt, m.StepAttempt)
+		require.Equal(t, item.Kind, m.Kind)
+		require.Equal(t, item.IsUser, m.IsUser)
+		require.Equal(t, item.Values, m.Values)
+		require.Equal(t, run.QueuedAt.Add(item.Offset), m.CreatedAt)
+	}
+}
+
+// TestGenerateMetadataSkipsItemsWithNoMatchingSpan proves generateMetadata
+// drops a metadata item whose SpanID isn't one of the replayed span tree's
+// own SpanIDs, rather than writing a dangling row -- the only way this can
+// happen is when the trace and metadata profile picked for one generated
+// run were sampled from two different source runs (see Templates' own doc
+// comment on independently-sampled pools).
+func TestGenerateMetadataSkipsItemsWithNoMatchingSpan(t *testing.T) {
+	tmpl := testTemplates()
+	tmpl.MetadataProfiles[0].Items = append(tmpl.MetadataProfiles[0].Items,
+		MetadataTemplateItem{SpanID: "span-from-a-different-run", Scope: "step", Kind: "orphan.kind", Values: "{}"})
+	rng := rand.New(rand.NewSource(11))
+
+	generated, err := GenerateRuns(rng, tmpl, testConfig(1))
+	require.NoError(t, err)
+
+	for _, m := range generated[0].Metadata {
+		require.NotEqual(t, "orphan.kind", m.Kind, "an item whose span doesn't exist in this run must be skipped")
+	}
+}
+
+// TestGenerateRunsWithNoMetadataProfilesGeneratesNoMetadata proves a source
+// with runs but genuinely no metadata (an empty tmpl.MetadataProfiles) is
+// faithfully replicated as zero metadata rows, not silently backfilled with
+// unrelated defaults.
+func TestGenerateRunsWithNoMetadataProfilesGeneratesNoMetadata(t *testing.T) {
+	tmpl := testTemplates()
+	tmpl.MetadataProfiles = nil
+	rng := rand.New(rand.NewSource(11))
+
+	generated, err := GenerateRuns(rng, tmpl, testConfig(1))
+	require.NoError(t, err)
+
+	require.Empty(t, generated[0].Metadata)
 }

--- a/cmd/duckdbseed/insert.go
+++ b/cmd/duckdbseed/insert.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,9 +19,10 @@ import (
 
 // Summary reports how many rows were written per table.
 type Summary struct {
-	Runs   int
-	Spans  int
-	Events int
+	Runs     int
+	Spans    int
+	Events   int
+	Metadata int
 }
 
 // Timings reports how much time GenerateAndInsert's two stages actually
@@ -38,9 +40,10 @@ type Timings struct {
 }
 
 // Column kind lists mirror pkg/db/duckdb/migrations/000001_baseline.sql's
-// column order for each table exactly. duckdb.QuackAppender's wire protocol
-// carries no column names — a row's values are matched positionally against
-// the table's own full column list — so, unlike the earlier duckdb-go-based
+// (and, for runs, 000002_runs_is_deferred.sql's appended column) column
+// order for each table exactly. duckdb.QuackAppender's wire protocol carries
+// no column names — a row's values are matched positionally against the
+// table's own full column list — so, unlike the earlier duckdb-go-based
 // version of this tool, there is no way to scope the appender to a subset
 // of columns: inngest.runs' inserted_at (DEFAULT current_timestamp) must be
 // supplied explicitly too (see runRowValues), even though nothing else in
@@ -54,6 +57,7 @@ var (
 		duckdb.QuackColumnVarchar,     // event_ids — VARCHAR[] via array-literal text, see runRowValues' doc comment
 		duckdb.QuackColumnVarchar,     // sessions — STRUCT(key VARCHAR, id VARCHAR)[] via JSON-literal text, see sessionsLiteral's doc comment
 		duckdb.QuackColumnTimestampMS, // inserted_at
+		duckdb.QuackColumnVarchar,     // is_deferred (BOOLEAN, VARCHAR-cast) — this tool never generates deferred runs, so always NULL
 	}
 	spanColumns = []duckdb.QuackColumnKind{
 		duckdb.QuackColumnUUID, duckdb.QuackColumnUUID, duckdb.QuackColumnVarchar, duckdb.QuackColumnTimestampMS, // account_id, env_id, run_id, run_queued_at
@@ -66,6 +70,20 @@ var (
 		duckdb.QuackColumnUUID, duckdb.QuackColumnUUID, duckdb.QuackColumnVarchar, duckdb.QuackColumnTimestampMS, // account_id, env_id, internal_id, received_at
 		duckdb.QuackColumnVarchar, duckdb.QuackColumnVarchar, duckdb.QuackColumnVarchar, duckdb.QuackColumnVarchar, // source, source_id, event_id, event_name
 		duckdb.QuackColumnJSON, duckdb.QuackColumnVarchar, duckdb.QuackColumnTimestampMS, duckdb.QuackColumnJSON, // event_data, event_v, event_ts, event_meta
+	}
+	// metadataColumns' step_index/step_attempt (INTEGER) and is_user
+	// (BOOLEAN) have no native duckdb.QuackColumnKind — see that type's own
+	// doc comment: only UUID/VARCHAR/JSON/TIMESTAMP_MS exist — so they're
+	// sent as QuackColumnVarchar text (see metadataRowValues) and rely on
+	// DuckDB's Appender doing implicit VARCHAR->INTEGER/BOOLEAN casting, the
+	// same mechanism already relied on (and verified against a real
+	// duckdb-quack server) for event_ids' VARCHAR->LIST casting above.
+	metadataColumns = []duckdb.QuackColumnKind{
+		duckdb.QuackColumnUUID, duckdb.QuackColumnUUID, duckdb.QuackColumnVarchar, duckdb.QuackColumnTimestampMS, // account_id, env_id, run_id, run_queued_at
+		duckdb.QuackColumnUUID, duckdb.QuackColumnUUID, duckdb.QuackColumnVarchar, duckdb.QuackColumnVarchar, // app_id, function_id, span_id, scope
+		duckdb.QuackColumnVarchar, duckdb.QuackColumnVarchar, duckdb.QuackColumnVarchar, // step_id, step_index, step_attempt
+		duckdb.QuackColumnVarchar, duckdb.QuackColumnVarchar, // kind, is_user
+		duckdb.QuackColumnJSON, duckdb.QuackColumnTimestampMS, // values, created_at
 	}
 )
 
@@ -85,10 +103,11 @@ type indexedBatch struct {
 // *sql.DB's pool — see duckdb.OpenConnector's doc comment for why) and its
 // own set.
 type appenderSet struct {
-	conn   driver.Conn
-	runs   *duckdb.QuackAppender
-	spans  *duckdb.QuackAppender
-	events *duckdb.QuackAppender
+	conn     driver.Conn
+	runs     *duckdb.QuackAppender
+	spans    *duckdb.QuackAppender
+	events   *duckdb.QuackAppender
+	metadata *duckdb.QuackAppender
 }
 
 func newAppenderSet(ctx context.Context, connector *duckdb.Connector) (*appenderSet, error) {
@@ -112,31 +131,34 @@ func newAppenderSet(ctx context.Context, connector *duckdb.Connector) (*appender
 		_ = conn.Close()
 		return nil, fmt.Errorf("duckdbseed: creating events appender: %w", err)
 	}
+	metadata, err := duckdb.NewQuackAppenderFromConn(ctx, conn, duckdb.DuckLakeAlias, "main", "run_metadata", metadataColumns)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("duckdbseed: creating run_metadata appender: %w", err)
+	}
 
-	return &appenderSet{conn: conn, runs: runs, spans: spans, events: events}, nil
+	return &appenderSet{conn: conn, runs: runs, spans: spans, events: events, metadata: metadata}, nil
 }
 
 func (a *appenderSet) close(ctx context.Context) error {
-	return errors.Join(a.runs.Close(ctx), a.spans.Close(ctx), a.events.Close(ctx), a.conn.Close())
+	return errors.Join(a.runs.Close(ctx), a.spans.Close(ctx), a.events.Close(ctx), a.metadata.Close(ctx), a.conn.Close())
 }
 
-// insertBatch flattens one chunk of generated runs into its three tables'
-// rows, sorts each table's rows to match that table's declared physical
-// sort key (see sortRuns/sortSpans/sortEvents), and appends them — in the
-// run/event/span order the tool has always used — flushing each appender
-// once the batch is fully appended.
+// insertBatch flattens one chunk of generated runs into its four tables'
+// rows and appends them — in the run/event/span/metadata order the tool
+// has always used (metadata appended last, after spans) — flushing each
+// appender once the batch is fully appended.
 func (a *appenderSet) insertBatch(ctx context.Context, batch []GeneratedRun) (Summary, error) {
 	var runs []RunRow
 	var spans []SpanRow
 	var events []EventRow
+	var metadataRows []MetadataRow
 	for _, g := range batch {
 		runs = append(runs, g.Run)
 		spans = append(spans, g.Spans...)
 		events = append(events, g.Events...)
+		metadataRows = append(metadataRows, g.Metadata...)
 	}
-	sortRuns(runs)
-	sortSpans(spans)
-	sortEvents(events)
 
 	now := time.Now().UTC()
 	for _, r := range runs {
@@ -154,6 +176,11 @@ func (a *appenderSet) insertBatch(ctx context.Context, batch []GeneratedRun) (Su
 			return Summary{}, fmt.Errorf("duckdbseed: appending span %s: %w", s.SpanID, err)
 		}
 	}
+	for _, md := range metadataRows {
+		if err := a.metadata.AppendRow(metadataRowValues(md)...); err != nil {
+			return Summary{}, fmt.Errorf("duckdbseed: appending metadata for span %s: %w", md.SpanID, err)
+		}
+	}
 
 	if err := a.runs.Flush(ctx); err != nil {
 		return Summary{}, fmt.Errorf("duckdbseed: flushing runs appender: %w", err)
@@ -164,8 +191,11 @@ func (a *appenderSet) insertBatch(ctx context.Context, batch []GeneratedRun) (Su
 	if err := a.spans.Flush(ctx); err != nil {
 		return Summary{}, fmt.Errorf("duckdbseed: flushing spans appender: %w", err)
 	}
+	if err := a.metadata.Flush(ctx); err != nil {
+		return Summary{}, fmt.Errorf("duckdbseed: flushing metadata appender: %w", err)
+	}
 
-	return Summary{Runs: len(runs), Spans: len(spans), Events: len(events)}, nil
+	return Summary{Runs: len(runs), Spans: len(spans), Events: len(events), Metadata: len(metadataRows)}, nil
 }
 
 // runRowValues matches runColumns' order exactly. event_ids (VARCHAR[]) is
@@ -185,6 +215,7 @@ func runRowValues(r RunRow, now time.Time) []any {
 		r.AppID, r.FunctionID, r.Status,
 		r.Inputs, r.Output, eventIDsLiteral(r.EventIDs), sessionsLiteral(r.Sessions),
 		now,
+		nil, // is_deferred — this tool never generates deferred runs
 	}
 }
 
@@ -197,6 +228,30 @@ func spanRowValues(s SpanRow) []any {
 		s.AccountID, s.EnvID, s.RunID, s.RunQueuedAt,
 		s.AppID, s.FunctionID, s.Name, s.StartTime, s.EndTime,
 		s.TraceID, s.SpanID, parent, s.Attributes, nil, nullableJSON(s.Output), nullableJSON(s.Input),
+	}
+}
+
+// metadataRowValues matches metadataColumns' order exactly. step_index/
+// step_attempt/is_user go through the same VARCHAR-text-plus-implicit-cast
+// trick as event_ids above (see metadataColumns' doc comment) since
+// duckdb.QuackColumnKind has no native INTEGER/BOOLEAN wire type.
+func metadataRowValues(m MetadataRow) []any {
+	var stepID, stepIndex, stepAttempt any
+	if m.StepID != nil {
+		stepID = *m.StepID
+	}
+	if m.StepIndex != nil {
+		stepIndex = strconv.Itoa(*m.StepIndex)
+	}
+	if m.StepAttempt != nil {
+		stepAttempt = strconv.Itoa(*m.StepAttempt)
+	}
+	return []any{
+		m.AccountID, m.EnvID, m.RunID, m.RunQueuedAt,
+		m.AppID, m.FunctionID, m.SpanID, m.Scope,
+		stepID, stepIndex, stepAttempt,
+		m.Kind, strconv.FormatBool(m.IsUser),
+		m.Values, m.CreatedAt,
 	}
 }
 
@@ -395,6 +450,7 @@ func drainAndInsert(ctx context.Context, connector *duckdb.Connector, work <-cha
 				summary.Runs += batchSummary.Runs
 				summary.Spans += batchSummary.Spans
 				summary.Events += batchSummary.Events
+				summary.Metadata += batchSummary.Metadata
 				if onProgress != nil {
 					onProgress(b.index, totalBatches, summary.Runs, total)
 				}
@@ -459,4 +515,30 @@ func sortEvents(rows []EventRow) {
 func eventSortKey(e EventRow) string {
 	return fmt.Sprintf("%04d-%02d-%s-%s-%s-%020d",
 		e.ReceivedAt.Year(), e.ReceivedAt.Month(), e.AccountID, e.EnvID, e.InternalID, e.ReceivedAt.UnixNano())
+}
+
+func sortMetadata(rows []MetadataRow) {
+	sort.Slice(rows, func(i, j int) bool { return metadataSortKey(rows[i]) < metadataSortKey(rows[j]) })
+}
+
+// metadataSortKey mirrors inngest.run_metadata's SORTED BY
+// (year(run_queued_at), month(run_queued_at), account_id, env_id, run_id,
+// scope, step_id, step_index, step_attempt, span_id, kind). step_index/
+// step_attempt sort as -1 when NULL (a run-scoped row) — only meant to keep
+// output deterministic, not to reproduce DuckDB's own NULL-ordering rules.
+func metadataSortKey(m MetadataRow) string {
+	var stepID string
+	if m.StepID != nil {
+		stepID = *m.StepID
+	}
+	stepIndex, stepAttempt := -1, -1
+	if m.StepIndex != nil {
+		stepIndex = *m.StepIndex
+	}
+	if m.StepAttempt != nil {
+		stepAttempt = *m.StepAttempt
+	}
+	return fmt.Sprintf("%04d-%02d-%s-%s-%s-%s-%s-%020d-%020d-%s-%s",
+		m.RunQueuedAt.Year(), m.RunQueuedAt.Month(), m.AccountID, m.EnvID, m.RunID,
+		m.Scope, stepID, stepIndex, stepAttempt, m.SpanID, m.Kind)
 }

--- a/cmd/duckdbseed/insert_test.go
+++ b/cmd/duckdbseed/insert_test.go
@@ -71,6 +71,25 @@ func TestSortEventsMatchesTheEventsTableSortKey(t *testing.T) {
 		"internal_id must outrank received_at within the same year/month/tenant")
 }
 
+// TestSortMetadataMatchesTheMetadataTableSortKey pins run_metadata's key:
+// SORTED BY (year(run_queued_at), month(run_queued_at), account_id, env_id,
+// run_id, scope, step_id, step_index, step_attempt, span_id, kind).
+func TestSortMetadataMatchesTheMetadataTableSortKey(t *testing.T) {
+	sameMonth := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	runID := uuid.New().String()
+	accountID, envID := uuid.New(), uuid.New()
+
+	rows := []MetadataRow{
+		{RunID: runID, AccountID: accountID, EnvID: envID, RunQueuedAt: sameMonth, Scope: "step", SpanID: "b-span"},
+		{RunID: runID, AccountID: accountID, EnvID: envID, RunQueuedAt: sameMonth, Scope: "run", SpanID: "a-span"},
+	}
+
+	sortMetadata(rows)
+
+	require.Equal(t, []string{"a-span", "b-span"}, []string{rows[0].SpanID, rows[1].SpanID},
+		"scope must outrank span_id (\"run\" sorts before \"step\")")
+}
+
 func TestInsertGeneratedRunsWritesRunsSpansAndEvents(t *testing.T) {
 	connector, db := newTestDB(t, 1)
 	ctx := t.Context()
@@ -84,13 +103,16 @@ func TestInsertGeneratedRunsWritesRunsSpansAndEvents(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, summary.Runs)
 
-	wantSpans, wantEvents := 0, 0
+	wantSpans, wantEvents, wantMetadata := 0, 0, 0
 	for _, g := range generated {
 		wantSpans += len(g.Spans)
 		wantEvents += len(g.Events)
+		wantMetadata += len(g.Metadata)
 	}
 	require.Equal(t, wantSpans, summary.Spans)
 	require.Equal(t, wantEvents, summary.Events)
+	require.Equal(t, wantMetadata, summary.Metadata)
+	require.Greater(t, wantMetadata, 0, "testTemplates' MetadataProfiles should produce some metadata across 3 runs")
 
 	var runCount int
 	row := db.QueryRowContext(ctx, "SELECT count(*) FROM "+duckdb.DuckLakeAlias+".runs;")
@@ -106,6 +128,11 @@ func TestInsertGeneratedRunsWritesRunsSpansAndEvents(t *testing.T) {
 	row = db.QueryRowContext(ctx, "SELECT count(*) FROM "+duckdb.DuckLakeAlias+".events;")
 	require.NoError(t, row.Scan(&eventCount))
 	require.Equal(t, wantEvents, eventCount)
+
+	var metadataCount int
+	row = db.QueryRowContext(ctx, "SELECT count(*) FROM "+duckdb.DuckLakeAlias+".run_metadata;")
+	require.NoError(t, row.Scan(&metadataCount))
+	require.Equal(t, wantMetadata, metadataCount)
 }
 
 func TestInsertGeneratedRunsWithNoRunsIsANoop(t *testing.T) {

--- a/cmd/duckdbseed/main.go
+++ b/cmd/duckdbseed/main.go
@@ -1,8 +1,9 @@
 // Command duckdbseed seeds a DuckDB dual-write database
-// (inngest.runs/run_trace_spans/events, per
-// pkg/db/duckdb/migrations/000001_baseline.sql) with synthetic test data
-// shaped after a real dev database, for exercising pkg/cqrs/duckdbquery and
-// the trace UI without running real workloads through `inngest dev`.
+// (inngest.runs/run_trace_spans/events/run_metadata, per
+// pkg/db/duckdb/migrations/000001_baseline.sql and
+// 000003_run_metadata.sql) with synthetic test data shaped after a real dev
+// database, for exercising pkg/cqrs/duckdbquery and the trace UI without
+// running real workloads through `inngest dev`.
 //
 // It writes via pkg/db/duckdb's quack Appender (duckdb.QuackAppender) over
 // the same subprocess/HTTP transport dual-write itself uses — not
@@ -110,7 +111,7 @@ func main() {
 	if *dryRun {
 		verb = "would seed"
 	}
-	fmt.Printf("%s %d runs, %d spans, %d events into %s\n", verb, summary.Runs, summary.Spans, summary.Events, targetDir)
+	fmt.Printf("%s %d runs, %d spans, %d events, %d metadata rows into %s\n", verb, summary.Runs, summary.Spans, summary.Events, summary.Metadata, targetDir)
 }
 
 // formatRate renders count/d as a "%.0f" items-per-second figure for log
@@ -197,7 +198,7 @@ func run(ctx context.Context, cfg runConfig) (Summary, error) {
 	wallStart := time.Now()
 	summary, timings, err := GenerateAndInsert(ctx, targetConnector, rng, tmpl, genCfg, cfg.BatchSize, cfg.Parallelism, onProgress)
 	wall := time.Since(wallStart)
-	totalRows := summary.Runs + summary.Spans + summary.Events
+	totalRows := summary.Runs + summary.Spans + summary.Events + summary.Metadata
 	cfg.logf("sampling %s, generation %s (cumulative, %s runs/sec), insertion %s (cumulative, %s rows/sec), wall %s (%s runs/sec overall)",
 		sampleDur,
 		timings.Generate, formatRate(cfg.RunCount, timings.Generate),
@@ -214,6 +215,7 @@ func summarizeGeneratedRuns(generated []GeneratedRun) Summary {
 		summary.Runs++
 		summary.Spans += len(g.Spans)
 		summary.Events += len(g.Events)
+		summary.Metadata += len(g.Metadata)
 	}
 	return summary
 }

--- a/cmd/duckdbseed/sample.go
+++ b/cmd/duckdbseed/sample.go
@@ -58,6 +58,14 @@ func DefaultTemplates() Templates {
 		EventProfiles: [][]EventTemplate{
 			{{Name: "app/seeded.event", Data: `{}`, Offset: -200 * time.Millisecond}},
 		},
+		MetadataProfiles: []MetadataProfile{
+			{
+				Items: []MetadataTemplateItem{
+					{SpanID: "seeded-root", Scope: "run", Kind: "inngest.experiment", IsUser: false, Values: `{"seeded":true}`},
+					{SpanID: "seeded-step-1", Scope: "step", StepID: strPtr("seeded-step-1"), StepIndex: intPtr(0), StepAttempt: intPtr(1), Kind: "user.custom", IsUser: true, Values: `{"seeded":true}`},
+				},
+			},
+		},
 	}
 }
 
@@ -77,12 +85,13 @@ func BuildTemplates(ctx context.Context, db *sql.DB, limit int) (tmpl Templates,
 }
 
 // SampleTemplates samples up to limit distinct runs from each of
-// inngest.runs/run_trace_spans/events and returns the distinct tenant
-// tuples, statuses, and whole per-run shapes observed — a template
-// GenerateRuns samples from to produce data that looks like it. Returns a
-// zero-value Templates (no error) when the source tables are empty.
-// sampleRuns/sampleTraces/sampleEventProfiles each pick their own bounded
-// set of run_ids independently, so the pools aren't guaranteed to be the
+// inngest.runs/run_trace_spans/events/run_metadata and returns the
+// distinct tenant tuples, statuses, and whole per-run shapes observed — a
+// template GenerateRuns samples from to produce data that looks like it.
+// Returns a zero-value Templates (no error) when the source tables are
+// empty. Each of sampleRuns/sampleTraces/sampleEventProfiles/
+// sampleMetadata picks its own bounded set of run_ids independently (see
+// their own doc comments), so the four pools aren't guaranteed to be the
 // same runs -- consistent with Templates' existing "independently sampled
 // pools, mixed at generation time" design.
 func SampleTemplates(ctx context.Context, db *sql.DB, limit int) (Templates, error) {
@@ -105,6 +114,12 @@ func SampleTemplates(ctx context.Context, db *sql.DB, limit int) (Templates, err
 		return Templates{}, err
 	}
 	tmpl.EventProfiles = eventProfiles
+
+	profiles, err := sampleMetadata(ctx, db, limit)
+	if err != nil {
+		return Templates{}, err
+	}
+	tmpl.MetadataProfiles = profiles
 
 	return tmpl, nil
 }
@@ -374,10 +389,142 @@ func durationPtr(d time.Duration) *time.Duration {
 	return &d
 }
 
-// strPtr returns a pointer to s, for SpanTemplate's optional string
-// fields.
+// sampleMetadata reads every inngest.run_metadata row belonging to up to
+// limit distinct sampled runs, joined only onto its own run's queued_at,
+// and groups them into whole per-run metadata profiles (see
+// MetadataProfile) -- each row's SpanID/Scope/StepID/StepIndex/
+// StepAttempt reused completely verbatim, the same way SpanTemplate
+// reuses SpanID/ParentSpanID (see its own doc comment), so no join against
+// run_trace_spans is needed here at all: generateMetadata attaches an
+// item to whichever replayed span happens to share its exact SpanID.
+// Offset is each row's created_at relative to that run's own queued_at.
+//
+// limit bounds the number of distinct RUNS sampled, not rows: run_ids are
+// picked up front (a cheap scan) before the timing join runs, so a source
+// with a long history doesn't pay for more than a handful of runs' worth
+// of metadata regardless of how much it has accumulated overall.
+func sampleMetadata(ctx context.Context, db *sql.DB, limit int) ([]MetadataProfile, error) {
+	query := fmt.Sprintf(`
+	WITH sampled_runs AS (
+		SELECT DISTINCT run_id FROM %s.run_metadata LIMIT ?
+	),
+	run_timing AS (
+		SELECT run_id, queued_at
+		FROM %s.runs
+		WHERE run_id IN (SELECT run_id FROM sampled_runs)
+		QUALIFY row_number() OVER (PARTITION BY run_id ORDER BY ended_at DESC NULLS LAST, started_at DESC NULLS LAST) = 1
+	)
+	SELECT m.run_id, rt.queued_at, m.span_id, m.scope, m.step_id, m.step_index, m.step_attempt, m.kind, m.is_user, m.values, m.created_at
+	FROM %s.run_metadata m
+	JOIN run_timing rt ON rt.run_id = m.run_id;`, duckdb.DuckLakeAlias, duckdb.DuckLakeAlias, duckdb.DuckLakeAlias)
+	rows, err := db.QueryContext(ctx, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("duckdbseed: sampling metadata: %w", err)
+	}
+	defer rows.Close()
+
+	byRun := map[string]*MetadataProfile{}
+	var order []string
+	for rows.Next() {
+		var rawRunID, rawQueuedAt any
+		var spanID, scope string
+		var rawStepID, rawStepIndex, rawStepAttempt any
+		var kind string
+		var rawIsUser, rawValues, rawCreatedAt any
+		if err := rows.Scan(&rawRunID, &rawQueuedAt, &spanID, &scope, &rawStepID, &rawStepIndex, &rawStepAttempt, &kind, &rawIsUser, &rawValues, &rawCreatedAt); err != nil {
+			return nil, fmt.Errorf("duckdbseed: scanning sampled metadata: %w", err)
+		}
+
+		queuedAt, err := duckdb.AsTimestamp(rawQueuedAt)
+		if err != nil {
+			return nil, fmt.Errorf("duckdbseed: parsing sampled run queued_at: %w", err)
+		}
+		createdAt, err := duckdb.AsTimestamp(rawCreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("duckdbseed: parsing sampled metadata created_at: %w", err)
+		}
+
+		runID := fmt.Sprint(rawRunID)
+		profile, ok := byRun[runID]
+		if !ok {
+			profile = &MetadataProfile{}
+			byRun[runID] = profile
+			order = append(order, runID)
+		}
+
+		var stepID *string
+		if s, ok := rawStepID.(string); ok {
+			stepID = &s
+		}
+		var stepIndex *int
+		if rawStepIndex != nil {
+			v := int(int64Value(rawStepIndex))
+			stepIndex = &v
+		}
+		var stepAttempt *int
+		if rawStepAttempt != nil {
+			v := int(int64Value(rawStepAttempt))
+			stepAttempt = &v
+		}
+
+		profile.Items = append(profile.Items, MetadataTemplateItem{
+			SpanID:      spanID,
+			Scope:       scope,
+			StepID:      stepID,
+			StepIndex:   stepIndex,
+			StepAttempt: stepAttempt,
+			Kind:        kind,
+			IsUser:      boolValue(rawIsUser),
+			Values:      jsonText(rawValues),
+			Offset:      createdAt.Sub(queuedAt),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("duckdbseed: reading sampled metadata: %w", err)
+	}
+
+	profiles := make([]MetadataProfile, len(order))
+	for i, runID := range order {
+		profiles[i] = *byRun[runID]
+	}
+	return profiles, nil
+}
+
+// strPtr returns a pointer to s, for SpanTemplate/MetadataTemplateItem's
+// optional string fields.
 func strPtr(s string) *string {
 	return &s
+}
+
+// intPtr returns a pointer to i, for MetadataTemplateItem's optional int
+// fields.
+func intPtr(i int) *int {
+	return &i
+}
+
+// boolValue type-asserts a scanned BOOLEAN column's value, defaulting to
+// false for a NULL or unexpected type rather than erroring — used only for
+// is_root (computed by this file's own query, never NULL) and is_user
+// (NOT NULL in the schema), so this is a defensive fallback, not an
+// expected path.
+func boolValue(v any) bool {
+	b, _ := v.(bool)
+	return b
+}
+
+// int64Value type-asserts a scanned integer column's value, tolerating
+// both int64 (the quack transport's shape for BIGINT) and float64 (the
+// jsonlines transport decodes numbers via encoding/json) — mirroring
+// pkg/db/duckdb.AsInt64's same dual handling for the same reason.
+func int64Value(v any) int64 {
+	switch n := v.(type) {
+	case int64:
+		return n
+	case float64:
+		return int64(n)
+	default:
+		return 0
+	}
 }
 
 func tenantFromValues(rawAccountID, rawEnvID, rawAppID, rawFunctionID any) (Tenant, error) {

--- a/cmd/duckdbseed/sample_test.go
+++ b/cmd/duckdbseed/sample_test.go
@@ -56,6 +56,14 @@ func TestSampleTemplatesReadsRealRowsAsTemplates(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO inngest.run_metadata (account_id, env_id, run_id, run_queued_at, app_id, function_id, span_id, scope, kind, is_user, values, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 'run', 'inngest.experiment', false, ?, ?);`,
+		accountID.String(), envID.String(), runID, now, appID.String(), functionID.String(),
+		"span-1", `{"variant":"a"}`, now,
+	)
+	require.NoError(t, err)
+
 	tmpl, err := SampleTemplates(ctx, db, 200)
 	require.NoError(t, err)
 
@@ -87,24 +95,31 @@ func TestSampleTemplatesReadsRealRowsAsTemplates(t *testing.T) {
 
 	require.Len(t, tmpl.EventProfiles, 1)
 	require.Equal(t, []EventTemplate{{Name: "app/one", Data: `{"k":"v"}`, Offset: receivedAt.Sub(now)}}, tmpl.EventProfiles[0])
+
+	require.Len(t, tmpl.MetadataProfiles, 1)
+	profile := tmpl.MetadataProfiles[0]
+	require.Equal(t, []MetadataTemplateItem{
+		{SpanID: "span-1", Scope: "run", Kind: "inngest.experiment", IsUser: false, Values: `{"variant":"a"}`, Offset: 0},
+	}, profile.Items)
 }
 
 // TestSampleTemplatesPreservesRealSpanIDsAndParentsVerbatim proves the fix
 // for a real bug affecting every run sampled from an actual `inngest dev`
-// database: sampleTraces used to try to detect which span was "the root"
-// by checking parent_span_id IS NULL -- but a real root span
-// ("executor.run") is created with no OTel parent, and OTel's zero SpanID
-// stringifies to the literal "0000000000000000", never SQL NULL or "", so
-// that check never matched any real run's root at all, silently dropping
-// every sampled trace (falling back to the 2-span defaults). The fix
-// removes root detection entirely: SpanTemplate now carries each
-// span_id/parent_span_id completely unchanged, so the exact same
-// relationship (child's parent_span_id text matching root's span_id text)
-// still holds after replay without this package ever needing to resolve
-// it itself. This seeds a run shaped exactly like real dualwrite output:
-// the root's own parent_span_id is the literal OTel zero-SpanID sentinel,
-// and every other span's parent_span_id is the deterministic value that
-// equals the root's own span_id (mirroring pkg/tracing/util.go's
+// database: sampleTraces/sampleMetadata used to try to detect which span
+// was "the root" by checking parent_span_id IS NULL -- but a real root
+// span ("executor.run") is created with no OTel parent, and OTel's zero
+// SpanID stringifies to the literal "0000000000000000", never SQL NULL or
+// "", so that check never matched any real run's root at all, silently
+// dropping every sampled trace and metadata profile (falling back to the
+// 2-span/no-metadata defaults). The fix removes root detection entirely:
+// SpanTemplate/MetadataTemplateItem now carry each span_id/parent_span_id
+// completely unchanged, so the exact same relationship (child's
+// parent_span_id text matching root's span_id text) still holds after
+// replay without this package ever needing to resolve it itself. This
+// seeds a run shaped exactly like real dualwrite output: the root's own
+// parent_span_id is the literal OTel zero-SpanID sentinel, and every
+// other span's parent_span_id is the deterministic value that equals the
+// root's own span_id (mirroring pkg/tracing/util.go's
 // RunSpanRefFromMetadata).
 func TestSampleTemplatesPreservesRealSpanIDsAndParentsVerbatim(t *testing.T) {
 	_, db := newTestDB(t, 1)
@@ -141,6 +156,13 @@ func TestSampleTemplatesPreservesRealSpanIDsAndParentsVerbatim(t *testing.T) {
 	insertSpan("step-0", rootSpanID, now.Add(time.Second))
 	insertSpan("step-1", rootSpanID, now.Add(2*time.Second))
 
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO inngest.run_metadata (account_id, env_id, run_id, run_queued_at, app_id, function_id, span_id, scope, step_id, step_index, step_attempt, kind, is_user, values, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, 'step', ?, 1, 1, 'user.custom', true, '{"n":2}', ?);`,
+		accountID.String(), envID.String(), runID, now, appID.String(), functionID.String(), "step-1", "step-1", now,
+	)
+	require.NoError(t, err)
+
 	tmpl, err := SampleTemplates(ctx, db, 200)
 	require.NoError(t, err)
 
@@ -159,6 +181,12 @@ func TestSampleTemplatesPreservesRealSpanIDsAndParentsVerbatim(t *testing.T) {
 	require.Equal(t, rootSpanID, *bySpanID["step-0"].ParentSpanID)
 	require.NotNil(t, bySpanID["step-1"].ParentSpanID)
 	require.Equal(t, rootSpanID, *bySpanID["step-1"].ParentSpanID)
+
+	require.Len(t, tmpl.MetadataProfiles, 1)
+	profile := tmpl.MetadataProfiles[0]
+	require.Equal(t, []MetadataTemplateItem{
+		{SpanID: "step-1", Scope: "step", StepID: strPtr("step-1"), StepIndex: intPtr(1), StepAttempt: intPtr(1), Kind: "user.custom", IsUser: true, Values: `{"n":2}`, Offset: 0},
+	}, profile.Items)
 
 	// Replaying the sampled trace must preserve the exact same
 	// relationship, purely because SpanID/ParentSpanID are copied

--- a/cmd/duckdbseed/types.go
+++ b/cmd/duckdbseed/types.go
@@ -1,8 +1,9 @@
 // Command duckdbseed seeds a DuckDB dual-write database
-// (inngest.runs/run_trace_spans/events, per
-// pkg/db/duckdb/migrations/000001_baseline.sql) with synthetic test data
-// shaped after a real dev database, for exercising pkg/cqrs/duckdbquery and
-// the trace UI without running real workloads through `inngest dev`.
+// (inngest.runs/run_trace_spans/events/run_metadata, per
+// pkg/db/duckdb/migrations/000001_baseline.sql and
+// 000003_run_metadata.sql) with synthetic test data shaped after a real dev
+// database, for exercising pkg/cqrs/duckdbquery and the trace UI without
+// running real workloads through `inngest dev`.
 package main
 
 import (
@@ -24,12 +25,12 @@ type Tenant struct {
 // synthetic rows — either sampled from a real database (see sample.go) or
 // the built-in defaults (DefaultTemplates) when no real data is available.
 // JSON-valued fields hold raw JSON text, reused verbatim as payload shapes.
-// Traces/EventProfiles are deliberately not flat pools of independently-
-// chosen values the way Statuses/Inputs/Outputs are: a run's span tree
-// shape and its triggering events are each properties of one real sampled
-// run, replayed onto a new one intact (same names/attributes/payloads/
-// relative timing) rather than reassembled from unrelated pieces — see
-// each type's own doc comment.
+// Traces/EventProfiles/MetadataProfiles are deliberately not flat pools of
+// independently-chosen values the way Statuses/Inputs/Outputs are: a run's
+// span tree shape, its triggering events, and its metadata are each
+// properties of one real sampled run, replayed onto a new one intact (same
+// names/attributes/payloads/relative timing) rather than reassembled from
+// unrelated pieces — see each type's own doc comment.
 type Templates struct {
 	Tenants  []Tenant
 	Statuses []string
@@ -41,6 +42,9 @@ type Templates struct {
 	// EventTemplate) — usually one event, but a batch-triggered run can have
 	// several, all received close together.
 	EventProfiles [][]EventTemplate
+	// MetadataProfiles are whole sampled runs' worth of metadata shape (see
+	// MetadataProfile).
+	MetadataProfiles []MetadataProfile
 }
 
 // SpanTemplate is one sampled span, stripped of everything that ties it to
@@ -101,6 +105,39 @@ type EventTemplate struct {
 	Name   string
 	Data   string
 	Offset time.Duration
+}
+
+// MetadataTemplateItem is one sampled inngest.run_metadata row, stripped
+// only of its tenant/run identity (see MetadataProfile) so it can be
+// replayed onto a newly generated run. SpanID/Scope/StepID/StepIndex/
+// StepAttempt are reused completely verbatim from the sampled row, the
+// same way SpanTemplate reuses SpanID/ParentSpanID (see its doc comment)
+// -- generateMetadata attaches an item to whichever replayed span shares
+// its exact SpanID, rather than recomputing a root/step position itself.
+// Offset is this row's created_at relative to the sampled run's own
+// queued_at (see SpanTemplate's doc comment for why every offset in this
+// package shares that reference point).
+type MetadataTemplateItem struct {
+	SpanID      string
+	Scope       string
+	StepID      *string
+	StepIndex   *int
+	StepAttempt *int
+	Kind        string
+	IsUser      bool
+	Values      string
+	Offset      time.Duration
+}
+
+// MetadataProfile is one sampled run's entire metadata shape: every
+// inngest.run_metadata row it had, verbatim. generateMetadata replays a
+// whole profile onto a newly generated run's span tree, skipping any item
+// whose SpanID doesn't match one of that run's actual replayed spans (only
+// possible when the trace and metadata profile picked for one generated
+// run were sampled from two different source runs -- see Templates' own
+// doc comment) rather than writing a metadata row with no matching span.
+type MetadataProfile struct {
+	Items []MetadataTemplateItem
 }
 
 // GenerateConfig parameterizes GenerateRuns.
@@ -181,10 +218,34 @@ type EventRow struct {
 	EventMeta  string
 }
 
-// GeneratedRun bundles one synthetic run together with its span tree and
-// the events it was triggered by.
+// MetadataRow mirrors inngest.run_metadata's columns
+// (pkg/db/duckdb/migrations/000003_run_metadata.sql). StepID/StepIndex/
+// StepAttempt are nil for a run-scoped row (Scope == "run"), matching
+// pkg/execution/dualwrite/listener.go's OnMetadataEntry, which leaves them
+// unset the same way for run-scoped metadata.
+type MetadataRow struct {
+	AccountID   uuid.UUID
+	EnvID       uuid.UUID
+	RunID       string
+	RunQueuedAt time.Time
+	AppID       uuid.UUID
+	FunctionID  uuid.UUID
+	SpanID      string
+	Scope       string
+	StepID      *string
+	StepIndex   *int
+	StepAttempt *int
+	Kind        string
+	IsUser      bool
+	Values      string
+	CreatedAt   time.Time
+}
+
+// GeneratedRun bundles one synthetic run together with its span tree, the
+// events it was triggered by, and the metadata attached to its spans.
 type GeneratedRun struct {
-	Run    RunRow
-	Spans  []SpanRow
-	Events []EventRow
+	Run      RunRow
+	Spans    []SpanRow
+	Events   []EventRow
+	Metadata []MetadataRow
 }

--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -118,6 +118,7 @@ func NewCheckpointAPI(o Opts) CheckpointAPI {
 		BackoffFunc:                  o.CheckpointOpts.BackoffFunc,
 		EnforceStepSizeLimits:        o.CheckpointOpts.EnforceStepSizeLimits,
 		AllowAsyncDispatchValidation: o.CheckpointOpts.AllowAsyncDispatchValidation,
+		SyncLifecycleListeners:       o.SyncLifecycleListeners,
 	})
 
 	api := checkpointAPI{

--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -192,6 +192,11 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 	// extended-trace case still looks up the user-created span by its ID.
 	var parentSpanRef *meta.SpanReference
 	var scope metadata.Scope
+	// hashedStepID/stepAttempt feed addTenantIDs below (for dual-write's
+	// inngest.run_metadata step_id/step_attempt columns), populated only in
+	// the step-scoped case.
+	var hashedStepID string
+	var stepAttempt *int
 
 	switch {
 	case req.Target.StepID == nil:
@@ -201,7 +206,6 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 	case req.Target.StepAttempt == nil || req.Target.SpanID == nil:
 		scope = enums.MetadataScopeStep
 
-		var hashedStepID string
 		if req.Target.StepIndex == nil || *req.Target.StepIndex == 0 {
 			sum := sha1.Sum([]byte(*req.Target.StepID))
 			hashedStepID = hex.EncodeToString(sum[:])
@@ -213,6 +217,7 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 		if req.Target.StepAttempt == nil || *req.Target.StepAttempt < 0 {
 			parentSpanRef = tracing.FinalizedStepSpanRefFromMetadataAndStepID(stateMetadata, hashedStepID)
 		} else {
+			stepAttempt = req.Target.StepAttempt
 			parentSpanRef = tracing.RetryStepSpanRefFromMetadataAndStepID(stateMetadata, hashedStepID, *req.Target.StepAttempt)
 		}
 
@@ -236,6 +241,15 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &stateMetadata.ID.FunctionID)
 		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &stateMetadata.ID.RunID)
 		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &stateMetadata.ID.Tenant.AppID)
+		if hashedStepID != "" {
+			meta.AddAttr(cfg.Attrs, meta.Attrs.StepID, &hashedStepID)
+			if req.Target.StepIndex != nil {
+				meta.AddAttr(cfg.Attrs, meta.Attrs.StepUserlandIndex, req.Target.StepIndex)
+			}
+			if stepAttempt != nil {
+				meta.AddAttr(cfg.Attrs, meta.Attrs.StepAttempt, stepAttempt)
+			}
+		}
 	}
 
 	for _, md := range req.Metadata {
@@ -249,6 +263,7 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 			md,
 			scope,
 			addTenantIDs,
+			tracing.WithMetadataSyncListeners(a.opts.SyncLifecycleListeners...),
 		)
 		if err != nil {
 			return err
@@ -383,12 +398,36 @@ func (a router) addRunMetadataLegacy(ctx context.Context, auth apiv1auth.V1Auth,
 		DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", parentSpan.TraceID, parentSpan.SpanID),
 	}
 
+	// hashedStepID mirrors AddRunMetadata's own derivation above -- this
+	// legacy path resolves parentSpanRef differently (a ClickHouse lookup
+	// rather than a deterministic computation), but req.Target carries the
+	// same step identifiers either way.
+	var hashedStepID string
+	if scope == enums.MetadataScopeStep && req.Target.StepID != nil {
+		if req.Target.StepIndex == nil || *req.Target.StepIndex == 0 {
+			sum := sha1.Sum([]byte(*req.Target.StepID))
+			hashedStepID = hex.EncodeToString(sum[:])
+		} else {
+			sum := sha1.Sum(fmt.Appendf(nil, "%s:%d", *req.Target.StepID, *req.Target.StepIndex))
+			hashedStepID = hex.EncodeToString(sum[:])
+		}
+	}
+
 	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
 		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, util.ToPtr(auth.AccountID()))
 		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID()))
 		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &parentSpan.FunctionID)
 		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &parentSpan.RunID)
 		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &parentSpan.AppID)
+		if hashedStepID != "" {
+			meta.AddAttr(cfg.Attrs, meta.Attrs.StepID, &hashedStepID)
+			if req.Target.StepIndex != nil {
+				meta.AddAttr(cfg.Attrs, meta.Attrs.StepUserlandIndex, req.Target.StepIndex)
+			}
+			if req.Target.StepAttempt != nil && *req.Target.StepAttempt >= 0 {
+				meta.AddAttr(cfg.Attrs, meta.Attrs.StepAttempt, req.Target.StepAttempt)
+			}
+		}
 	}
 
 	for _, md := range req.Metadata {
@@ -402,6 +441,7 @@ func (a router) addRunMetadataLegacy(ctx context.Context, auth apiv1auth.V1Auth,
 			md,
 			scope,
 			addTenantIDs,
+			tracing.WithMetadataSyncListeners(a.opts.SyncLifecycleListeners...),
 		)
 		if err != nil {
 			return err

--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -432,6 +432,7 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 				m,
 				enums.MetadataScopeExtendedTrace,
 				addTenantIDs,
+				tracing.WithMetadataSyncListeners(a.opts.SyncLifecycleListeners...),
 			)
 			if err != nil {
 				l.Error("failed to create metadata span", "err", err)

--- a/pkg/coreapi/graph/loaders/trace_flat.go
+++ b/pkg/coreapi/graph/loaders/trace_flat.go
@@ -3,10 +3,13 @@
 // convertRunSpanToGQL (trace.go), it carries no logic for the old
 // dynamic/fragment-merged
 // model: no discovery-step hiding, no SDK "inngest.execution" wrapper
-// collapsing, no userland-span reparenting, no metadata-span rollup — none
-// of those cases can occur in a flat tree, so there are no guard clauses
-// for them here. opcodeToGQL/stepStatusToGQL are shared with the other
-// converter since they're pure enum mappers with no rollup assumptions.
+// collapsing, no userland-span reparenting — none of those cases can occur
+// in a flat tree, so there are no guard clauses for them here.
+// opcodeToGQL/stepStatusToGQL are shared with the other converter since
+// they're pure enum mappers with no rollup assumptions. Metadata is a
+// straight copy, not a rollup: pkg/cqrs/duckdbquery's GetSpansByRunID
+// (attachMetadata) already collapsed inngest.run_metadata to the latest row
+// per (span_id, kind) before this function ever sees span.Metadata.
 package loader
 
 import (
@@ -140,6 +143,15 @@ func convertFlatSpanToGQL(ctx context.Context, span *cqrs.OtelSpan) (*models.Run
 			}
 			gqlSpan.StepInfo = si
 		}
+	}
+
+	for _, md := range span.Metadata {
+		gqlSpan.Metadata = append(gqlSpan.Metadata, &models.SpanMetadata{
+			Kind:      md.Kind,
+			Scope:     md.Scope,
+			Values:    md.Values,
+			UpdatedAt: md.UpdatedAt,
+		})
 	}
 
 	gqlSpan.ChildrenSpans = make([]*models.RunTraceSpan, 0, len(span.Children))

--- a/pkg/cqrs/duckdbquery/defer_test.go
+++ b/pkg/cqrs/duckdbquery/defer_test.go
@@ -45,7 +45,7 @@ func TestGetRunDefersReturnsSingleAfterRunDefer(t *testing.T) {
 		meta.Attrs.DeferFnSlug.Key():     "deferred-fn",
 		meta.Attrs.DeferStatus.Key():     enums.DeferStatusAfterRun.String(),
 	})
-	seedSpanRow(t, ctx, m, appID, functionID, runID, spanID, "", meta.SpanNameDefer, now, now, attrs)
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, spanID, "", meta.SpanNameDefer, now, now, attrs)
 
 	out, err := m.GetRunDefers(ctx, []ulid.ULID{runID})
 	require.NoError(t, err)
@@ -87,8 +87,8 @@ func TestGetRunDefersMergesAbortOverAfterRun(t *testing.T) {
 		meta.Attrs.DeferHashedID.Key(): "hash-2",
 		meta.Attrs.DeferStatus.Key():   enums.DeferStatusAborted.String(),
 	})
-	seedSpanRow(t, ctx, m, appID, functionID, runID, spanID, "", meta.SpanNameDefer, now, now, addAttrs)
-	seedSpanRow(t, ctx, m, appID, functionID, runID, spanID, "", meta.SpanNameDefer, now.Add(time.Second), now.Add(time.Second), abortAttrs)
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, spanID, "", meta.SpanNameDefer, now, now, addAttrs)
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, spanID, "", meta.SpanNameDefer, now.Add(time.Second), now.Add(time.Second), abortAttrs)
 
 	out, err := m.GetRunDefers(ctx, []ulid.ULID{runID})
 	require.NoError(t, err)
@@ -131,8 +131,8 @@ func TestGetRunDefersMergesScheduleLinkOverAfterRun(t *testing.T) {
 		meta.Attrs.DeferStatus.Key():     enums.DeferStatusAfterRun.String(),
 		meta.Attrs.DeferChildRunID.Key(): childRunID.String(),
 	})
-	seedSpanRow(t, ctx, m, appID, functionID, runID, spanID, "", meta.SpanNameDefer, now, now, addAttrs)
-	seedSpanRow(t, ctx, m, appID, functionID, runID, spanID, "", meta.SpanNameDefer, now.Add(time.Second), now.Add(time.Second), linkAttrs)
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, spanID, "", meta.SpanNameDefer, now, now, addAttrs)
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, spanID, "", meta.SpanNameDefer, now.Add(time.Second), now.Add(time.Second), linkAttrs)
 
 	out, err := m.GetRunDefers(ctx, []ulid.ULID{runID})
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestGetRunDeferredFromReadsParentLinkage(t *testing.T) {
 		meta.Attrs.DeferParentRunIDs.Key(): []string{parentRunID.String()},
 		meta.Attrs.DeferParentFnSlug.Key(): "parent-fn",
 	})
-	seedSpanRow(t, ctx, m, appID, functionID, childRunID, "child-queued-span", "", tracingv3.SpanNameRunQueued, now, now, attrs)
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, childRunID, "child-queued-span", "", tracingv3.SpanNameRunQueued, now, now, attrs)
 
 	out, err := m.GetRunDeferredFrom(ctx, []ulid.ULID{childRunID})
 	require.NoError(t, err)
@@ -191,7 +191,7 @@ func TestGetRunDeferredFromReturnsEmptyForNormalRun(t *testing.T) {
 	runID := ulid.MustNew(ulid.Now(), rand.Reader)
 	now := time.Now().UTC()
 
-	seedSpanRow(t, ctx, m, appID, functionID, runID, "queued-span", "", tracingv3.SpanNameRunQueued, now, now, "{}")
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, "queued-span", "", tracingv3.SpanNameRunQueued, now, now, "{}")
 
 	out, err := m.GetRunDeferredFrom(ctx, []ulid.ULID{runID})
 	require.NoError(t, err)

--- a/pkg/cqrs/duckdbquery/spans.go
+++ b/pkg/cqrs/duckdbquery/spans.go
@@ -3,16 +3,25 @@ package duckdbquery
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/db/duckdb"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
 	tracingv3 "github.com/inngest/inngest/pkg/tracing/v3"
 	"github.com/oklog/ulid/v2"
 )
 
 const spanColumns = "span_id, trace_id, parent_span_id, start_time, end_time, name, attributes, run_id, app_id, function_id, output, input"
+
+// spanColumnsPrefixed is spanColumns with each column prefixed "s." for use
+// inside GetSpansByRunID's latest_metadata CTE, which joins run_trace_spans
+// (aliased s) against run_metadata (aliased m) and needs the two
+// disambiguated.
+const spanColumnsPrefixed = "s.span_id, s.trace_id, s.parent_span_id, s.start_time, s.end_time, s.name, s.attributes, s.run_id, s.app_id, s.function_id, s.output, s.input"
 
 // GetSpansByRunID builds the run's span tree from inngest.run_trace_spans.
 // Unlike pkg/cqrs/manager's dynamic/fragment-merged model, this table is
@@ -22,10 +31,39 @@ const spanColumns = "span_id, trace_id, parent_span_id, start_time, end_time, na
 // passes (build every span first, then link) so a child's parent — however
 // it happens to be ordered by start_time, which can tie for point-in-time
 // spans — is always already present in the lookup map before it's needed.
+//
+// Metadata (inngest.run_metadata) is aggregated in SQL rather than scanned
+// as a second round trip or a row-multiplying join: the latest_metadata CTE
+// LEFT JOINs it on (account_id, env_id, run_id, span_id) and collapses
+// multiple emissions of the same (span_id, kind) to the latest by
+// created_at via QUALIFY — see execution.MetadataEntry's doc comment on why
+// "op" isn't stored, so there's no per-key fragment folding to replay, only
+// a last-write-wins pick — then the outer query GROUPs BY every span column
+// and aggregates the (already-collapsed) metadata rows into one
+// LIST(STRUCT(scope, kind, values, created_at)) column per span, so this
+// function still gets exactly one result row per span.
 func (m *Manager) GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.OtelSpan, error) {
 	query := fmt.Sprintf(
-		"SELECT %s FROM %s.run_trace_spans WHERE run_id = ? ORDER BY start_time ASC;",
-		spanColumns, duckdb.DuckLakeAlias,
+		`WITH latest_metadata AS (
+		   SELECT %s, m.scope, m.kind, m.values, m.created_at
+		   FROM %s.run_trace_spans s
+		   LEFT JOIN %s.run_metadata m
+		     ON m.account_id = s.account_id AND m.env_id = s.env_id
+		     AND m.run_id = s.run_id AND m.span_id = s.span_id
+		   WHERE s.run_id = ?
+		   QUALIFY m.kind IS NULL OR ROW_NUMBER() OVER (
+		     PARTITION BY m.span_id, m.kind ORDER BY m.created_at DESC
+		   ) = 1
+		 )
+		 SELECT
+		   %s,
+		   list({'scope': scope, 'kind': kind, 'values': values, 'created_at': created_at})
+		     FILTER (WHERE kind IS NOT NULL) AS metadata
+		 FROM latest_metadata
+		 GROUP BY %s
+		 ORDER BY start_time ASC;`,
+		spanColumnsPrefixed, duckdb.DuckLakeAlias, duckdb.DuckLakeAlias,
+		spanColumns, spanColumns,
 	)
 	rows, err := m.db.QueryContext(ctx, query, runID.String())
 	if err != nil {
@@ -186,8 +224,9 @@ func (m *Manager) GetSpanOutput(ctx context.Context, id cqrs.SpanIdentifier) (*c
 	return so, nil
 }
 
-// scanSpan scans one row of a spanColumns-shaped SELECT into a *cqrs.OtelSpan.
-// Destination order must match spanColumns exactly.
+// scanSpan scans one row of a spanColumns-plus-metadata-shaped SELECT (see
+// GetSpansByRunID's query) into a *cqrs.OtelSpan. Destination order must
+// match spanColumns exactly, followed by the aggregated metadata column.
 func scanSpan(ctx context.Context, rows *sql.Rows) (span *cqrs.OtelSpan, parentSpanID string, err error) {
 	var (
 		spanID, traceID                   string
@@ -197,10 +236,12 @@ func scanSpan(ctx context.Context, rows *sql.Rows) (span *cqrs.OtelSpan, parentS
 		rawAttributes                     any
 		rawRunID, rawAppID, rawFunctionID any
 		rawOutput, rawInput               any
+		rawMetadata                       any
 	)
 	if err := rows.Scan(
 		&spanID, &traceID, &rawParentSpanID, &rawStartTime, &rawEndTime, &name,
 		&rawAttributes, &rawRunID, &rawAppID, &rawFunctionID, &rawOutput, &rawInput,
+		&rawMetadata,
 	); err != nil {
 		return nil, "", err
 	}
@@ -280,5 +321,62 @@ func scanSpan(ctx context.Context, rows *sql.Rows) (span *cqrs.OtelSpan, parentS
 		newSpan.OutputID = &encoded
 	}
 
+	newSpan.Metadata, err = scanSpanMetadata(rawMetadata)
+	if err != nil {
+		return nil, "", err
+	}
+
 	return newSpan, parentSpanID, nil
+}
+
+// scanSpanMetadata decodes GetSpansByRunID's aggregated
+// LIST(STRUCT(scope, kind, values, created_at)) metadata column -- raw is
+// nil for a span with no metadata at all (an empty list also decodes to a
+// zero-length, non-nil slice; both are treated as "no metadata").
+func scanSpanMetadata(raw any) ([]*cqrs.SpanMetadata, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("duckdbquery: expected list for metadata column, got %T", raw)
+	}
+
+	out := make([]*cqrs.SpanMetadata, 0, len(items))
+	for _, item := range items {
+		fields, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("duckdbquery: expected struct for metadata list element, got %T", item)
+		}
+
+		kindStr, _ := fields["kind"].(string)
+		scopeStr, _ := fields["scope"].(string)
+		scope, err := enums.MetadataScopeString(scopeStr)
+		if err != nil {
+			return nil, fmt.Errorf("duckdbquery: parsing metadata scope %q: %w", scopeStr, err)
+		}
+		createdAt, err := asTimestamp(fields["created_at"], "created_at")
+		if err != nil {
+			return nil, err
+		}
+
+		var values metadata.Values
+		if v, ok := fields["values"].(map[string]any); ok {
+			valuesByt, err := json.Marshal(v)
+			if err != nil {
+				return nil, fmt.Errorf("duckdbquery: re-marshaling metadata values: %w", err)
+			}
+			if err := json.Unmarshal(valuesByt, &values); err != nil {
+				return nil, fmt.Errorf("duckdbquery: unmarshaling metadata values: %w", err)
+			}
+		}
+
+		out = append(out, &cqrs.SpanMetadata{
+			Scope:     scope,
+			Kind:      metadata.Kind(kindStr),
+			Values:    values,
+			UpdatedAt: createdAt,
+		})
+	}
+	return out, nil
 }

--- a/pkg/cqrs/duckdbquery/spans_test.go
+++ b/pkg/cqrs/duckdbquery/spans_test.go
@@ -11,16 +11,76 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func seedSpanRow(t *testing.T, ctx context.Context, m *Manager, appID, functionID uuid.UUID, runIDULID ulid.ULID, spanID, parentSpanID, name string, start, end time.Time, attrs string) {
+func seedSpanRow(t *testing.T, ctx context.Context, m *Manager, accountID, envID, appID, functionID uuid.UUID, runIDULID ulid.ULID, spanID, parentSpanID, name string, start, end time.Time, attrs string) {
 	t.Helper()
 	_, err := m.db.ExecContext(ctx,
 		`INSERT INTO inngest.run_trace_spans
 		 (account_id, env_id, run_id, run_queued_at, app_id, function_id, name, start_time, end_time, trace_id, span_id, parent_span_id, attributes)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`,
-		uuid.New().String(), uuid.New().String(), runIDULID.String(), start, appID.String(), functionID.String(),
+		accountID.String(), envID.String(), runIDULID.String(), start, appID.String(), functionID.String(),
 		name, start, end, "trace-1", spanID, parentSpanID, attrs,
 	)
 	require.NoError(t, err)
+}
+
+func seedMetadataRow(t *testing.T, ctx context.Context, m *Manager, accountID, envID, appID, functionID uuid.UUID, runID ulid.ULID, spanID, scope, kind string, isUser bool, values string, createdAt time.Time) {
+	t.Helper()
+	_, err := m.db.ExecContext(ctx,
+		`INSERT INTO inngest.run_metadata
+		 (account_id, env_id, run_id, run_queued_at, app_id, function_id, span_id, scope, kind, is_user, values, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);`,
+		accountID.String(), envID.String(), runID.String(), createdAt, appID.String(), functionID.String(),
+		spanID, scope, kind, isUser, values, createdAt,
+	)
+	require.NoError(t, err)
+}
+
+// TestGetSpansByRunIDAttachesMetadataViaJoin proves the LEFT JOIN onto
+// inngest.run_metadata attaches each span's metadata without a second
+// query, and that multiple emissions of the same (span_id, kind) collapse
+// to only the latest by created_at -- see execution.MetadataEntry's doc
+// comment on why "op" isn't stored, so there's no fragment folding, only a
+// last-write-wins pick.
+func TestGetSpansByRunIDAttachesMetadataViaJoin(t *testing.T) {
+	db, cleanup := newTestDuckDB(t)
+	defer cleanup()
+	ctx := t.Context()
+	m := Wrap(nil, db).(*Manager)
+
+	accountID, envID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	runID := ulid.MustNew(ulid.Now(), nil)
+	now := time.Now().UTC()
+
+	seedSpanRow(t, ctx, m, accountID, envID, appID, functionID, runID, "root-span", "", "executor.run", now, now.Add(time.Second), "{}")
+	seedSpanRow(t, ctx, m, accountID, envID, appID, functionID, runID, "child-span", "root-span", "executor.step", now.Add(time.Millisecond), now.Add(500*time.Millisecond), "{}")
+
+	// Two emissions of the same kind on root-span: only the later one
+	// (by created_at) should survive.
+	seedMetadataRow(t, ctx, m, accountID, envID, appID, functionID, runID, "root-span", "run", "stale.kind", false, `{"v":1}`, now)
+	seedMetadataRow(t, ctx, m, accountID, envID, appID, functionID, runID, "root-span", "run", "stale.kind", false, `{"v":2}`, now.Add(time.Minute))
+	// A distinct kind, also on root-span.
+	seedMetadataRow(t, ctx, m, accountID, envID, appID, functionID, runID, "root-span", "run", "other.kind", true, `{"v":3}`, now)
+	// A kind on child-span -- must not leak onto root-span.
+	seedMetadataRow(t, ctx, m, accountID, envID, appID, functionID, runID, "child-span", "step", "step.kind", false, `{"v":4}`, now)
+
+	root, err := m.GetSpansByRunID(ctx, runID)
+	require.NoError(t, err)
+	require.Len(t, root.Metadata, 2)
+
+	byKind := map[string]*cqrs.SpanMetadata{}
+	for _, md := range root.Metadata {
+		byKind[string(md.Kind)] = md
+	}
+	require.Contains(t, byKind, "stale.kind")
+	require.JSONEq(t, `2`, string(byKind["stale.kind"].Values["v"]))
+	require.Contains(t, byKind, "other.kind")
+	require.JSONEq(t, `3`, string(byKind["other.kind"].Values["v"]))
+
+	require.Len(t, root.Children, 1)
+	child := root.Children[0]
+	require.Len(t, child.Metadata, 1)
+	require.Equal(t, "step.kind", string(child.Metadata[0].Kind))
+	require.JSONEq(t, `4`, string(child.Metadata[0].Values["v"]))
 }
 
 func TestGetSpansByRunIDBuildsTreeFromFlatRows(t *testing.T) {
@@ -34,9 +94,9 @@ func TestGetSpansByRunIDBuildsTreeFromFlatRows(t *testing.T) {
 	now := time.Now().UTC()
 
 	// Root span: empty parent_span_id.
-	seedSpanRow(t, ctx, m, appID, functionID, runID, "root-span", "", "executor.run", now, now.Add(time.Second), "{}")
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, "root-span", "", "executor.run", now, now.Add(time.Second), "{}")
 	// Child span: parent is the root.
-	seedSpanRow(t, ctx, m, appID, functionID, runID, "child-span", "root-span", "executor.step", now.Add(time.Millisecond), now.Add(500*time.Millisecond), "{}")
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, "child-span", "root-span", "executor.step", now.Add(time.Millisecond), now.Add(500*time.Millisecond), "{}")
 
 	root, err := m.GetSpansByRunID(ctx, runID)
 	require.NoError(t, err)
@@ -77,7 +137,7 @@ func TestGetSpansByRunIDPromotesRunStartedOverQueuedForStillRunningFunction(t *t
 			}
 			for _, key := range order {
 				row := rows[key]
-				seedSpanRow(t, ctx, m, appID, functionID, runID, row.spanID, "run-root-not-yet-written", row.name, now, now, "{}")
+				seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, row.spanID, "run-root-not-yet-written", row.name, now, now, "{}")
 			}
 
 			root, err := m.GetSpansByRunID(ctx, runID)
@@ -102,7 +162,7 @@ func TestGetSpansByRunIDPromotesRunQueuedWhenNotYetStarted(t *testing.T) {
 	runID := ulid.MustNew(ulid.Now(), nil)
 	now := time.Now().UTC()
 
-	seedSpanRow(t, ctx, m, appID, functionID, runID, "run-queued", "run-root-not-yet-written", "executor.run.queued", now, now, "{}")
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, "run-queued", "run-root-not-yet-written", "executor.run.queued", now, now, "{}")
 
 	root, err := m.GetSpansByRunID(ctx, runID)
 	require.NoError(t, err)
@@ -127,8 +187,8 @@ func TestGetSpansByRunIDPrefersGenuineRootOverOrphanedRunSpans(t *testing.T) {
 
 	// The genuine root, inserted last (start_time is later) so scan order
 	// alone would otherwise favor the orphaned executor.run.started span.
-	seedSpanRow(t, ctx, m, appID, functionID, runID, "run-started", "run-root", "executor.run.started", now, now.Add(time.Second), "{}")
-	seedSpanRow(t, ctx, m, appID, functionID, runID, "run-root", "", "executor.run", now.Add(2*time.Second), now.Add(3*time.Second), "{}")
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, "run-started", "run-root", "executor.run.started", now, now.Add(time.Second), "{}")
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, "run-root", "", "executor.run", now.Add(2*time.Second), now.Add(3*time.Second), "{}")
 
 	root, err := m.GetSpansByRunID(ctx, runID)
 	require.NoError(t, err)
@@ -156,7 +216,7 @@ func TestGetSpansByRunIDSetsOutputIDWhenSpanHasOutputOrInput(t *testing.T) {
 	now := time.Now().UTC()
 
 	// Root span: still running, no output/input recorded yet.
-	seedSpanRow(t, ctx, m, appID, functionID, runID, "root-span", "", "executor.run", now, now.Add(time.Second), "{}")
+	seedSpanRow(t, ctx, m, uuid.New(), uuid.New(), appID, functionID, runID, "root-span", "", "executor.run", now, now.Add(time.Second), "{}")
 	// Child span: finished, has output.
 	_, err := m.db.ExecContext(ctx,
 		`INSERT INTO inngest.run_trace_spans

--- a/pkg/db/duckdb/migrations/000003_run_metadata.sql
+++ b/pkg/db/duckdb/migrations/000003_run_metadata.sql
@@ -1,0 +1,51 @@
+-- +goose Up
+
+-- inngest.run_metadata holds one row per metadata emission (executor
+-- generator/experiment metadata, the AddRunMetadata API, and userland span
+-- metadata extraction -- see pkg/execution/sync_lifecycle.go's
+-- OnMetadataEntry and its callers). It is a standalone table, joined onto
+-- inngest.run_trace_spans by (run_id, span_id) rather than a set of columns
+-- on that table, mirroring the reference metadata insights table's own
+-- separation of concerns.
+--
+-- Deliberately simpler than that reference design: this table drops the
+-- concept of a metadata "op" (merge/set/delete/add) entirely. Each row is
+-- the caller's full, already-resolved value set for one metadata emission,
+-- not a delta to be folded with prior emissions by key. A reader wanting
+-- "the current metadata for this span" collapses to the latest row per
+-- (run_id, span_id, kind) -- the same latest-row-wins pattern
+-- pkg/cqrs/duckdbquery already uses for inngest.runs -- rather than
+-- replaying an op history.
+CREATE TABLE IF NOT EXISTS inngest.run_metadata (
+  account_id     UUID NOT NULL,
+  env_id         UUID NOT NULL,
+  run_id         VARCHAR NOT NULL,
+  run_queued_at  TIMESTAMP_MS NOT NULL,
+  app_id         UUID NOT NULL,
+  function_id    UUID NOT NULL,
+  -- span_id is the run/step/request span this metadata annotates (the
+  -- "parent" every metadata span is created under) -- the join key onto
+  -- inngest.run_trace_spans.span_id, not this row's own identity.
+  span_id        VARCHAR NOT NULL,
+  scope          VARCHAR NOT NULL,
+  -- step_id/step_index/step_attempt identify the step this metadata belongs
+  -- to, independently of span_id (a request-scoped metadata span's span_id
+  -- is the request's execution span, not the step span, but it still
+  -- belongs to a step). All three are NULL for run-scoped metadata.
+  -- step_id is the same hashed step ID used to compute a step's own
+  -- deterministic span identity, not the SDK-facing userland step ID.
+  step_id        VARCHAR,
+  step_index     INTEGER,
+  step_attempt   INTEGER,
+  kind           VARCHAR NOT NULL,
+  is_user        BOOLEAN NOT NULL,
+  values         JSON NOT NULL,
+  created_at     TIMESTAMP_MS NOT NULL
+);
+ALTER TABLE inngest.run_metadata
+  SET SORTED BY (year(run_queued_at), month(run_queued_at), account_id, env_id, run_id, scope, step_id, step_index, step_attempt, span_id, kind);
+ALTER TABLE inngest.run_metadata
+  SET PARTITIONED BY (year(run_queued_at), month(run_queued_at), account_id);
+
+-- +goose Down
+DROP TABLE IF EXISTS inngest.run_metadata;

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -99,6 +99,14 @@ type Opts struct {
 	EnforceStepSizeLimits func(ctx context.Context, accountID uuid.UUID) bool
 	// AllowAsyncDispatchValidation gates the dispatch validator per account.
 	AllowAsyncDispatchValidation AllowAsyncDispatchValidation
+	// SyncLifecycleListeners are notified synchronously (see
+	// execution.SyncLifecycleListener and pkg/tracing.WithMetadataSyncListeners)
+	// of opcode-attached metadata and defer spans emitted while checkpointing,
+	// the same listeners pkg/api/apiv1's other span-creating endpoints use --
+	// wiring this through is what lets DuckDB dual-write (pkg/execution/dualwrite)
+	// observe checkpoint-originated metadata/defers, not just the executor's
+	// own in-process path.
+	SyncLifecycleListeners []execution.SyncLifecycleListener
 }
 
 // CheckpointQueue is the reduced queue surface used by checkpointing.
@@ -413,7 +421,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			// executor.WithSyncLifecycleListeners/runner.WithSyncLifecycleListeners
 			// (pkg/devserver), and the checkpoint path never receives it —
 			// consistent with every other hook here, none of which dual-write.
-			if err := defers.SaveFromOp(ctx, c.State, c.TracerProvider, nil, l, input.Metadata, op); err != nil {
+			if err := defers.SaveFromOp(ctx, c.State, c.TracerProvider, c.SyncLifecycleListeners, l, input.Metadata, op); err != nil {
 				// Log without returning the error: a bad defer must
 				// never fail its parent run. We may rethink this as
 				// the Defer feature matures.
@@ -427,7 +435,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 
 		case enums.OpcodeDeferAbort:
 			// nil sync listeners: see the OpcodeDeferAdd case above.
-			if err := defers.AbortFromOp(ctx, c.State, c.TracerProvider, nil, l, input.Metadata, op); err != nil {
+			if err := defers.AbortFromOp(ctx, c.State, c.TracerProvider, c.SyncLifecycleListeners, l, input.Metadata, op); err != nil {
 				// Log without returning the error: a bad defer must
 				// never fail its parent run. We may rethink this as
 				// the Defer feature matures.
@@ -632,7 +640,7 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 
 		case enums.OpcodeDeferAdd:
 			// nil sync listeners: see checkpoint's other OpcodeDeferAdd case.
-			if err := defers.SaveFromOp(ctx, c.State, c.TracerProvider, nil, l, &md, op); err != nil {
+			if err := defers.SaveFromOp(ctx, c.State, c.TracerProvider, c.SyncLifecycleListeners, l, &md, op); err != nil {
 				// Log without returning the error: a bad defer must
 				// never fail its parent run. We may rethink this as
 				// the Defer feature matures.
@@ -646,7 +654,7 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 
 		case enums.OpcodeDeferAbort:
 			// nil sync listeners: see checkpoint's other OpcodeDeferAdd case.
-			if err := defers.AbortFromOp(ctx, c.State, c.TracerProvider, nil, l, &md, op); err != nil {
+			if err := defers.AbortFromOp(ctx, c.State, c.TracerProvider, c.SyncLifecycleListeners, l, &md, op); err != nil {
 				// Log without returning the error: a bad defer must
 				// never fail its parent run. We may rethink this as
 				// the Defer feature matures.
@@ -920,6 +928,7 @@ func (c checkpointer) processMetadata(
 			spanMd.Op(),
 			values,
 			spanMd.Scope,
+			tracing.WithMetadataSyncListeners(c.SyncLifecycleListeners...),
 		)
 		if err != nil {
 			l.Warn("error creating metadata span in checkpoint",

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -583,6 +583,72 @@ func TestSyncStepMetadata(t *testing.T) {
 		require.True(hasMetadata, "Expected a metadata span")
 	})
 
+	t.Run("notifies sync lifecycle listeners of opcode-attached metadata", func(t *testing.T) {
+		// Opcode-attached metadata (op.Metadata) must reach any configured
+		// SyncLifecycleListeners the same way every other metadata span
+		// creation site in the codebase does (see
+		// tracing.WithMetadataSyncListeners callers in pkg/api/apiv1 and
+		// pkg/execution/executor) -- otherwise DuckDB dual-write never
+		// receives it.
+		ctx := context.Background()
+		require := require.New(t)
+
+		now := time.Now()
+		ops := []state.GeneratorOpcode{
+			{
+				ID:     "step-1",
+				Op:     enums.OpcodeStepRun,
+				Data:   json.RawMessage(`{"result": "step 1 output"}`),
+				Name:   "Step 1",
+				Timing: interval.New(now, now.Add(100*time.Millisecond)),
+				Metadata: []metadata.ScopedUpdate{
+					{
+						Scope: enums.MetadataScopeRun,
+						Update: metadata.Update{
+							RawUpdate: metadata.RawUpdate{
+								Kind:   "userland.test",
+								Op:     enums.MetadataOpcodeMerge,
+								Values: metadata.Values{"key": json.RawMessage(`"value"`)},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		mocks, testData := setupSyncCheckpointTest(t, ops...)
+
+		listener := &recordingMetadataListener{}
+		testData.checkpointer = New(Opts{
+			State:           mocks.state,
+			TracerProvider:  mocks.tracer,
+			Queue:           mocks.queue,
+			MetricsProvider: mocks.metrics,
+			Executor:        mocks.executor,
+			FnReader:        mocks.fnReader,
+			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
+				return true
+			}),
+			SyncLifecycleListeners: []execution.SyncLifecycleListener{listener},
+		})
+
+		expectedData := map[string]any{"data": json.RawMessage(`{"result": "step 1 output"}`)}
+		expectedOutputBytes, _ := json.Marshal(expectedData)
+		mocks.state.On("SaveStep", ctx, testData.metadata.ID, "step-1", expectedOutputBytes).Return(false, nil)
+
+		mocks.tracer.
+			On("CreateSpan", mock.Anything, mock.Anything, mock.AnythingOfType("*tracing.CreateSpanOptions")).
+			Return(&meta.SpanReference{}, nil)
+
+		mocks.metrics.On("OnStepFinished", ctx, mock.AnythingOfType("checkpoint.MetricCardinality"), enums.StepStatusCompleted)
+
+		err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+		require.NoError(err)
+
+		require.Len(listener.entries, 1, "Expected the metadata listener to be notified once")
+		require.Equal(metadata.Kind("userland.test"), listener.entries[0].Kind)
+	})
+
 	t.Run("creates spans on step error", func(t *testing.T) {
 		// A sync step error with metadata entries creates both the step
 		// span and metadata spans.
@@ -1036,6 +1102,18 @@ func setupSyncCheckpointTest(t *testing.T, ops ...state.GeneratorOpcode) (*testS
 }
 
 // Additional mock implementations for sync tests
+
+// recordingMetadataListener implements execution.SyncLifecycleListener,
+// recording every OnMetadataEntry call for assertions -- mirrors
+// pkg/tracing's own recordingMetadataListener test helper.
+type recordingMetadataListener struct {
+	execution.NoopSyncLifecycleListener
+	entries []execution.MetadataEntry
+}
+
+func (r *recordingMetadataListener) OnMetadataEntry(ctx context.Context, entry execution.MetadataEntry) {
+	r.entries = append(r.entries, entry)
+}
 
 type testSyncMocks struct {
 	state    *mockRunService

--- a/pkg/execution/dualwrite/listener.go
+++ b/pkg/execution/dualwrite/listener.go
@@ -51,11 +51,13 @@ import (
 type listener struct {
 	execution.NoopSyncLifecycleListener
 
-	runs   chan map[string]any
-	events chan map[string]any
+	runs     chan map[string]any
+	events   chan map[string]any
+	metadata chan map[string]any
 
-	droppedRuns   atomic.Int64
-	droppedEvents atomic.Int64
+	droppedRuns     atomic.Int64
+	droppedEvents   atomic.Int64
+	droppedMetadata atomic.Int64
 
 	// spanExporter/tp back every per-step hook's span creation — see
 	// tracing.go's doc comments. tp is what hooks actually call
@@ -74,10 +76,11 @@ type listener struct {
 	wg       sync.WaitGroup
 }
 
-func newListenerWithChannels(runsCap, eventsCap int) *listener {
+func newListenerWithChannels(runsCap, eventsCap, metadataCap int) *listener {
 	return &listener{
-		runs:   make(chan map[string]any, runsCap),
-		events: make(chan map[string]any, eventsCap),
+		runs:     make(chan map[string]any, runsCap),
+		events:   make(chan map[string]any, eventsCap),
+		metadata: make(chan map[string]any, metadataCap),
 	}
 }
 
@@ -94,6 +97,14 @@ func (l *listener) sendEvent(row map[string]any) {
 	case l.events <- row:
 	default:
 		l.droppedEvents.Add(1)
+	}
+}
+
+func (l *listener) sendMetadata(row map[string]any) {
+	select {
+	case l.metadata <- row:
+	default:
+		l.droppedMetadata.Add(1)
 	}
 }
 
@@ -647,6 +658,52 @@ func (l *listener) OnExtendedTraceSpan(ctx context.Context, span execution.Exten
 	})
 }
 
+// OnMetadataEntry writes one metadata emission directly into
+// inngest.run_metadata -- a standalone table, not a row in
+// inngest.run_trace_spans, so (unlike OnExtendedTraceSpan) this builds a row
+// by hand and sends it straight to its own batcher rather than creating a
+// span through l.tp. span_id identifies the run/step/request span this
+// metadata annotates (entry.Parent's own identity, recovered the same way
+// the real TracerProvider would), not a new span of its own -- the join key
+// a reader uses to correlate this row back to inngest.run_trace_spans. op
+// (merge/set/delete/add) is intentionally not stored: see
+// execution.MetadataEntry's doc comment.
+func (l *listener) OnMetadataEntry(ctx context.Context, entry execution.MetadataEntry) {
+	valuesByt, err := json.Marshal(entry.Values)
+	if err != nil {
+		logger.StdlibLogger(ctx).Error("dualwrite: failed to marshal metadata values", "kind", entry.Kind.String(), "error", err)
+		return
+	}
+
+	spanID := tracing.SpanContextFromMetadata(entry.Parent).SpanID().String()
+
+	row := map[string]any{
+		"account_id":    entry.AccountID.String(),
+		"env_id":        entry.EnvID.String(),
+		"run_id":        entry.RunID.String(),
+		"run_queued_at": ulid.Time(entry.RunID.Time()),
+		"app_id":        entry.AppID.String(),
+		"function_id":   entry.FunctionID.String(),
+		"span_id":       spanID,
+		"scope":         entry.Scope.String(),
+		"kind":          entry.Kind.String(),
+		"is_user":       entry.Kind.IsUser(),
+		"values":        string(valuesByt),
+		"created_at":    entry.CreatedAt,
+	}
+	if entry.StepID != "" {
+		row["step_id"] = entry.StepID
+	}
+	if entry.StepIndex != nil {
+		row["step_index"] = *entry.StepIndex
+	}
+	if entry.StepAttempt != nil {
+		row["step_attempt"] = *entry.StepAttempt
+	}
+
+	l.sendMetadata(row)
+}
+
 // OnDeferAdd writes the run's own executor.defer span (a new row, seeded
 // deterministically from (run_id, hashedID) via tracing.DeferSpanSeed --
 // see pkg/execution/defers.createDeferSpan, which does the same for the
@@ -1162,9 +1219,9 @@ func (l *listener) OnStepFinished(ctx context.Context, md sv2.Metadata, item que
 type Option func(*setupOpts)
 
 type setupOpts struct {
-	runsCap, spansCap, eventsCap int
-	batchMaxSize                 int
-	batchInterval                time.Duration
+	runsCap, spansCap, eventsCap, metadataCap int
+	batchMaxSize                              int
+	batchInterval                             time.Duration
 }
 
 func defaultSetupOpts() setupOpts {
@@ -1172,6 +1229,7 @@ func defaultSetupOpts() setupOpts {
 		runsCap:       10_000,
 		spansCap:      10_000,
 		eventsCap:     10_000,
+		metadataCap:   10_000,
 		batchMaxSize:  10_000,
 		batchInterval: 200 * time.Millisecond,
 	}
@@ -1206,12 +1264,13 @@ func NewListener(db *sql.DB, opts ...Option) execution.SyncLifecycleListener {
 		apply(&o)
 	}
 
-	l := newListenerWithChannels(o.runsCap, o.eventsCap)
+	l := newListenerWithChannels(o.runsCap, o.eventsCap, o.metadataCap)
 	l.db = db
 
 	tables := map[string]chan map[string]any{
-		"inngest.runs":   l.runs,
-		"inngest.events": l.events,
+		"inngest.runs":         l.runs,
+		"inngest.events":       l.events,
+		"inngest.run_metadata": l.metadata,
 	}
 	// One shared disabledState across every batcher (runs/events here, plus
 	// the span exporter's own below), so the driver's terminal

--- a/pkg/execution/dualwrite/listener_test.go
+++ b/pkg/execution/dualwrite/listener_test.go
@@ -19,6 +19,7 @@ import (
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
 	tracingv3 "github.com/inngest/inngest/pkg/tracing/v3"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
@@ -27,7 +28,7 @@ import (
 )
 
 func TestListenerOnEventReceivedNonBlockingWhenBufferFull(t *testing.T) {
-	l := newListenerWithChannels(1, 1) // capacity 1 for each of runs/events
+	l := newListenerWithChannels(1, 1, 1) // capacity 1 for each of runs/events/metadata
 
 	evt := event.NewBaseTrackedEvent(event.Event{Name: "test"}, nil)
 
@@ -52,7 +53,7 @@ func TestListenerOnEventReceivedNonBlockingWhenBufferFull(t *testing.T) {
 }
 
 func TestListenerOnFunctionScheduledEnqueuesRunRow(t *testing.T) {
-	l := newListenerWithChannels(10, 10)
+	l := newListenerWithChannels(10, 10, 10)
 	md := testMetadata(t)
 
 	l.OnFunctionScheduled(context.Background(), md, queue.Item{}, nil)
@@ -74,7 +75,7 @@ func TestListenerOnFunctionScheduledEnqueuesRunRow(t *testing.T) {
 // subsequent load) — as a real []string, stored as a DuckDB VARCHAR[] (see
 // pkg/db/duckdb/literal.go's []string encoding).
 func TestListenerOnFunctionScheduledSetsEventIDsFromMetadataConfig(t *testing.T) {
-	l := newListenerWithChannels(10, 10)
+	l := newListenerWithChannels(10, 10, 10)
 	md := testMetadata(t)
 	evt1, evt2 := ulid.MustNew(ulid.Now(), rand.Reader), ulid.MustNew(ulid.Now(), rand.Reader)
 	md.Config.EventIDs = []ulid.ULID{evt1, evt2}
@@ -95,7 +96,7 @@ func TestListenerOnFunctionScheduledSetsEventIDsFromMetadataConfig(t *testing.T)
 // "status" is handled for the same "column not applicable to this hook"
 // reasoning elsewhere in this file.
 func TestListenerOnFunctionScheduledOmitsEventIDsForCronRuns(t *testing.T) {
-	l := newListenerWithChannels(10, 10)
+	l := newListenerWithChannels(10, 10, 10)
 	md := testMetadata(t) // Config.EventIDs left empty, as a cron run would have it
 
 	l.OnFunctionScheduled(context.Background(), md, queue.Item{}, nil)
@@ -117,7 +118,7 @@ func TestListenerOnFunctionScheduledOmitsEventIDsForCronRuns(t *testing.T) {
 // normalizeRunSessions, which builds the same shape for the real run
 // span's "event.sessions" attribute.
 func TestListenerOnFunctionScheduledSetsSessionsFromTriggeringEvents(t *testing.T) {
-	l := newListenerWithChannels(10, 10)
+	l := newListenerWithChannels(10, 10, 10)
 	md := testMetadata(t)
 
 	evt1, err := json.Marshal(event.Event{Name: "test", Meta: event.EventMeta{
@@ -148,7 +149,7 @@ func TestListenerOnFunctionScheduledSetsSessionsFromTriggeringEvents(t *testing.
 // triggering event (or none at all) must never set "sessions", not set it
 // to an empty value.
 func TestListenerOnFunctionScheduledOmitsSessionsWhenNoTriggeringEventHasOne(t *testing.T) {
-	l := newListenerWithChannels(10, 10)
+	l := newListenerWithChannels(10, 10, 10)
 	md := testMetadata(t)
 
 	evt, err := json.Marshal(event.Event{Name: "test"})
@@ -892,6 +893,115 @@ func TestListenerOnExtendedTraceSpanWritesSpan(t *testing.T) {
 	attrs, ok := rows[0]["attributes"].(map[string]any)
 	require.True(t, ok, "attributes column should decode to a map, got %T", rows[0]["attributes"])
 	require.Equal(t, "hello", attrs["custom.attr"])
+}
+
+// TestListenerOnMetadataEntryWritesRow proves OnMetadataEntry writes a
+// standalone row into inngest.run_metadata (not inngest.run_trace_spans),
+// carrying the full, already-resolved value set and no "op" column -- see
+// execution.MetadataEntry's doc comment on why op is dropped -- joined onto
+// the annotated span via span_id, derived from Parent's own identity.
+func TestListenerOnMetadataEntryWritesRow(t *testing.T) {
+	db, cleanup := newTestDuckDB(t)
+	defer cleanup()
+	l := NewListener(db, func(o *setupOpts) { o.batchInterval = 20 * time.Millisecond })
+
+	accountID, envID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	runID := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader)
+	md := sv2.Metadata{ID: sv2.ID{
+		RunID:      runID,
+		FunctionID: functionID,
+		Tenant:     sv2.Tenant{AccountID: accountID, EnvID: envID, AppID: appID},
+	}}
+	sv2.InitConfig(&md.Config)
+	parent := tracing.RunSpanRefFromMetadata(&md)
+
+	entry := execution.MetadataEntry{
+		AccountID:  accountID,
+		EnvID:      envID,
+		AppID:      appID,
+		FunctionID: functionID,
+		RunID:      runID,
+		Parent:     parent,
+		Kind:       metadata.Kind("test.kind"),
+		Scope:      enums.MetadataScopeRun,
+		Values:     metadata.Values{"foo": json.RawMessage(`"bar"`)},
+		CreatedAt:  time.Now(),
+	}
+	l.OnMetadataEntry(context.Background(), entry)
+
+	require.Eventually(t, func() bool {
+		var count int
+		row := db.QueryRowContext(context.Background(), "SELECT count(*) FROM inngest.run_metadata;")
+		_ = row.Scan(&count)
+		return count == 1
+	}, 2*time.Second, 20*time.Millisecond, "metadata row should land after a batch flush")
+
+	rows := selectRows(t, db, "SELECT run_id, span_id, kind, scope, is_user, values, step_id, step_index, step_attempt FROM inngest.run_metadata;")
+	require.Len(t, rows, 1)
+	require.Equal(t, runID.String(), rows[0]["run_id"])
+	require.Equal(t, tracing.SpanContextFromMetadata(parent).SpanID().String(), rows[0]["span_id"])
+	require.Equal(t, "test.kind", rows[0]["kind"])
+	require.Equal(t, enums.MetadataScopeRun.String(), rows[0]["scope"])
+	require.Equal(t, false, rows[0]["is_user"])
+	require.Nil(t, rows[0]["step_id"], "run-scoped metadata should have no step_id")
+	require.Nil(t, rows[0]["step_index"])
+	require.Nil(t, rows[0]["step_attempt"])
+
+	values, ok := rows[0]["values"].(map[string]any)
+	require.True(t, ok, "values column should decode to a map, got %T", rows[0]["values"])
+	require.Equal(t, "bar", values["foo"])
+}
+
+// TestListenerOnMetadataEntryWritesStepLevelRow proves step-scoped metadata
+// carries its step_id/step_index/step_attempt columns, matching the
+// reference metadata insights table's own step-level support.
+func TestListenerOnMetadataEntryWritesStepLevelRow(t *testing.T) {
+	db, cleanup := newTestDuckDB(t)
+	defer cleanup()
+	l := NewListener(db, func(o *setupOpts) { o.batchInterval = 20 * time.Millisecond })
+
+	accountID, envID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	runID := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader)
+	md := sv2.Metadata{ID: sv2.ID{
+		RunID:      runID,
+		FunctionID: functionID,
+		Tenant:     sv2.Tenant{AccountID: accountID, EnvID: envID, AppID: appID},
+	}}
+	sv2.InitConfig(&md.Config)
+	parent := tracing.FinalizedStepSpanRefFromMetadataAndStepID(&md, "step-hash-1")
+
+	stepIndex := 2
+	stepAttempt := 1
+	entry := execution.MetadataEntry{
+		AccountID:   accountID,
+		EnvID:       envID,
+		AppID:       appID,
+		FunctionID:  functionID,
+		RunID:       runID,
+		Parent:      parent,
+		Kind:        metadata.Kind("test.kind"),
+		Scope:       enums.MetadataScopeStep,
+		Values:      metadata.Values{"foo": json.RawMessage(`"bar"`)},
+		CreatedAt:   time.Now(),
+		StepID:      "step-hash-1",
+		StepIndex:   &stepIndex,
+		StepAttempt: &stepAttempt,
+	}
+	l.OnMetadataEntry(context.Background(), entry)
+
+	require.Eventually(t, func() bool {
+		var count int
+		row := db.QueryRowContext(context.Background(), "SELECT count(*) FROM inngest.run_metadata;")
+		_ = row.Scan(&count)
+		return count == 1
+	}, 2*time.Second, 20*time.Millisecond, "metadata row should land after a batch flush")
+
+	rows := selectRows(t, db, "SELECT scope, step_id, step_index, step_attempt FROM inngest.run_metadata;")
+	require.Len(t, rows, 1)
+	require.Equal(t, enums.MetadataScopeStep.String(), rows[0]["scope"])
+	require.Equal(t, "step-hash-1", rows[0]["step_id"])
+	require.EqualValues(t, 2, rows[0]["step_index"])
+	require.EqualValues(t, 1, rows[0]["step_attempt"])
 }
 
 // deferScheduleEventJSON builds the raw JSON of an inngest/deferred.schedule

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2324,6 +2324,8 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 				httpTimingMd,
 				enums.MetadataScopeRequest,
 				instance.execSpan,
+				instance.edge.Incoming,
+				nil,
 			)
 			if err != nil {
 				l.Warn("error creating HTTP timing metadata span", "error", err)
@@ -2339,6 +2341,8 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 				timingMd,
 				enums.MetadataScopeRequest,
 				instance.execSpan,
+				instance.edge.Incoming,
+				nil,
 			)
 			if err != nil {
 				l.Warn("error creating timing metadata span", "error", err)
@@ -6214,6 +6218,8 @@ func (e *executor) emitExperimentMetadataFromOpts(ctx context.Context, runCtx ex
 
 func (e *executor) createMetadataSpan(ctx context.Context, runCtx execution.RunContext, location string, md metadata.Structured, scope metadata.Scope, op *state.GeneratorOpcode) (*meta.SpanReference, error) {
 	var parent *meta.SpanReference
+	var stepID string
+	var stepAttempt *int
 
 	runMD := runCtx.Metadata()
 
@@ -6221,8 +6227,11 @@ func (e *executor) createMetadataSpan(ctx context.Context, runCtx execution.RunC
 	case enums.MetadataScopeRun:
 		parent = tracing.RunSpanRefFromMetadata(runMD)
 	case enums.MetadataScopeStep, enums.MetadataScopeStepAttempt:
+		stepID = op.ID
 		if op.Op == enums.OpcodeStepError && IsStepRetryable(op, runCtx) {
-			parent = tracing.RetryStepSpanRefFromMetadataAndStepID(runMD, op.ID, runCtx.AttemptCount())
+			attempt := runCtx.AttemptCount()
+			stepAttempt = &attempt
+			parent = tracing.RetryStepSpanRefFromMetadataAndStepID(runMD, op.ID, attempt)
 		} else {
 			parent = tracing.FinalizedStepSpanRefFromMetadataAndStepID(runMD, op.ID)
 		}
@@ -6232,10 +6241,29 @@ func (e *executor) createMetadataSpan(ctx context.Context, runCtx execution.RunC
 		return nil, fmt.Errorf("unknown metadata scope: %s", sanitizeLogValue(scope.String()))
 	}
 
-	return e.createMetadataSpanOnParent(ctx, runCtx, location, md, scope, parent)
+	return e.createMetadataSpanOnParent(ctx, runCtx, location, md, scope, parent, stepID, stepAttempt)
 }
 
-func (e *executor) createMetadataSpanOnParent(ctx context.Context, runCtx execution.RunContext, location string, md metadata.Structured, scope metadata.Scope, parent *meta.SpanReference) (*meta.SpanReference, error) {
+// createMetadataSpanOnParent creates the metadata span itself. stepID and
+// stepAttempt (both optional -- empty/nil for run-scoped metadata) identify
+// the step this metadata belongs to for dual-write's inngest.run_metadata
+// table (see execution.MetadataEntry), independently of parent, which
+// identifies the span this metadata is attached to (a step's finalized span,
+// its retry span, or a request's execution span) -- the two usually
+// coincide but aren't the same concept: a request-scoped metadata span's
+// parent is the execution span, not the step span, yet it still belongs to
+// a specific step.
+func (e *executor) createMetadataSpanOnParent(ctx context.Context, runCtx execution.RunContext, location string, md metadata.Structured, scope metadata.Scope, parent *meta.SpanReference, stepID string, stepAttempt *int) (*meta.SpanReference, error) {
+	opts := []tracing.MetadataSpanAttrOpts{tracing.WithMetadataSyncListeners(e.syncLifecycles...)}
+	if stepID != "" {
+		opts = append(opts, func(cfg *tracing.MetadataSpanConfig) {
+			meta.AddAttr(cfg.Attrs, meta.Attrs.StepID, &stepID)
+			if stepAttempt != nil {
+				meta.AddAttr(cfg.Attrs, meta.Attrs.StepAttempt, stepAttempt)
+			}
+		})
+	}
+
 	ref, err := tracing.CreateMetadataSpan(
 		ctx,
 		e.tracerProvider,
@@ -6245,6 +6273,7 @@ func (e *executor) createMetadataSpanOnParent(ctx context.Context, runCtx execut
 		runCtx.Metadata(),
 		md,
 		scope,
+		opts...,
 	)
 	if err != nil {
 		if errors.Is(err, metadata.ErrMetadataSpanTooLarge) {

--- a/pkg/execution/sync_lifecycle.go
+++ b/pkg/execution/sync_lifecycle.go
@@ -13,6 +13,7 @@ import (
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -249,6 +250,54 @@ type SyncLifecycleListener interface {
 	// span is historical, reported after the fact via OTLP), so there's
 	// nothing here that would need the caller's clock read.
 	OnExtendedTraceSpan(ctx context.Context, span ExtendedTraceSpan)
+
+	// OnMetadataEntry is called synchronously after a metadata span is
+	// created -- from the executor (generator/experiment metadata) or the
+	// REST API (AddRunMetadata, userland span metadata extraction; see
+	// pkg/tracing.CreateMetadataSpanFromValues, the single chokepoint every
+	// caller funnels through). Like OnExtendedTraceSpan, there is no
+	// statev2.Metadata guaranteed at every call site (userland span metadata
+	// extraction has none), so identifiers are carried individually, and
+	// there is no "now" parameter since entry.CreatedAt already pins the
+	// moment.
+	OnMetadataEntry(ctx context.Context, entry MetadataEntry)
+}
+
+// MetadataEntry carries everything OnMetadataEntry needs to record one
+// metadata emission -- unlike ExtendedTraceSpan, it isn't itself a span:
+// dual-write never creates an OTel span for it (see
+// dualwrite.listener.OnMetadataEntry), only a row in a standalone table.
+// Parent is the run/step/request span this metadata annotates -- its own
+// span ID (recoverable via tracing.SpanContextFromMetadata, the same helper
+// the real TracerProvider uses) is the join key onto
+// inngest.run_trace_spans.span_id. Op (metadata.Opcode --
+// merge/set/delete/add) is deliberately not carried here: this dual-write
+// path stores each emission as a standalone row and leaves later readers to
+// collapse to the latest one per (run_id, span_id, kind), rather than
+// replicating the production pipeline's per-key, op-aware fragment folding.
+type MetadataEntry struct {
+	AccountID  uuid.UUID
+	EnvID      uuid.UUID
+	AppID      uuid.UUID
+	FunctionID uuid.UUID
+	RunID      ulid.ULID
+	Parent     *meta.SpanReference
+	Kind       metadata.Kind
+	Scope      metadata.Scope
+	Values     metadata.Values
+	CreatedAt  time.Time
+
+	// StepID/StepIndex/StepAttempt identify the step this metadata belongs
+	// to, independently of Parent (which identifies the span this metadata
+	// is attached to -- a request-scoped metadata span's Parent is the
+	// request's execution span, not the step span, but it still belongs to
+	// a step). All three are empty/nil for run-scoped metadata. StepID is
+	// the same hashed step ID used to compute a step's own deterministic
+	// span identity (see tracing.FinalizedStepSpanRefFromMetadataAndStepID),
+	// not the SDK-facing userland step ID.
+	StepID      string
+	StepIndex   *int
+	StepAttempt *int
 }
 
 // ExtendedTraceSpan carries everything OnExtendedTraceSpan needs to record a
@@ -338,3 +387,5 @@ func (NoopSyncLifecycleListener) OnDeferAbort(context.Context, statev2.Metadata,
 }
 
 func (NoopSyncLifecycleListener) OnExtendedTraceSpan(context.Context, ExtendedTraceSpan) {}
+
+func (NoopSyncLifecycleListener) OnMetadataEntry(context.Context, MetadataEntry) {}

--- a/pkg/tracing/metadata.go
+++ b/pkg/tracing/metadata.go
@@ -3,19 +3,38 @@ package tracing
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/execution"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
+	"github.com/oklog/ulid/v2"
 )
 
 type MetadataSpanAttrOpts func(cfg *MetadataSpanConfig)
 
 type MetadataSpanConfig struct {
 	Attrs *meta.SerializableAttrs
+
+	// SyncListeners are notified synchronously, via OnMetadataEntry, right
+	// after this span is created -- mirroring
+	// execution.SyncLifecycleListener's dual-write hooks for run/step/
+	// userland spans (see pkg/execution/dualwrite). Nil/empty is a no-op;
+	// only a caller wiring DuckDB dual-write sets this today.
+	SyncListeners []execution.SyncLifecycleListener
+}
+
+// WithMetadataSyncListeners registers listeners to notify synchronously
+// after a metadata span is created -- see MetadataSpanConfig.SyncListeners.
+func WithMetadataSyncListeners(ls ...execution.SyncLifecycleListener) MetadataSpanAttrOpts {
+	return func(cfg *MetadataSpanConfig) {
+		cfg.SyncListeners = append(cfg.SyncListeners, ls...)
+	}
 }
 
 func CreateMetadataSpan(ctx context.Context, tracerProvider TracerProvider, parent *meta.SpanReference, location, pkgName string, stateMetadata *statev2.Metadata, spanMetadata metadata.Structured, scope metadata.Scope, opts ...MetadataSpanAttrOpts) (*meta.SpanReference, error) {
@@ -101,7 +120,79 @@ func CreateMetadataSpanFromValues(ctx context.Context, tracerProvider TracerProv
 		return nil, err
 	}
 
+	if len(cfg.SyncListeners) > 0 {
+		if entry, ok := buildSyncMetadataEntry(cfg.Attrs, parent, stateMetadata, kind, scope, values); ok {
+			for _, l := range cfg.SyncListeners {
+				l.OnMetadataEntry(ctx, entry)
+			}
+		} else {
+			logger.StdlibLogger(ctx).Error("tracing: metadata span sync dispatch missing run ID", "location", location, "kind", kind.String())
+		}
+	}
+
 	return ref, nil
+}
+
+// buildSyncMetadataEntry assembles an execution.MetadataEntry for
+// OnMetadataEntry from the same inputs CreateMetadataSpanFromValues already
+// has -- tenant/run identity comes from stateMetadata when the caller
+// provided one (the executor and AddRunMetadata always do), falling back to
+// attrs (already resolved by the time this runs, regardless of whether the
+// caller set them via stateMetadata or an option like addTenantIDs) for the
+// one call site that has neither (pkg/api/apiv1/traces.go's
+// commitSpanMetadata). ok is false when neither source yields a run ID,
+// since a row with no run ID can't be joined onto anything.
+func buildSyncMetadataEntry(attrs *meta.SerializableAttrs, parent *meta.SpanReference, stateMetadata *statev2.Metadata, kind metadata.Kind, scope metadata.Scope, values metadata.Values) (execution.MetadataEntry, bool) {
+	entry := execution.MetadataEntry{
+		Parent:    parent,
+		Kind:      kind,
+		Scope:     scope,
+		Values:    values,
+		CreatedAt: time.Now(),
+	}
+
+	if stateMetadata != nil {
+		entry.AccountID = stateMetadata.ID.Tenant.AccountID
+		entry.EnvID = stateMetadata.ID.Tenant.EnvID
+		entry.AppID = stateMetadata.ID.Tenant.AppID
+		entry.FunctionID = stateMetadata.ID.FunctionID
+		entry.RunID = stateMetadata.ID.RunID
+	} else {
+		if v, ok := meta.GetAttr(attrs, meta.Attrs.AccountID); ok && v != nil {
+			entry.AccountID = *v
+		}
+		if v, ok := meta.GetAttr(attrs, meta.Attrs.EnvID); ok && v != nil {
+			entry.EnvID = *v
+		}
+		if v, ok := meta.GetAttr(attrs, meta.Attrs.AppID); ok && v != nil {
+			entry.AppID = *v
+		}
+		if v, ok := meta.GetAttr(attrs, meta.Attrs.FunctionID); ok && v != nil {
+			entry.FunctionID = *v
+		}
+		v, ok := meta.GetAttr(attrs, meta.Attrs.RunID)
+		if !ok || v == nil || *v == (ulid.ULID{}) {
+			return execution.MetadataEntry{}, false
+		}
+		entry.RunID = *v
+	}
+
+	// Step identity is carried on attrs regardless of whether stateMetadata
+	// is set -- every caller that knows it's operating on a step adds it via
+	// a MetadataSpanAttrOpts (e.g. the executor's createMetadataSpanOnParent,
+	// apiv1/metadata.go's addTenantIDs), independently of tenant/run
+	// identity's source above.
+	if v, ok := meta.GetAttr(attrs, meta.Attrs.StepID); ok && v != nil {
+		entry.StepID = *v
+	}
+	if v, ok := meta.GetAttr(attrs, meta.Attrs.StepUserlandIndex); ok && v != nil {
+		entry.StepIndex = v
+	}
+	if v, ok := meta.GetAttr(attrs, meta.Attrs.StepAttempt); ok && v != nil {
+		entry.StepAttempt = v
+	}
+
+	return entry, true
 }
 
 func RawMetadataAttrs(kind metadata.Kind, values metadata.Values, op metadata.Opcode) *meta.SerializableAttrs {

--- a/pkg/tracing/metadata_test.go
+++ b/pkg/tracing/metadata_test.go
@@ -2,18 +2,33 @@ package tracing
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 )
+
+// recordingMetadataListener implements execution.SyncLifecycleListener,
+// recording every OnMetadataEntry call for assertions.
+type recordingMetadataListener struct {
+	execution.NoopSyncLifecycleListener
+	entries []execution.MetadataEntry
+}
+
+func (r *recordingMetadataListener) OnMetadataEntry(ctx context.Context, entry execution.MetadataEntry) {
+	r.entries = append(r.entries, entry)
+}
 
 // mockStructured implements metadata.Structured with configurable behavior.
 type mockStructured struct {
@@ -176,4 +191,132 @@ func TestCreateMetadataSpanFromValues_CumulativeIncrementAcrossMultipleSpans(t *
 	// Delta should be the first span only
 	delta := stateMd.Metrics.MetadataSize - stateMd.Metrics.MetadataSizeLoaded
 	require.Equal(t, spanSize, delta)
+}
+
+func TestCreateMetadataSpanFromValues_NotifiesSyncListenersWithStateMetadata(t *testing.T) {
+	tp := NewNoopTracerProvider()
+	rec := &recordingMetadataListener{}
+
+	accountID, envID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+	stateMd := &statev2.Metadata{ID: statev2.ID{
+		RunID:      runID,
+		FunctionID: functionID,
+		Tenant:     statev2.Tenant{AccountID: accountID, EnvID: envID, AppID: appID},
+	}}
+
+	values := metadata.Values{"foo": json.RawMessage(`"bar"`)}
+	ref, err := CreateMetadataSpanFromValues(
+		context.Background(), tp, &meta.SpanReference{},
+		"test.location", "test", stateMd,
+		"test.kind", enums.MetadataOpcodeMerge, values, enums.MetadataScopeStep,
+		WithMetadataSyncListeners(rec),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+	require.Len(t, rec.entries, 1)
+
+	got := rec.entries[0]
+	require.Equal(t, accountID, got.AccountID)
+	require.Equal(t, envID, got.EnvID)
+	require.Equal(t, appID, got.AppID)
+	require.Equal(t, functionID, got.FunctionID)
+	require.Equal(t, runID, got.RunID)
+	require.Equal(t, metadata.Kind("test.kind"), got.Kind)
+	require.Equal(t, enums.MetadataScopeStep, got.Scope)
+	require.Equal(t, values, got.Values)
+}
+
+// TestCreateMetadataSpanFromValues_NotifiesSyncListenersWithStepIdentity
+// proves step identity (added via an attrs option, mirroring
+// pkg/execution/executor's createMetadataSpanOnParent) is picked up
+// alongside stateMetadata-sourced tenant/run identity -- the two are
+// populated independently in buildSyncMetadataEntry.
+func TestCreateMetadataSpanFromValues_NotifiesSyncListenersWithStepIdentity(t *testing.T) {
+	tp := NewNoopTracerProvider()
+	rec := &recordingMetadataListener{}
+
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+	stateMd := &statev2.Metadata{ID: statev2.ID{RunID: runID}}
+
+	stepID := "step-hash-1"
+	stepAttempt := 2
+	withStepIdentity := func(cfg *MetadataSpanConfig) {
+		meta.AddAttr(cfg.Attrs, meta.Attrs.StepID, &stepID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.StepAttempt, &stepAttempt)
+	}
+
+	values := metadata.Values{"foo": json.RawMessage(`"bar"`)}
+	ref, err := CreateMetadataSpanFromValues(
+		context.Background(), tp, &meta.SpanReference{},
+		"test.location", "test", stateMd,
+		"test.kind", enums.MetadataOpcodeMerge, values, enums.MetadataScopeStep,
+		withStepIdentity,
+		WithMetadataSyncListeners(rec),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+	require.Len(t, rec.entries, 1)
+
+	got := rec.entries[0]
+	require.Equal(t, runID, got.RunID)
+	require.Equal(t, stepID, got.StepID)
+	require.NotNil(t, got.StepAttempt)
+	require.Equal(t, stepAttempt, *got.StepAttempt)
+	require.Nil(t, got.StepIndex)
+}
+
+// TestCreateMetadataSpanFromValues_NotifiesSyncListenersFromAttrsWhenStateMetadataNil
+// proves the fallback path buildSyncMetadataEntry needs for
+// pkg/api/apiv1/traces.go's commitSpanMetadata, the one caller with no
+// statev2.Metadata at all -- identity there arrives only via an attrs-set
+// option (addTenantIDs), mimicked here.
+func TestCreateMetadataSpanFromValues_NotifiesSyncListenersFromAttrsWhenStateMetadataNil(t *testing.T) {
+	tp := NewNoopTracerProvider()
+	rec := &recordingMetadataListener{}
+
+	accountID, envID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	addTenantIDs := func(cfg *MetadataSpanConfig) {
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, &accountID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, &envID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &appID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &functionID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &runID)
+	}
+
+	values := metadata.Values{"foo": json.RawMessage(`"bar"`)}
+	ref, err := CreateMetadataSpanFromValues(
+		context.Background(), tp, &meta.SpanReference{},
+		"test.location", "test", nil,
+		"test.kind", enums.MetadataOpcodeMerge, values, enums.MetadataScopeExtendedTrace,
+		addTenantIDs,
+		WithMetadataSyncListeners(rec),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+	require.Len(t, rec.entries, 1)
+	require.Equal(t, runID, rec.entries[0].RunID)
+	require.Equal(t, accountID, rec.entries[0].AccountID)
+}
+
+// TestCreateMetadataSpanFromValues_SkipsSyncListenersWithNoRunID proves a
+// missing run ID (neither stateMetadata nor attrs supply one) is a no-op,
+// not a panic or a garbage row -- there's nothing for such a row to join
+// onto.
+func TestCreateMetadataSpanFromValues_SkipsSyncListenersWithNoRunID(t *testing.T) {
+	tp := NewNoopTracerProvider()
+	rec := &recordingMetadataListener{}
+
+	values := metadata.Values{"foo": json.RawMessage(`"bar"`)}
+	ref, err := CreateMetadataSpanFromValues(
+		context.Background(), tp, &meta.SpanReference{},
+		"test.location", "test", nil,
+		"test.kind", enums.MetadataOpcodeMerge, values, enums.MetadataScopeExtendedTrace,
+		WithMetadataSyncListeners(rec),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, ref)
+	require.Empty(t, rec.entries)
 }


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This adds support for span metadata to the new duckdb data layer

closes EXE-2194

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
