### PR TITLE
fix(api): normalize unknown REST v2 body field errors

### DIFF
--- a/pkg/api/v2/enum_json.go
+++ b/pkg/api/v2/enum_json.go
@@ -3,12 +3,17 @@ package apiv2
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
 	"google.golang.org/protobuf/proto"
 )
+
+var unknownProtoJSONFieldRegexp = regexp.MustCompile(`unknown field "([^"]+)"`)
 
 var responseEnumPrefixes = []string{
 	"APP_METHOD_",
@@ -75,6 +80,40 @@ func (m responseEnumMarshaler) NewEncoder(w io.Writer) runtime.Encoder {
 		_, err = w.Write(m.Delimiter())
 		return err
 	})
+}
+
+// NewDecoder preserves grpc-gateway's default protobuf JSON decoding while
+// translating unknown-field errors into REST v2's structured error format.
+func (m responseEnumMarshaler) NewDecoder(r io.Reader) runtime.Decoder {
+	return requestBodyDecoder{Decoder: m.JSONPb.NewDecoder(r)}
+}
+
+type requestBodyDecoder struct {
+	runtime.Decoder
+}
+
+func (d requestBodyDecoder) Decode(v any) error {
+	err := d.Decoder.Decode(v)
+	if err == nil {
+		return nil
+	}
+	if match := unknownProtoJSONFieldRegexp.FindStringSubmatch(err.Error()); len(match) == 2 {
+		return unexpectedRequestBodyFieldError{field: match[1]}
+	}
+	return err
+}
+
+type unexpectedRequestBodyFieldError struct {
+	field string
+}
+
+func (e unexpectedRequestBodyFieldError) Error() string {
+	response := apiv2base.ErrorResponse{Errors: []apiv2base.ErrorItem{{
+		Code:    apiv2base.ErrorInvalidRequest,
+		Message: fmt.Sprintf("Unexpected request body field %q", e.field),
+	}}}
+	data, _ := json.Marshal(response)
+	return string(data)
 }
 
 func shortenResponseEnumNames(data []byte) ([]byte, error) {

--- a/pkg/api/v2/enum_json.go
+++ b/pkg/api/v2/enum_json.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -37,7 +38,9 @@ func newResponseEnumMarshaler() runtime.Marshaler {
 }
 
 func NewResponseEnumMarshaler() runtime.Marshaler {
-	return responseEnumMarshaler{JSONPb: &runtime.JSONPb{}}
+	return responseEnumMarshaler{JSONPb: &runtime.JSONPb{
+		UnmarshalOptions: protojson.UnmarshalOptions{DiscardUnknown: false},
+	}}
 }
 
 func (responseEnumMarshaler) StreamContentType(any) string {

--- a/pkg/api/v2/http_test.go
+++ b/pkg/api/v2/http_test.go
@@ -98,6 +98,49 @@ func TestHTTPGateway_Health(t *testing.T) {
 	})
 }
 
+func TestHTTPGateway_RejectsUnexpectedRequestBodyFields(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		path string
+		body string
+	}{
+		{
+			name: "top-level field",
+			path: "/api/v2/envs",
+			body: `{"name":"test","unexpected":"secret-value"}`,
+		},
+		{
+			name: "nested field",
+			path: "/api/v2/runs/01hp1zx8m3ng9vp6qn0xk7j4cy/rerun",
+			body: `{"fromStep":{"stepId":"step-1","unexpected":"secret-value"}}`,
+		},
+		{
+			name: "field-specific body binding",
+			path: "/api/v2/runs/01hp1zx8m3ng9vp6qn0xk7j4cy/scores",
+			body: `[{"name":"accuracy","value":0.5,"unexpected":"secret-value"}]`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			handler, err := newTestHTTPHandler(t.Context(), ServiceOptions{}, HTTPHandlerOptions{})
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, test.path, strings.NewReader(test.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusBadRequest, rec.Code)
+			var body errorResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+			require.Equal(t, []errorItem{{
+				Code:    apiv2base.ErrorInvalidRequest,
+				Message: `Unexpected request body field "unexpected"`,
+			}}, body.Errors)
+			require.NotContains(t, rec.Body.String(), "secret-value")
+		})
+	}
+}
+
 func TestHTTPGateway_SandboxesNotImplementedInDevServer(t *testing.T) {
 	handler, err := newTestHTTPHandler(context.Background(), ServiceOptions{}, HTTPHandlerOptions{})
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

grpc-gateway’s protobuf JSON decoder already rejects unknown fields in declared request bodies, but REST v2 previously returned the underlying protobuf diagnostic:

```text
proto: ... unknown field "scootyPuffJr"
```

This change translates that decoding failure into the REST v2 error response matching other errors:

```json
{
  "errors": [{
    "code": "invalid_request",
    "message": "Unexpected request body field \"scootyPuffJr\""
  }]
}
```

This does not make request body decoding stricter yet. It only changes how existing unknown-field errors are presented. However, we are explicitly setting the `DiscardUnknown` option so we aren't getting the zero value by chance.

## Release note

REST v2 now returns a clear `invalid_request` error when a JSON request body contains a field unsupported by the server.

## Migration note

None