### PR TITLE
refactor(metadata): Remove span metadata feature flag

### DIFF
--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -79,8 +79,6 @@ type CheckpointAPIOpts struct {
 	RunJWTSecret []byte
 	// BackoffFunc computes retry timing. If nil, uses the default backoff table.
 	BackoffFunc backoff.BackoffFunc
-	// AllowStepMetadata controls whether step metadata is allowed for a given account.
-	AllowStepMetadata executor.AllowStepMetadata
 	// EnforceStepSizeLimits controls whether step output size limits are enforced for a given account.
 	// The default is to always enforce the limits.
 	EnforceStepSizeLimits func(ctx context.Context, accountID uuid.UUID) bool
@@ -118,7 +116,6 @@ func NewCheckpointAPI(o Opts) CheckpointAPI {
 		},
 		MetricsProvider:              o.CheckpointOpts.CheckpointMetrics,
 		BackoffFunc:                  o.CheckpointOpts.BackoffFunc,
-		AllowStepMetadata:            o.CheckpointOpts.AllowStepMetadata,
 		EnforceStepSizeLimits:        o.CheckpointOpts.EnforceStepSizeLimits,
 		AllowAsyncDispatchValidation: o.CheckpointOpts.AllowAsyncDispatchValidation,
 	})

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -563,9 +563,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		}),
 		executor.WithTracerProvider(tp),
 
-		executor.WithAllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
-			return enableStepMetadata
-		}),
 		executor.WithCapacityManager(cm),
 		executor.WithSemaphoreManager(semaphores),
 		executor.WithUseConstraintAPI(func(ctx context.Context, accountID uuid.UUID) (enable bool) {
@@ -678,9 +675,6 @@ func start(ctx context.Context, opts StartOpts) error {
 				RunOutputReader: devutil.NewLocalOutputReader(core.Resolver(), ds.Data, ds.Data),
 				RunJWTSecret:    consts.DevServerRunJWTSecret,
 				BackoffFunc:     retryBackoff,
-				AllowStepMetadata: func(ctx context.Context, acctID uuid.UUID) bool {
-					return enableStepMetadata
-				},
 				AllowAsyncDispatchValidation: func(ctx context.Context, acctID uuid.UUID) bool {
 					return enableAsyncDispatchValidation
 				},

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -94,8 +94,6 @@ type Opts struct {
 	// BackoffFunc computes the retry time for a given attempt number.
 	// If nil, defaults to backoff.DefaultBackoff.
 	BackoffFunc backoff.BackoffFunc
-	// AllowStepMetadata controls whether step metadata is allowed for a given account.
-	AllowStepMetadata executor.AllowStepMetadata
 	// EnforceStepSizeLimits controls whether step output size limits are enforced for a given account.
 	// The default is to always enforce the limits.
 	EnforceStepSizeLimits func(ctx context.Context, accountID uuid.UUID) bool
@@ -818,10 +816,6 @@ func (c checkpointer) processMetadata(
 	op state.GeneratorOpcode,
 	location string,
 ) {
-	if !c.AllowStepMetadata.Enabled(ctx, accountID) {
-		return
-	}
-
 	// Extract experiment metadata from opts and merge into the list of
 	// metadata entries to process. The SDK spreads group.experiment()
 	// variant context onto a sub-step's opts; emitting the metadata span

--- a/pkg/execution/checkpoint/checkpoint_async_test.go
+++ b/pkg/execution/checkpoint/checkpoint_async_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
-	"github.com/inngest/inngest/pkg/execution/executor"
 	"github.com/inngest/inngest/pkg/execution/executor/queueref"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	sv1 "github.com/inngest/inngest/pkg/execution/state"
@@ -129,7 +128,7 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 
 	t.Run("step with metadata creates spans", func(t *testing.T) {
 		// Async checkpoint with metadata-bearing opcodes creates both
-		// step and metadata spans when AllowStepMetadata returns true.
+		// step and metadata spans.
 		ctx := context.Background()
 		require := require.New(t)
 
@@ -158,15 +157,11 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 
 		mocks, testData := setupAsyncCheckpointTest(t, ops...)
 
-		// Replace checkpointer with AllowStepMetadata enabled
 		testData.checkpointer = New(Opts{
 			State:           mocks.state,
 			TracerProvider:  mocks.tracer,
 			Queue:           mocks.queue,
 			MetricsProvider: mocks.metrics,
-			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
-				return true
-			}),
 		})
 
 		expectedData := map[string]any{"data": json.RawMessage(`{"result": "step 1 output"}`)}

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/apiresult"
-	"github.com/inngest/inngest/pkg/execution/executor"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	sv1 "github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/v2"
@@ -517,7 +516,7 @@ func TestCheckpointSyncSteps(t *testing.T) {
 func TestSyncStepMetadata(t *testing.T) {
 	t.Run("creates spans on success", func(t *testing.T) {
 		// A sync step with valid metadata entries creates both the step
-		// span and metadata spans when AllowStepMetadata returns true.
+		// span and metadata spans.
 		ctx := context.Background()
 		require := require.New(t)
 
@@ -546,7 +545,6 @@ func TestSyncStepMetadata(t *testing.T) {
 
 		mocks, testData := setupSyncCheckpointTest(t, ops...)
 
-		// Replace checkpointer with one that has AllowStepMetadata enabled
 		testData.checkpointer = New(Opts{
 			State:           mocks.state,
 			TracerProvider:  mocks.tracer,
@@ -554,9 +552,6 @@ func TestSyncStepMetadata(t *testing.T) {
 			MetricsProvider: mocks.metrics,
 			Executor:        mocks.executor,
 			FnReader:        mocks.fnReader,
-			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
-				return true
-			}),
 		})
 
 		expectedData := map[string]any{"data": json.RawMessage(`{"result": "step 1 output"}`)}
@@ -629,9 +624,6 @@ func TestSyncStepMetadata(t *testing.T) {
 			MetricsProvider: mocks.metrics,
 			Executor:        mocks.executor,
 			FnReader:        mocks.fnReader,
-			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
-				return true
-			}),
 		})
 
 		mocks.tracer.
@@ -659,66 +651,6 @@ func TestSyncStepMetadata(t *testing.T) {
 		}
 		require.True(hasStep, "Expected a step span")
 		require.True(hasMetadata, "Expected a metadata span")
-	})
-
-	t.Run("no metadata when flag disabled", func(t *testing.T) {
-		// No metadata spans are created when AllowStepMetadata returns
-		// false, even if the opcode contains metadata entries.
-		ctx := context.Background()
-		require := require.New(t)
-
-		now := time.Now()
-		ops := []state.GeneratorOpcode{
-			{
-				ID:     "step-1",
-				Op:     enums.OpcodeStepRun,
-				Data:   json.RawMessage(`{"result": "step 1 output"}`),
-				Name:   "Step 1",
-				Timing: interval.New(now, now.Add(100*time.Millisecond)),
-				Metadata: []metadata.ScopedUpdate{
-					{
-						Scope: enums.MetadataScopeRun,
-						Update: metadata.Update{
-							RawUpdate: metadata.RawUpdate{
-								Kind:   "userland.test",
-								Op:     enums.MetadataOpcodeMerge,
-								Values: metadata.Values{"key": json.RawMessage(`"value"`)},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		mocks, testData := setupSyncCheckpointTest(t, ops...)
-
-		testData.checkpointer = New(Opts{
-			State:           mocks.state,
-			TracerProvider:  mocks.tracer,
-			Queue:           mocks.queue,
-			MetricsProvider: mocks.metrics,
-			Executor:        mocks.executor,
-			FnReader:        mocks.fnReader,
-			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
-				return false
-			}),
-		})
-
-		expectedData := map[string]any{"data": json.RawMessage(`{"result": "step 1 output"}`)}
-		expectedOutputBytes, _ := json.Marshal(expectedData)
-		mocks.state.On("SaveStep", ctx, testData.metadata.ID, "step-1", expectedOutputBytes).Return(false, nil)
-
-		mocks.tracer.
-			On("CreateSpan", mock.Anything, mock.Anything, mock.AnythingOfType("*tracing.CreateSpanOptions")).
-			Return(&meta.SpanReference{}, nil)
-
-		mocks.metrics.On("OnStepFinished", ctx, mock.AnythingOfType("checkpoint.MetricCardinality"), enums.StepStatusCompleted)
-
-		err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
-		require.NoError(err)
-
-		require.Len(mocks.tracer.createdSpans, 1, "Expected only 1 step span, no metadata span")
-		require.Equal(meta.SpanNameStep, mocks.tracer.createdSpans[0].name)
 	})
 
 	t.Run("invalid metadata skipped", func(t *testing.T) {
@@ -763,9 +695,6 @@ func TestSyncStepMetadata(t *testing.T) {
 			MetricsProvider: mocks.metrics,
 			Executor:        mocks.executor,
 			FnReader:        mocks.fnReader,
-			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
-				return true
-			}),
 		})
 
 		expectedData := map[string]any{"data": json.RawMessage(`{"result": "step 1 output"}`)}
@@ -820,9 +749,6 @@ func TestSyncStepMetadata(t *testing.T) {
 			MetricsProvider: mocks.metrics,
 			Executor:        mocks.executor,
 			FnReader:        mocks.fnReader,
-			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
-				return true
-			}),
 		})
 
 		expectedData := map[string]any{"data": json.RawMessage(`{"result": "variant output"}`)}
@@ -879,9 +805,6 @@ func TestSyncStepMetadata(t *testing.T) {
 			MetricsProvider: mocks.metrics,
 			Executor:        mocks.executor,
 			FnReader:        mocks.fnReader,
-			AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
-				return true
-			}),
 		})
 
 		expectedData := map[string]any{"data": json.RawMessage(`{"result": "ok"}`)}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -447,20 +447,20 @@ type ExecutorRealtimeConfig struct {
 	PublishURL string
 }
 
-// AllowStepMetadata determines if step metadata should be enabled for the account
+// AllowStepMetadata is kept only so existing callers (e.g. the monorepo)
+// constructing a WithAllowStepMetadata option still compile.
+//
+// Deprecated: step metadata is now always enabled; this type and
+// WithAllowStepMetadata no longer have any effect and will be removed.
 type AllowStepMetadata func(ctx context.Context, acctID uuid.UUID) bool
 
-func (am AllowStepMetadata) Enabled(ctx context.Context, acctID uuid.UUID) bool {
-	if am == nil {
-		return false
-	}
-
-	return am(ctx, acctID)
-}
-
+// WithAllowStepMetadata is a no-op.
+//
+// Deprecated: step metadata is now always enabled; this option no longer has
+// any effect and will be removed. Kept temporarily for compatibility with
+// existing callers in the monorepo.
 func WithAllowStepMetadata(md AllowStepMetadata) ExecutorOpt {
 	return func(e execution.Executor) error {
-		e.(*executor).allowStepMetadata = md
 		return nil
 	}
 }
@@ -555,8 +555,7 @@ type executor struct {
 	traceReader    cqrs.TraceReader
 	tracerProvider tracing.TracerProvider
 
-	allowStepMetadata AllowStepMetadata
-	clock             clockwork.Clock
+	clock clockwork.Clock
 
 	conditionalTracer itrace.ConditionalTracer
 }
@@ -2261,38 +2260,36 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			return nil, err
 		}
 
-		if e.allowStepMetadata.Enabled(ctx, instance.Metadata().ID.Tenant.AccountID) {
-			// Extract HTTP timing metadata from httpstat if available.
-			// This captures the detailed connection timing breakdown (DNS, TCP, TLS, TTFB, transfer)
-			// from the HTTP request to the user's SDK function.
-			if resp.HTTPStat != nil {
-				httpTimingMd := extractors.ExtractHTTPTimingMetadata(resp.HTTPStat)
-				_, err := e.createMetadataSpanOnParent(
-					ctx,
-					&instance,
-					"executor.httpTiming",
-					httpTimingMd,
-					enums.MetadataScopeRequest,
-					instance.execSpan,
-				)
-				if err != nil {
-					l.Warn("error creating HTTP timing metadata span", "error", err)
-				}
+		// Extract HTTP timing metadata from httpstat if available.
+		// This captures the detailed connection timing breakdown (DNS, TCP, TLS, TTFB, transfer)
+		// from the HTTP request to the user's SDK function.
+		if resp.HTTPStat != nil {
+			httpTimingMd := extractors.ExtractHTTPTimingMetadata(resp.HTTPStat)
+			_, err := e.createMetadataSpanOnParent(
+				ctx,
+				&instance,
+				"executor.httpTiming",
+				httpTimingMd,
+				enums.MetadataScopeRequest,
+				instance.execSpan,
+			)
+			if err != nil {
+				l.Warn("error creating HTTP timing metadata span", "error", err)
 			}
+		}
 
-			// Attach timing breakdown metadata (queue delay, system latency, network total)
-			if timingMd := extractors.BuildTimingMetadata(instance.item.RunInfo, resp.HTTPStat); timingMd != nil {
-				_, err := e.createMetadataSpanOnParent(
-					ctx,
-					&instance,
-					"executor.timing",
-					timingMd,
-					enums.MetadataScopeRequest,
-					instance.execSpan,
-				)
-				if err != nil {
-					l.Warn("error creating timing metadata span", "error", err)
-				}
+		// Attach timing breakdown metadata (queue delay, system latency, network total)
+		if timingMd := extractors.BuildTimingMetadata(instance.item.RunInfo, resp.HTTPStat); timingMd != nil {
+			_, err := e.createMetadataSpanOnParent(
+				ctx,
+				&instance,
+				"executor.timing",
+				timingMd,
+				enums.MetadataScopeRequest,
+				instance.execSpan,
+			)
+			if err != nil {
+				l.Warn("error creating timing metadata span", "error", err)
 			}
 		}
 
@@ -6208,21 +6205,19 @@ func (e *executor) emitStepSpan(ctx context.Context, runCtx execution.RunContext
 		logger.StdlibLogger(ctx).Warn("error creating step span", "error", err)
 	}
 
-	if e.allowStepMetadata.Enabled(ctx, runCtx.Metadata().ID.Tenant.AccountID) {
-		e.handleGeneratorMetadata(ctx, runCtx, gen, extraMetadata...)
+	e.handleGeneratorMetadata(ctx, runCtx, gen, extraMetadata...)
 
-		// Extract experiment metadata from opcode opts. The SDK spreads
-		// group.experiment() variant context (experimentName, variant,
-		// selectionStrategy) onto variant sub-steps' opts; landing the
-		// same data as a step-scoped metadata span means ClickHouse
-		// can aggregate variant output metrics in a single-row query.
-		//
-		// Performing this emission server-side (rather than via an SDK
-		// addMetadata() call) means clients receive experiment data
-		// without needing to upgrade their SDK, and keeps the metadata
-		// contract consistent across SDK languages.
-		e.emitExperimentMetadataFromOpts(ctx, runCtx, gen)
-	}
+	// Extract experiment metadata from opcode opts. The SDK spreads
+	// group.experiment() variant context (experimentName, variant,
+	// selectionStrategy) onto variant sub-steps' opts; landing the
+	// same data as a step-scoped metadata span means ClickHouse
+	// can aggregate variant output metrics in a single-row query.
+	//
+	// Performing this emission server-side (rather than via an SDK
+	// addMetadata() call) means clients receive experiment data
+	// without needing to upgrade their SDK, and keeps the metadata
+	// contract consistent across SDK languages.
+	e.emitExperimentMetadataFromOpts(ctx, runCtx, gen)
 }
 
 func (e *executor) emitNonStepSpan(ctx context.Context, runCtx execution.RunContext, gen *state.GeneratorOpcode, result *apiresult.APIResult, status enums.StepStatus) {


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This removes the span metadata feature flag (it was always enabled) but keeps enough of the symbols referenced by monorepo to not break things

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
