### PR TITLE
fix(semaphores):  improve semaphore iteration, breaking early, etc

### DIFF
--- a/pkg/constraintapi/config.go
+++ b/pkg/constraintapi/config.go
@@ -22,6 +22,10 @@ type Semaphore struct {
 	Release SemaphoreReleaseMode `json:"r"`
 }
 
+func (s Semaphore) Kind() SemaphoreKind {
+	return semaphoreKind(s.ID)
+}
+
 // AutoReleaseSemaphores returns only auto-release semaphores from a slice.
 // Used to add worker concurrency semaphores to every queue item (not just start).
 func AutoReleaseSemaphores(sems []Semaphore) []Semaphore {

--- a/pkg/constraintapi/semaphore.go
+++ b/pkg/constraintapi/semaphore.go
@@ -19,6 +19,16 @@ const (
 	SemaphoreReleaseManual SemaphoreReleaseMode = 1
 )
 
+type SemaphoreKind int
+
+const (
+	SemaphoreKindUnknown  SemaphoreKind = 0
+	SemaphoreKindAccount  SemaphoreKind = 1
+	SemaphoreKindApp      SemaphoreKind = 2
+	SemaphoreKindFunction SemaphoreKind = 3
+	SemaphoreKindFnKey    SemaphoreKind = 4
+)
+
 // SemaphoreIDApp returns the semaphore ID for worker concurrency (per-app).
 func SemaphoreIDApp(appID uuid.UUID) string {
 	return fmt.Sprintf("app:%s", appID)
@@ -33,6 +43,20 @@ func SemaphoreIDFn(functionID uuid.UUID) string {
 // The ID is a hash of the function ID + the raw (unevaluated) expression.
 func SemaphoreIDFnKey(functionID uuid.UUID, expression string) string {
 	return fmt.Sprintf("fnkey:%s", util.XXHash(functionID.String()+expression))
+}
+
+func semaphoreKind(id string) SemaphoreKind {
+	if len(id) > 3 {
+		switch id[0:3] {
+		case "app":
+			return SemaphoreKindApp
+		case "fn:":
+			return SemaphoreKindFunction
+		case "fnk":
+			return SemaphoreKindFnKey
+		}
+	}
+	return SemaphoreKindUnknown
 }
 
 // SemaphoreConstraint represents a semaphore-based capacity constraint.
@@ -54,6 +78,10 @@ type SemaphoreConstraint struct {
 
 	// Release controls when the semaphore counter is decremented.
 	Release SemaphoreReleaseMode
+}
+
+func (s SemaphoreConstraint) Kind() SemaphoreKind {
+	return semaphoreKind(s.ID)
 }
 
 func (s *SemaphoreConstraint) UsageKey(accountID uuid.UUID) string {

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -174,6 +174,10 @@ type ItemLeaseConstraintCheckResult struct {
 	LimitingConstraint enums.QueueConstraint
 
 	RetryAfter time.Time
+
+	// ExhaustedSemaphores lists the semaphores that had no capacity when no
+	// lease was granted.  empty when a lease was granted.
+	ExhaustedSemaphores []constraintapi.SemaphoreConstraint
 }
 
 func ConstraintConfigFromConstraints(
@@ -572,8 +576,9 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 		span.SetAttributes(attribute.Bool("constrained", true))
 
 		return ItemLeaseConstraintCheckResult{
-			LimitingConstraint: constraint,
-			RetryAfter:         res.RetryAfter,
+			LimitingConstraint:  constraint,
+			RetryAfter:          res.RetryAfter,
+			ExhaustedSemaphores: exhaustedSemaphores(res.ExhaustedConstraints),
 		}, nil
 	}
 
@@ -587,6 +592,31 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 			IssuedAtMS: now.UnixMilli(),
 		},
 	}, nil
+}
+
+// exhaustedSemaphores returns the semaphore constraints in the given exhausted
+// constraint list.
+func exhaustedSemaphores(exhausted []constraintapi.ConstraintItem) []constraintapi.SemaphoreConstraint {
+	var sems []constraintapi.SemaphoreConstraint
+	for _, ci := range exhausted {
+		if ci.Kind != constraintapi.ConstraintKindSemaphore || ci.Semaphore == nil {
+			continue
+		}
+		sems = append(sems, *ci.Semaphore)
+	}
+	return sems
+}
+
+// hasAppSemaphore reports whether any of the given semaphores is an app worker
+// concurrency semaphore.  every item of a connect app carries the app semaphore,
+// so one exhausted app semaphore blocks the whole partition.
+func hasAppSemaphore(sems []constraintapi.SemaphoreConstraint) bool {
+	for _, s := range sems {
+		if s.Kind() == constraintapi.SemaphoreKindApp {
+			return true
+		}
+	}
+	return false
 }
 
 func (q *queueProcessor) hasReusableCapacityLease(item *QueueItem, now time.Time) bool {

--- a/pkg/execution/queue/errors.go
+++ b/pkg/execution/queue/errors.go
@@ -92,8 +92,9 @@ var (
 	ErrConcurrencyLimitCustomKey = fmt.Errorf("at concurrency limit")
 
 	// ErrSemaphoreLimit represents a semaphore capacity limit for a specific queue item.
-	// Unlike partition/account limits, this is per-item (only start jobs carry semaphores),
-	// so the iterator should skip the item and continue scanning.
+	// app semaphores are on every item of a connect app, so the iterator stops on the
+	// first hit.  fn and fnkey semaphores are only on start items, so the iterator skips
+	// the item and keeps scanning.
 	ErrSemaphoreLimit = fmt.Errorf("at semaphore capacity limit")
 )
 

--- a/pkg/execution/queue/lease_item.go
+++ b/pkg/execution/queue/lease_item.go
@@ -369,14 +369,33 @@ func (q *queueProcessor) LeaseItem(ctx context.Context, req LeaseItemRequest, di
 		}
 		return LeaseItemResult{Status: LeaseItemStatusCustomConcurrencyLimited, RetryAfter: limitedRetryAfter}, nil
 	case errors.Is(cause, ErrSemaphoreLimit):
-		// Semaphore capacity exhausted for this specific item (e.g., start job with fn concurrency).
-		// Skip this item and continue scanning; other items without semaphores (step 2, etc.)
-		// can still be processed.
+		result := LeaseItemResult{
+			Status:              LeaseItemStatusSemaphoreLimited,
+			RetryAfter:          limitedRetryAfter,
+			ExhaustedSemaphores: constraintRes.ExhaustedSemaphores,
+		}
+		appLimited := hasAppSemaphore(constraintRes.ExhaustedSemaphores)
+
 		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
 			PkgName: pkgName,
-			Tags:    map[string]any{"status": "semaphore_limit", "queue_shard": q.Shard().Name(), "constraint_source": "constraintapi"},
+			Tags: map[string]any{
+				"status":            "semaphore_limit",
+				"queue_shard":       q.Shard().Name(),
+				"constraint_source": "constraintapi",
+				"app_semaphore":     appLimited,
+			},
 		})
-		return LeaseItemResult{Status: LeaseItemStatusSemaphoreLimited, RetryAfter: limitedRetryAfter}, nil
+
+		if appLimited {
+			// a partition is one function and a function belongs to one app, so every
+			// remaining item carries this exhausted app semaphore.  stop the iterator
+			// the same way fn concurrency does instead of checking each item.
+			return result, fmt.Errorf("semaphore hit: %w", ErrProcessNoUserConstraintCapacity)
+		}
+
+		// fn and fnkey semaphores are only on start items.  later steps of runs that
+		// already hold the semaphore carry none, so keep scanning.
+		return result, nil
 	case errors.Is(cause, ErrQueueItemNotFound):
 		// This is an okay error.  Move to the next job item.
 		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -353,6 +353,13 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 			requeue = q.SemaphoreRequeueExtension()
 		}
 
+		if iter.CtrSuccess.Load() == 0 {
+			// nothing was dispatched, so no completion will re-add this partition as
+			// a continuation.  drop any existing continuation, otherwise the next tick
+			// re-processes the partition and ignores the forced requeue below.
+			q.removeContinue(ctx, p, false)
+		}
+
 		// Requeue this partition as we hit concurrency limits.
 		metrics.IncrQueuePartitionConcurrencyLimitCounter(ctx, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": shard.Name()}})
 		err = shard.PartitionRequeue(ctx, p, q.Clock().Now().Truncate(time.Second).Add(requeue), true)

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -3,10 +3,13 @@ package queue
 import (
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/inngest/inngest/pkg/constraintapi"
 	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -58,6 +61,49 @@ type ProcessorIterator struct {
 	// When true, we use a shorter partition requeue delay since semaphore-blocked items stay in
 	// the ready queue and can be picked up quickly once capacity is freed.
 	IsSemaphoreLimitOnly atomic.Bool
+
+	// exhaustedSemaphores holds the semaphores seen exhausted in this pass, keyed by
+	// id and evaluated key hash.  later items that have one of them are limited
+	// without another constraint API call, speeding up iteration
+	exhaustedSemaphores   map[string]struct{}
+	exhaustedSemaphoresMu sync.Mutex
+}
+
+func semaphoreMemoKey(id, evaluatedKeyHash string) string {
+	return id + ":" + evaluatedKeyHash
+}
+
+func (p *ProcessorIterator) rememberExhaustedSemaphores(sems []constraintapi.SemaphoreConstraint) {
+	if len(sems) == 0 {
+		return
+	}
+	p.exhaustedSemaphoresMu.Lock()
+	defer p.exhaustedSemaphoresMu.Unlock()
+	if p.exhaustedSemaphores == nil {
+		p.exhaustedSemaphores = make(map[string]struct{}, len(sems))
+	}
+	for _, s := range sems {
+		p.exhaustedSemaphores[semaphoreMemoKey(s.ID, s.EvaluatedKeyHash)] = struct{}{}
+	}
+}
+
+// semaphoreExhausted reports whether the item carries a semaphore that was already
+// seen exhausted in this pass.
+func (p *ProcessorIterator) semaphoreExhausted(item *QueueItem) bool {
+	if len(item.Data.Semaphores) == 0 {
+		return false
+	}
+	p.exhaustedSemaphoresMu.Lock()
+	defer p.exhaustedSemaphoresMu.Unlock()
+	if len(p.exhaustedSemaphores) == 0 {
+		return false
+	}
+	for _, s := range item.Data.Semaphores {
+		if _, ok := p.exhaustedSemaphores[semaphoreMemoKey(s.ID, s.EvaluatedKeyHash)]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *ProcessorIterator) Iterate(ctx context.Context) error {
@@ -186,6 +232,19 @@ func (p *ProcessorIterator) LeaseItem(ctx context.Context, item *QueueItem) erro
 		}
 	}
 
+	if p.semaphoreExhausted(item) {
+		shardName := ""
+		if shard := p.Queue.Shard(); shard != nil {
+			shardName = shard.Name()
+		}
+		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags:    map[string]any{"status": "semaphore_limit", "queue_shard": shardName, "constraint_source": "memo"},
+		})
+		p.applyLeaseItemResult(LeaseItemResult{Status: LeaseItemStatusSemaphoreLimited})
+		return nil
+	}
+
 	priority := uint(0)
 	if opts := p.Queue.Options(); opts != nil {
 		priority = opts.PartitionPriorityFinder(ctx, *p.Partition)
@@ -203,6 +262,7 @@ func (p *ProcessorIterator) LeaseItem(ctx context.Context, item *QueueItem) erro
 		EarliestPeekTimeFallbackMS: earliestPeekTimeFallbackMS,
 		StaticTime:                 p.StaticTime,
 	}, p.Dispatch)
+	p.rememberExhaustedSemaphores(result.ExhaustedSemaphores)
 	p.applyLeaseItemResult(result)
 	return err
 }

--- a/pkg/execution/queue/processor_iterator_semaphore_test.go
+++ b/pkg/execution/queue/processor_iterator_semaphore_test.go
@@ -1,0 +1,177 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/constraintapi"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/util"
+	"github.com/jonboulle/clockwork"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func semaphoreTestItem(accountID, envID, fnID uuid.UUID, at time.Time, sems ...constraintapi.Semaphore) *QueueItem {
+	return &QueueItem{
+		ID:          ulid.Make().String(),
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		AtMS:        at.UnixMilli(),
+		Data: Item{
+			Kind: KindEdge,
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				RunID:       ulid.Make(),
+			},
+			Semaphores: sems,
+		},
+	}
+}
+
+// semaphoreLeaser mimics queueProcessor.LeaseItem for items whose semaphores are
+// in exhausted.  an exhausted app semaphore stops the iterator, an exhausted fn
+// semaphore skips the item, anything else is dispatched.
+func semaphoreLeaser(exhausted map[string]constraintapi.SemaphoreConstraint, calls *int32) QueueItemLeaser {
+	return mockQueueItemLeaser{
+		fn: func(ctx context.Context, req LeaseItemRequest, dispatch DispatchFunc) (LeaseItemResult, error) {
+			atomic.AddInt32(calls, 1)
+
+			var hit []constraintapi.SemaphoreConstraint
+			for _, s := range req.Item.Data.Semaphores {
+				if c, ok := exhausted[semaphoreMemoKey(s.ID, s.EvaluatedKeyHash)]; ok {
+					hit = append(hit, c)
+				}
+			}
+			if len(hit) > 0 {
+				res := LeaseItemResult{Status: LeaseItemStatusSemaphoreLimited, ExhaustedSemaphores: hit}
+				if hasAppSemaphore(hit) {
+					return res, fmt.Errorf("semaphore hit: %w", ErrProcessNoUserConstraintCapacity)
+				}
+				return res, nil
+			}
+
+			_, err := dispatch(ctx, ProcessItem{I: *req.Item})
+			return LeaseItemResult{Status: LeaseItemStatusDispatched}, err
+		},
+	}
+}
+
+func TestProcessorIteratorStopsOnExhaustedAppSemaphore(t *testing.T) {
+	ctx := context.Background()
+
+	accountID, envID, fnID, appID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	at := time.Now().Add(-time.Minute).Truncate(time.Millisecond)
+
+	appSem := constraintapi.Semaphore{ID: constraintapi.SemaphoreIDApp(appID), Weight: 1}
+	appConstraint := constraintapi.SemaphoreConstraint{ID: appSem.ID, Weight: 1}
+	require.Equal(t, constraintapi.SemaphoreKindApp, appConstraint.Kind())
+
+	shard := &mockShardForIterator{name: "test-shard"}
+	opts := NewQueueOptions()
+	WithQueueItemEarliestPeekTimeEnabled(func(ctx context.Context, shardName string, acctID, gotEnvID, gotFnID uuid.UUID) QueueItemEarliestPeekTimeConfig {
+		return QueueItemEarliestPeekTimeConfig{Enabled: true, BulkStampLimit: 100}
+	})(opts)
+
+	mockProc := &mockQueueProcessor{
+		shard:     shard,
+		clock:     clockwork.NewRealClock(),
+		sem:       util.NewTrackingSemaphore(10),
+		workers:   make(chan ProcessItem, 10),
+		shadowMap: make(map[string]ShadowContinuation),
+		opts:      opts,
+	}
+
+	items := make([]*QueueItem, 5)
+	for i := range items {
+		items[i] = semaphoreTestItem(accountID, envID, fnID, at, appSem)
+	}
+
+	var calls int32
+	iter := ProcessorIterator{
+		Partition: &QueuePartition{ID: fnID.String(), AccountID: accountID, EnvID: &envID, FunctionID: &fnID},
+		Items:     items,
+		Queue:     mockProc,
+		Leaser: semaphoreLeaser(map[string]constraintapi.SemaphoreConstraint{
+			semaphoreMemoKey(appSem.ID, appSem.EvaluatedKeyHash): appConstraint,
+		}, &calls),
+		Dispatch: func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
+			mockProc.workers <- item
+			return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
+		},
+		StaticTime: at.Add(2 * time.Second),
+	}
+
+	require.NoError(t, iter.Iterate(ctx))
+
+	// the first item stops the pass.  no other item reaches the leaser.
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+	require.Equal(t, int32(1), iter.CtrConcurrency.Load())
+	require.Equal(t, int32(0), iter.CtrSuccess.Load())
+	require.True(t, iter.IsSemaphoreLimitOnly.Load())
+	require.True(t, iter.IsRequeuable())
+
+	// the remaining four items are bulk stamped like a concurrency limit.
+	require.Equal(t, int32(4), atomic.LoadInt32(&shard.earliestPeekTimeCalls))
+}
+
+func TestProcessorIteratorMemoizesExhaustedFnSemaphores(t *testing.T) {
+	ctx := context.Background()
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	at := time.Now().Add(-time.Minute).Truncate(time.Millisecond)
+
+	keyed := constraintapi.SemaphoreIDFnKey(fnID, "event.data.customer")
+	semA := constraintapi.Semaphore{ID: keyed, EvaluatedKeyHash: "a", Weight: 1, Release: constraintapi.SemaphoreReleaseManual}
+	semB := constraintapi.Semaphore{ID: keyed, EvaluatedKeyHash: "b", Weight: 1, Release: constraintapi.SemaphoreReleaseManual}
+	exhaustedA := constraintapi.SemaphoreConstraint{ID: semA.ID, EvaluatedKeyHash: semA.EvaluatedKeyHash, Weight: 1, Release: semA.Release}
+	require.Equal(t, constraintapi.SemaphoreKindFnKey, exhaustedA.Kind())
+
+	shard := &mockShardForIterator{name: "test-shard"}
+	mockProc := &mockQueueProcessor{
+		shard:     shard,
+		clock:     clockwork.NewRealClock(),
+		sem:       util.NewTrackingSemaphore(10),
+		workers:   make(chan ProcessItem, 10),
+		shadowMap: make(map[string]ShadowContinuation),
+		opts:      NewQueueOptions(),
+	}
+
+	items := []*QueueItem{
+		semaphoreTestItem(accountID, envID, fnID, at, semA), // exhausted, one round trip
+		semaphoreTestItem(accountID, envID, fnID, at),       // no semaphore, dispatched
+		semaphoreTestItem(accountID, envID, fnID, at, semA), // memo hit, no round trip
+		semaphoreTestItem(accountID, envID, fnID, at, semB), // other key, dispatched
+		semaphoreTestItem(accountID, envID, fnID, at, semA), // memo hit, no round trip
+	}
+
+	var calls int32
+	iter := ProcessorIterator{
+		Partition: &QueuePartition{ID: fnID.String(), AccountID: accountID, EnvID: &envID, FunctionID: &fnID},
+		Items:     items,
+		Queue:     mockProc,
+		Leaser: semaphoreLeaser(map[string]constraintapi.SemaphoreConstraint{
+			semaphoreMemoKey(semA.ID, semA.EvaluatedKeyHash): exhaustedA,
+		}, &calls),
+		Dispatch: func(_ context.Context, item ProcessItem) (DispatchedItem, error) {
+			mockProc.workers <- item
+			return NewCompletedDispatchedItem(DispatchedItemResult{}), nil
+		},
+		StaticTime: at.Add(2 * time.Second),
+	}
+
+	require.NoError(t, iter.Iterate(ctx))
+
+	// items 1, 2 and 4 reach the leaser.  items 3 and 5 are answered by the memo.
+	require.Equal(t, int32(3), atomic.LoadInt32(&calls))
+	require.Equal(t, int32(3), iter.CtrConcurrency.Load())
+	require.Equal(t, int32(2), iter.CtrSuccess.Load())
+	require.True(t, iter.IsSemaphoreLimitOnly.Load())
+	require.Len(t, mockProc.workers, 2)
+}

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"time"
 
+	"github.com/inngest/inngest/pkg/constraintapi"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -84,6 +85,9 @@ type LeaseItemResult struct {
 	Status     LeaseItemStatus
 	Err        error
 	RetryAfter time.Time
+	// ExhaustedSemaphores lists the semaphores that had no capacity for this item.
+	// the iterator uses it to skip later items that carry the same semaphore.
+	ExhaustedSemaphores []constraintapi.SemaphoreConstraint
 }
 
 type RunResult struct {

--- a/pkg/execution/state/redis_state/constraints_semaphore_test.go
+++ b/pkg/execution/state/redis_state/constraints_semaphore_test.go
@@ -1,0 +1,220 @@
+package redis_state
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/constraintapi"
+	"github.com/inngest/inngest/pkg/enums"
+	osqueue "github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/jonboulle/clockwork"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+)
+
+// an app semaphore with no capacity key is the connect app with no workers.
+func TestItemLeaseConstraintCheckReportsExhaustedAppSemaphore(t *testing.T) {
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClock()
+	r.SetTime(clock.Now())
+	ctx := context.Background()
+
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("default"),
+		constraintapi.WithClock(clock),
+	)
+	require.NoError(t, err)
+
+	accountID, envID, fnID, appID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	constraints := osqueue.PartitionConstraintConfig{
+		FunctionVersion: 1,
+		Concurrency: osqueue.PartitionConcurrency{
+			AccountConcurrency:  10,
+			FunctionConcurrency: 5,
+		},
+	}
+
+	q, shard := newQueue(
+		t, rc,
+		osqueue.WithClock(clock),
+		osqueue.WithCapacityManager(cm),
+		osqueue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
+			return constraints
+		}),
+	)
+
+	appSem := constraintapi.Semaphore{
+		ID:      constraintapi.SemaphoreIDApp(appID),
+		Weight:  1,
+		Release: constraintapi.SemaphoreReleaseAuto,
+	}
+
+	item := osqueue.QueueItem{
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		Data: osqueue.Item{
+			Kind:    osqueue.KindEdge,
+			Payload: json.RawMessage(`{"test":"payload"}`),
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				AppID:       appID,
+			},
+			Semaphores: []constraintapi.Semaphore{appSem},
+		},
+	}
+
+	qi, err := shard.EnqueueItem(ctx, item, clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	sp := osqueue.ItemShadowPartition(ctx, qi)
+	backlog := osqueue.ItemBacklog(ctx, qi)
+
+	res, err := q.ItemLeaseConstraintCheck(ctx, &sp, &backlog, constraints, &qi, clock.Now())
+	require.NoError(t, err)
+
+	require.Nil(t, res.CapacityLease)
+	require.Equal(t, enums.QueueConstraintSemaphore, res.LimitingConstraint)
+	require.Len(t, res.ExhaustedSemaphores, 1)
+	require.Equal(t, appSem.ID, res.ExhaustedSemaphores[0].ID)
+	require.Equal(t, constraintapi.SemaphoreKindApp, res.ExhaustedSemaphores[0].Kind())
+}
+
+// the real LeaseItem path.  one exhausted app semaphore stops the pass after a
+// single constraint API call, while an exhausted fnkey semaphore only skips the
+// items that carry it and is checked once per pass.
+func TestQueueProcessorIterateWithExhaustedSemaphores(t *testing.T) {
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClock()
+	ctx := context.Background()
+
+	cmLifecycles := constraintapi.NewConstraintAPIDebugLifecycles()
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("default"),
+		constraintapi.WithClock(clock),
+		constraintapi.WithLifecycles(cmLifecycles),
+	)
+	require.NoError(t, err)
+
+	reset := func() {
+		r.FlushAll()
+		r.SetTime(clock.Now())
+		cmLifecycles.Reset()
+	}
+
+	accountID, envID, fnID, appID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	constraints := osqueue.PartitionConstraintConfig{
+		FunctionVersion: 1,
+		Concurrency: osqueue.PartitionConcurrency{
+			AccountConcurrency:  10,
+			FunctionConcurrency: 10,
+		},
+	}
+
+	newItem := func(sems ...constraintapi.Semaphore) osqueue.QueueItem {
+		return osqueue.QueueItem{
+			FunctionID:  fnID,
+			WorkspaceID: envID,
+			Data: osqueue.Item{
+				Kind:    osqueue.KindEdge,
+				Payload: json.RawMessage(`{"test":"payload"}`),
+				Identifier: state.Identifier{
+					AccountID:   accountID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
+					AppID:       appID,
+				},
+				Semaphores: sems,
+			},
+		}
+	}
+
+	setup := func(t *testing.T, items ...osqueue.QueueItem) (osqueue.ProcessorIterator, *constraintapi.ConstraintApiDebugLifecycles) {
+		reset()
+
+		q, shard := newQueue(
+			t, rc,
+			osqueue.WithClock(clock),
+			osqueue.WithCapacityManager(cm),
+			osqueue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
+				return constraints
+			}),
+		)
+
+		queued := make([]*osqueue.QueueItem, 0, len(items))
+		for _, item := range items {
+			qi, err := shard.EnqueueItem(ctx, item, clock.Now(), osqueue.EnqueueOpts{})
+			require.NoError(t, err)
+			queued = append(queued, &qi)
+		}
+
+		p := osqueue.ItemPartition(ctx, *queued[0])
+
+		return osqueue.ProcessorIterator{
+			Partition: &p,
+			Items:     queued,
+			Queue:     q,
+			Dispatch: func(_ context.Context, item osqueue.ProcessItem) (osqueue.DispatchedItem, error) {
+				q.Workers() <- item
+				return osqueue.NewCompletedDispatchedItem(osqueue.DispatchedItemResult{}), nil
+			},
+			StaticTime: clock.Now(),
+		}, cmLifecycles
+	}
+
+	t.Run("app semaphore stops the pass after one acquire", func(t *testing.T) {
+		appSem := constraintapi.Semaphore{ID: constraintapi.SemaphoreIDApp(appID), Weight: 1}
+
+		iter, lc := setup(t, newItem(appSem), newItem(appSem), newItem(appSem), newItem(appSem))
+
+		require.NoError(t, iter.Iterate(ctx))
+
+		require.Equal(t, 1, len(lc.AcquireCalls))
+		require.Equal(t, int32(1), iter.CtrConcurrency.Load())
+		require.Equal(t, int32(0), iter.CtrSuccess.Load())
+		require.True(t, iter.IsSemaphoreLimitOnly.Load())
+		require.True(t, iter.IsRequeuable())
+	})
+
+	t.Run("fnkey semaphore is checked once and skips only matching items", func(t *testing.T) {
+		keyed := constraintapi.SemaphoreIDFnKey(fnID, "event.data.customer")
+		semA := constraintapi.Semaphore{ID: keyed, EvaluatedKeyHash: "a", Weight: 1, Release: constraintapi.SemaphoreReleaseManual}
+
+		iter, lc := setup(t,
+			newItem(semA), // exhausted, one acquire
+			newItem(),     // dispatched, one acquire
+			newItem(semA), // memo, no acquire
+			newItem(semA), // memo, no acquire
+		)
+
+		require.NoError(t, iter.Iterate(ctx))
+
+		require.Equal(t, 2, len(lc.AcquireCalls))
+		require.Equal(t, int32(3), iter.CtrConcurrency.Load())
+		require.Equal(t, int32(1), iter.CtrSuccess.Load())
+		require.True(t, iter.IsSemaphoreLimitOnly.Load())
+	})
+}


### PR DESCRIPTION
## Description

inspect semaphore constraint kinds and break early on kinds that indicate the entire partition peek cannot be worked on.  also, cache denied constraints by semaphore key so these don't require additional constraint calls when iterating.

## Release note

improves speed of queue when workers are at their concurrency cap

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
