### PR TITLE
feat(dashboard): add hobby execution limit notices

### DIFF
--- a/ui/apps/dashboard/src/components/ExecutionLimit/ExecutionLimitCard.tsx
+++ b/ui/apps/dashboard/src/components/ExecutionLimit/ExecutionLimitCard.tsx
@@ -1,0 +1,62 @@
+import { Link } from '@inngest/components/Link';
+import ProgressBar from '@inngest/components/ProgressBar/ProgressBar';
+import { RiArrowRightLine } from '@remixicon/react';
+
+import { pathCreator } from '@/utils/urls';
+import { SidebarAlertCard } from '../NavigationV2/SidebarAlertCard';
+
+export type ExecutionLimitCardProps = {
+  className?: string;
+  executionLimit: number;
+  upgradeTo?: string;
+  usedExecutions: number;
+};
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+
+export function ExecutionLimitCard({
+  className,
+  executionLimit,
+  upgradeTo = pathCreator.billing({
+    tab: 'plans',
+    ref: 'app-hobby-execution-limit-card',
+  }),
+  usedExecutions,
+}: ExecutionLimitCardProps) {
+  const formattedLimit = numberFormatter.format(executionLimit);
+  const formattedUsage = numberFormatter.format(usedExecutions);
+
+  return (
+    <SidebarAlertCard
+      className={className}
+      kind="error"
+      footer={
+        <Link
+          to={upgradeTo}
+          className="text-error decoration-error hover:text-tertiary-2xIntense hover:decoration-tertiary-2xIntense gap-0.5 text-xs leading-5"
+          iconAfter={<RiArrowRightLine className="h-3.5 w-3.5" />}
+        >
+          Upgrade plan
+        </Link>
+      }
+    >
+      <h2 className="text-xs font-bold leading-4">New runs are paused</h2>
+      <p className="mt-1 text-xs font-medium leading-4">
+        You&apos;ve used {formattedUsage} executions in the last 30 days and
+        reached the Hobby limit. New runs and scheduled functions won&apos;t
+        start and aren&apos;t queued. Upgrade to Pro to resume now.
+      </p>
+      <div className="mt-2 pt-1">
+        <ProgressBar
+          kind="error"
+          limit={executionLimit}
+          size="small"
+          value={usedExecutions}
+        />
+        <p className="mt-[3px] text-xs font-bold leading-4">
+          {formattedUsage}/{formattedLimit} Executions
+        </p>
+      </div>
+    </SidebarAlertCard>
+  );
+}

--- a/ui/apps/dashboard/src/components/ExecutionLimit/ExecutionLimitPill.tsx
+++ b/ui/apps/dashboard/src/components/ExecutionLimit/ExecutionLimitPill.tsx
@@ -1,0 +1,40 @@
+import { Link } from '@inngest/components/Link';
+import { Pill } from '@inngest/components/Pill/Pill';
+import { RiArrowRightLine, RiErrorWarningFill } from '@remixicon/react';
+
+import { pathCreator } from '@/utils/urls';
+
+export type ExecutionLimitPillProps = {
+  className?: string;
+  upgradeTo?: string;
+};
+
+export function ExecutionLimitPill({
+  className,
+  upgradeTo = pathCreator.billing({
+    tab: 'plans',
+    ref: 'app-hobby-execution-limit-pill',
+  }),
+}: ExecutionLimitPillProps) {
+  return (
+    <Pill
+      action={
+        <Link
+          to={upgradeTo}
+          className="text-error decoration-error hover:text-tertiary-2xIntense hover:decoration-tertiary-2xIntense gap-0.5 text-xs leading-none"
+          iconAfter={<RiArrowRightLine className="h-3.5 w-3.5" />}
+        >
+          Upgrade
+        </Link>
+      }
+      appearance="outlined"
+      className={className}
+      icon={<RiErrorWarningFill className="h-3.5 w-3.5" />}
+      iconSide="left"
+      kind="error"
+    >
+      Hobby account execution limit reached. Upgrade your plan to continue using
+      Inngest.
+    </Pill>
+  );
+}

--- a/ui/apps/dashboard/src/components/ExecutionLimit/index.ts
+++ b/ui/apps/dashboard/src/components/ExecutionLimit/index.ts
@@ -1,0 +1,8 @@
+export {
+  ExecutionLimitCard,
+  type ExecutionLimitCardProps,
+} from './ExecutionLimitCard';
+export {
+  ExecutionLimitPill,
+  type ExecutionLimitPillProps,
+} from './ExecutionLimitPill';

--- a/ui/apps/dashboard/src/components/NavigationV2/SidebarAlertCard.tsx
+++ b/ui/apps/dashboard/src/components/NavigationV2/SidebarAlertCard.tsx
@@ -1,0 +1,44 @@
+import { cn } from '@inngest/components/utils/classNames';
+
+const kindStyles = {
+  default: 'border-subtle bg-canvasBase text-basis',
+  error: 'border-tertiary-xSubtle bg-error text-error',
+  warning: 'border-accent-xSubtle bg-warning text-warning',
+} as const;
+
+export type SidebarAlertCardProps = {
+  children: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+  footer?: React.ReactNode;
+  footerClassName?: string;
+  kind?: keyof typeof kindStyles;
+};
+
+export function SidebarAlertCard({
+  children,
+  className,
+  contentClassName,
+  footer,
+  footerClassName,
+  kind = 'default',
+}: SidebarAlertCardProps) {
+  return (
+    <section
+      className={cn(
+        'w-full overflow-hidden rounded border leading-tight',
+        kindStyles[kind],
+        className,
+      )}
+    >
+      <div className={cn('px-2 py-3', contentClassName)}>{children}</div>
+      {footer && (
+        <div
+          className={cn('border-t border-inherit px-2 py-1.5', footerClassName)}
+        >
+          {footer}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/ui/apps/dashboard/src/components/SeatOverage/SeatOverageWidget.tsx
+++ b/ui/apps/dashboard/src/components/SeatOverage/SeatOverageWidget.tsx
@@ -8,10 +8,10 @@ import {
 import { RiCloseLine, RiErrorWarningFill } from '@remixicon/react';
 
 import { pathCreator } from '@/utils/urls';
+import { SidebarAlertCard } from '../NavigationV2/SidebarAlertCard';
 import { useSeatOverage } from './useSeatOverage';
 import { Link } from '@tanstack/react-router';
 
-// TODO: turn into a component for all other upsell widgets
 export default function SeatOverageWidget({
   collapsed,
 }: {
@@ -56,7 +56,10 @@ export default function SeatOverageWidget({
       )}
 
       {!collapsed && (
-        <div className="text-basis mb-5 block rounded border border-amber-200 bg-amber-50 p-3 leading-tight">
+        <SidebarAlertCard
+          className="text-basis mb-5 border-amber-200 bg-amber-50"
+          contentClassName="p-3"
+        >
           <div className="flex min-h-[110px] flex-col justify-between">
             <div>
               <div className="flex items-center justify-between">
@@ -97,7 +100,7 @@ export default function SeatOverageWidget({
               Upgrade plan
             </Link>
           </div>
-        </div>
+        </SidebarAlertCard>
       )}
     </>
   );

--- a/ui/packages/components/src/Pill/Pill.stories.tsx
+++ b/ui/packages/components/src/Pill/Pill.stories.tsx
@@ -1,3 +1,4 @@
+import { RiArrowRightLine, RiErrorWarningFill } from '@remixicon/react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { Pill } from './Pill';
@@ -21,6 +22,22 @@ export const Default: Story = {};
 
 export const WithLink: Story = {
   args: {
-    href: new URL('http://inngest.com'),
+    href: 'https://inngest.com',
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    appearance: 'outlined',
+    kind: 'error',
+    icon: <RiErrorWarningFill className="h-3.5 w-3.5" />,
+    iconSide: 'left',
+    children: 'Hobby account execution limit reached. Upgrade your plan to continue using Inngest.',
+    action: (
+      <button className="flex items-center gap-0.5 underline underline-offset-2">
+        Upgrade
+        <RiArrowRightLine className="h-3.5 w-3.5" />
+      </button>
+    ),
   },
 };

--- a/ui/packages/components/src/Pill/Pill.test.tsx
+++ b/ui/packages/components/src/Pill/Pill.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { Pill } from './Pill';
+
+class ResizeObserverMock {
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+
+beforeAll(() => vi.stubGlobal('ResizeObserver', ResizeObserverMock));
+afterAll(() => vi.unstubAllGlobals());
+afterEach(cleanup);
+
+describe('Pill', () => {
+  it('renders a trailing action separately from truncatable content', () => {
+    render(<Pill action={<a href="/billing/plans">Upgrade</a>}>Execution limit reached</Pill>);
+
+    expect(screen.getByText('Execution limit reached')).toBeTruthy();
+
+    const action = screen.getByRole('link', { name: 'Upgrade' });
+    expect(action.getAttribute('href')).toBe('/billing/plans');
+    expect(action.parentElement?.className).toContain('shrink-0');
+  });
+});

--- a/ui/packages/components/src/Pill/Pill.tsx
+++ b/ui/packages/components/src/Pill/Pill.tsx
@@ -10,6 +10,27 @@ import { RiTimeLine } from '@remixicon/react';
 export type PillKind = 'default' | 'info' | 'warning' | 'primary' | 'error' | 'secondary';
 export type PillAppearance = 'solid' | 'outlined' | 'solidBright';
 
+export type PillProps = {
+  children: React.ReactNode;
+  className?: string;
+  href?: LinkProps['href'];
+  to?: LinkProps['to'];
+  appearance?: PillAppearance;
+  kind?: PillKind;
+  icon?: React.ReactNode;
+  iconSide?: 'right' | 'left' | 'iconOnly';
+  /**
+   * A separately interactive element rendered after the pill's content. Do not
+   * combine this with `href` or `to`, since that would nest interactive links.
+   */
+  action?: React.ReactNode;
+  /**
+   * Use this when you want one of the sides to be flat. The other sides will be
+   * rounded.
+   */
+  flatSide?: 'left' | 'right';
+};
+
 export function Pill({
   children,
   className = '',
@@ -20,28 +41,15 @@ export function Pill({
   flatSide,
   icon,
   iconSide,
-}: {
-  children: React.ReactNode;
-  className?: string;
-  href?: LinkProps['href'];
-  to?: LinkProps['to'];
-  appearance?: PillAppearance;
-  kind?: PillKind;
-  icon?: React.ReactNode;
-  iconSide?: 'right' | 'left' | 'iconOnly';
-  /**
-   * Use this when you want one of the sides to be flat. The other sides will be
-   * rounded.
-   */
-  flatSide?: 'left' | 'right';
-}) {
+  action,
+}: PillProps) {
   const pillRef = useRef<HTMLSpanElement | HTMLAnchorElement | null>(null);
-  const hiddenTextRef = useRef<HTMLSpanElement | null>(null);
+  const contentRef = useRef<HTMLSpanElement | null>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 
   const pillColors = getPillColors({ kind, appearance, clickable: !!href || !!to });
   const classNames = cn(
-    'inline-flex items-center gap-0.5 h-5 px-2 text-xs leading-none font-medium truncate max-w-full',
+    'inline-flex h-5 max-w-full items-center gap-0.5 whitespace-nowrap px-2 text-xs font-medium leading-none',
     pillColors,
     className
   );
@@ -54,21 +62,17 @@ export function Pill({
 
   useEffect(() => {
     const checkTruncation = () => {
-      if (!pillRef.current || !hiddenTextRef.current) return;
-
-      // Get the actual width of the pill and its hidden text content
-      const pillWidth = pillRef.current.offsetWidth;
-      const fullTextWidth = hiddenTextRef.current.offsetWidth;
-
-      setIsTruncated(fullTextWidth > pillWidth);
+      if (!contentRef.current) return;
+      setIsTruncated(contentRef.current.scrollWidth > contentRef.current.clientWidth);
     };
 
     checkTruncation();
     const resizeObserver = new ResizeObserver(checkTruncation);
     if (pillRef.current) resizeObserver.observe(pillRef.current);
+    if (contentRef.current) resizeObserver.observe(contentRef.current);
 
     return () => resizeObserver.disconnect();
-  }, [children]);
+  }, [action, children]);
 
   const extractText = (node: React.ReactNode): string => {
     return Children.toArray(node)
@@ -84,20 +88,31 @@ export function Pill({
 
   const tooltipText = extractText(children);
 
+  const pillContent = (
+    <>
+      {icon && iconSide === 'left' && <span className="shrink-0">{icon}</span>}
+      {icon && iconSide === 'iconOnly' ? (
+        icon
+      ) : (
+        <span ref={contentRef} className="min-w-0 truncate">
+          {children}
+        </span>
+      )}
+      {icon && iconSide === 'right' && <span className="shrink-0">{icon}</span>}
+      {action && <span className="ml-4 shrink-0">{action}</span>}
+    </>
+  );
+
   const pillWrapper =
     href || to ? (
       <Link href={href} to={to} className="flex" onClick={(e) => e.stopPropagation()}>
         <span ref={pillRef} className={cn('rounded', classNames)}>
-          {icon && iconSide === 'left' && icon}
-          {icon && iconSide === 'iconOnly' ? icon : <span className="truncate">{children}</span>}
-          {icon && iconSide === 'right' && icon}
+          {pillContent}
         </span>
       </Link>
     ) : (
       <span ref={pillRef} className={cn(roundedClasses, classNames)}>
-        {icon && iconSide === 'left' && icon}
-        {icon && iconSide === 'iconOnly' ? icon : <span className="truncate">{children}</span>}
-        {icon && iconSide === 'right' && icon}
+        {pillContent}
       </span>
     );
   return (
@@ -112,15 +127,6 @@ export function Pill({
       ) : (
         pillWrapper
       )}
-
-      {/* Hidden text element to measure actual content width */}
-      <span
-        ref={hiddenTextRef}
-        className={cn(classNames, 'invisible absolute left-0 top-0 whitespace-nowrap')}
-        aria-hidden="true"
-      >
-        <span>{children}</span>
-      </span>
     </>
   );
 }

--- a/ui/packages/components/src/Pill/index.ts
+++ b/ui/packages/components/src/Pill/index.ts
@@ -1,2 +1,9 @@
-export { Pill, PillContent, type PillContentProps, type PillAppearance } from './Pill';
+export {
+  Pill,
+  PillContent,
+  type PillAppearance,
+  type PillContentProps,
+  type PillKind,
+  type PillProps,
+} from './Pill';
 export { HorizontalPillList } from './HorizontalPillList';

--- a/ui/packages/components/src/ProgressBar/ProgressBar.stories.tsx
+++ b/ui/packages/components/src/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ProgressBar from './ProgressBar';
+
+const meta = {
+  title: 'Components/ProgressBar',
+  component: ProgressBar,
+  decorators: [
+    (Story) => (
+      <div className="w-64">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    limit: 100,
+    value: 50,
+  },
+} satisfies Meta<typeof ProgressBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof ProgressBar>;
+
+export const Default: Story = {};
+
+export const SmallError: Story = {
+  args: {
+    kind: 'error',
+    size: 'small',
+    value: 100,
+  },
+};

--- a/ui/packages/components/src/ProgressBar/ProgressBar.test.tsx
+++ b/ui/packages/components/src/ProgressBar/ProgressBar.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import ProgressBar from './ProgressBar';
+
+afterEach(cleanup);
+
+describe('ProgressBar', () => {
+  it('preserves the default progress bar treatment', () => {
+    const { container } = render(<ProgressBar limit={100} value={50} />);
+
+    expect(screen.getByRole('progressbar').className).toContain('h-6');
+    expect(container.querySelector('[style="width: 50%;"]')).toBeTruthy();
+  });
+
+  it('renders the small error treatment at the limit', () => {
+    const { container } = render(<ProgressBar kind="error" limit={100} size="small" value={100} />);
+
+    const progressBar = screen.getByRole('progressbar');
+    expect(progressBar.className).toContain('h-1');
+    expect(progressBar.className).toContain('bg-tertiary-xSubtle');
+
+    const indicator = container.querySelector('[style="width: 100%;"]');
+    expect(indicator?.className).toContain('bg-tertiary-intense');
+  });
+});

--- a/ui/packages/components/src/ProgressBar/ProgressBar.tsx
+++ b/ui/packages/components/src/ProgressBar/ProgressBar.tsx
@@ -2,13 +2,23 @@ import * as Progress from '@radix-ui/react-progress';
 
 import { cn } from '../utils/classNames';
 
-type ProgressBarProps = {
+export type ProgressBarProps = {
   limit: number | null;
   value: number;
   overageAllowed?: boolean;
+  className?: string;
+  kind?: 'default' | 'error';
+  size?: 'default' | 'small';
 };
 
-const ProgressBar = ({ limit, value, overageAllowed }: ProgressBarProps) => {
+const ProgressBar = ({
+  limit,
+  value,
+  overageAllowed,
+  className,
+  kind = 'default',
+  size = 'default',
+}: ProgressBarProps) => {
   const progress = limit === null ? 0 : Math.min((value / limit) * 100, 100);
   const includedWidth = limit !== null && progress === 100 ? (limit / value) * 100 : progress;
   const additionalWidth = progress >= 100 ? 100 - includedWidth : 0;
@@ -18,8 +28,11 @@ const ProgressBar = ({ limit, value, overageAllowed }: ProgressBarProps) => {
   return (
     <Progress.Root
       className={cn(
-        'relative flex h-6 overflow-hidden rounded-md',
-        'outline-subtle outline outline-1 -outline-offset-1'
+        'relative flex overflow-hidden',
+        size === 'default' && 'outline-subtle h-6 rounded-md outline outline-1 -outline-offset-1',
+        size === 'small' && 'h-1 rounded-sm',
+        kind === 'error' && 'bg-tertiary-xSubtle',
+        className
       )}
       value={progress}
       max={100}
@@ -27,14 +40,16 @@ const ProgressBar = ({ limit, value, overageAllowed }: ProgressBarProps) => {
       <Progress.Indicator
         className={cn(
           'bg-primary-moderate',
-          isOverTheLimit && !overageAllowed && 'bg-errorContrast'
+          isOverTheLimit && !overageAllowed && 'bg-errorContrast',
+          kind === 'error' && 'bg-tertiary-intense'
         )}
         style={{ width: `${includedWidth}%` }}
       />
       <Progress.Indicator
         className={cn(
           'bg-primary-2xSubtle',
-          isOverTheLimit && !overageAllowed && 'bg-errorContrast'
+          isOverTheLimit && !overageAllowed && 'bg-errorContrast',
+          kind === 'error' && 'bg-tertiary-intense'
         )}
         style={{ width: `${additionalWidth}%` }}
       />


### PR DESCRIPTION
## Description

- Adds reusable execution-limit card and pill components for the Hobby hard-cap experience.
- Adds a shared sidebar alert card and reuses it for the existing seat-overage widget.
- Extends the Pill and ProgressBar primitives with the action, error, and compact treatments needed by the designs.
- Intentionally leaves eligibility, triggering, and layout wiring to a follow-up.

<img width="1912" height="982" alt="Screenshot 2026-09-02 at 8 57 51 AM" src="https://github.com/user-attachments/assets/d91c3057-27f4-4326-9e22-d87141fc073a" />
