### PR TITLE
cloud(ui): redesign the org menu on the shared DropdownMenu

### DIFF
--- a/ui/apps/dashboard/src/components/Layout/OrgAvatar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/OrgAvatar.tsx
@@ -1,0 +1,45 @@
+import { Image } from '@unpic/react';
+import { cn } from '@inngest/components/utils/classNames';
+
+import type { ProfileDisplayType } from '@/queries/server/profile';
+
+// The trigger in the top bar uses a small circle; the org menu header uses a
+// larger rounded square.
+const sizes = {
+  sm: { frame: 'h-7 w-7 rounded-full', text: 'text-xs', px: 28 },
+  lg: { frame: 'h-9 w-9 rounded-lg', text: 'text-base', px: 36 },
+} as const;
+
+export default function OrgAvatar({
+  profile,
+  size,
+}: {
+  profile: ProfileDisplayType;
+  size: keyof typeof sizes;
+}) {
+  const orgName = profile.orgName ?? '';
+  const initial = orgName.substring(0, 1) || '?';
+  const { frame, text, px } = sizes[size];
+
+  return (
+    <span
+      className={cn(
+        'bg-canvasMuted text-subtle border-muted flex shrink-0 items-center justify-center overflow-hidden border uppercase',
+        frame,
+        text,
+      )}
+    >
+      {profile.orgProfilePic ? (
+        <Image
+          src={profile.orgProfilePic}
+          className={cn('object-cover', frame)}
+          width={px}
+          height={px}
+          alt="org-profile-pic"
+        />
+      ) : (
+        initial
+      )}
+    </span>
+  );
+}

--- a/ui/apps/dashboard/src/components/Layout/OrgButton.tsx
+++ b/ui/apps/dashboard/src/components/Layout/OrgButton.tsx
@@ -1,6 +1,5 @@
-import { Image } from '@unpic/react';
-
 import type { ProfileDisplayType } from '@/queries/server/profile';
+import OrgAvatar from './OrgAvatar';
 
 export default function OrgButton({
   profile,
@@ -8,23 +7,10 @@ export default function OrgButton({
   profile: ProfileDisplayType;
 }) {
   const orgName = profile.orgName ?? '';
-  const initial = orgName.substring(0, 1) || '?';
 
   return (
     <>
-      <span className="bg-canvasMuted text-subtle flex border border-muted h-7 w-7 shrink-0 items-center justify-center overflow-hidden rounded-full text-xs uppercase">
-        {profile.orgProfilePic ? (
-          <Image
-            src={profile.orgProfilePic}
-            className="h-7 w-7 rounded-full object-cover"
-            width={24}
-            height={24}
-            alt="org-profile-pic"
-          />
-        ) : (
-          initial
-        )}
-      </span>
+      <OrgAvatar profile={profile} size="sm" />
       <span className="max-w-[140px] truncate leading-normal" title={orgName}>
         {orgName}
       </span>

--- a/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
+++ b/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Button } from '@inngest/components/Button';
 import { Skeleton } from '@inngest/components/Skeleton/Skeleton';
 import {
   DropdownMenu,
@@ -81,6 +82,26 @@ export const OrgMenu = ({ children, profile, showOnboardingWidget }: Props) => {
             )}
           </div>
         </DropdownMenuLabel>
+
+        {/* Marketplace accounts are redirected off the plans tab, so the
+            button would be a dead end for them. */}
+        {!profile.isMarketplace && (
+          <div className="px-1.5 pb-1">
+            <Button
+              kind="secondary"
+              appearance="outlined"
+              label="Upgrade"
+              className="w-full"
+              onClick={() => {
+                setOpen(false);
+                navigate({
+                  to: '/billing/plans' as FileRouteTypes['to'],
+                  search: { ref: 'app-org-menu-upgrade' },
+                });
+              }}
+            />
+          </div>
+        )}
 
         <DropdownMenuItem
           onSelect={() =>

--- a/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
+++ b/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from '@inngest/components/DropdownMenu';
 import { useNavigate } from '@tanstack/react-router';
+import { gql, type TypedDocumentNode } from 'urql';
 import {
   RiArrowLeftRightLine,
   RiBillLine,
@@ -21,7 +22,6 @@ import {
 } from '@remixicon/react';
 
 import type { FileRouteTypes } from '@/routeTree.gen';
-import { GetCurrentPlanDocument } from '@/gql/graphql';
 import type { ProfileDisplayType } from '@/queries/server/profile';
 import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 import { pathCreator } from '@/utils/urls';
@@ -35,6 +35,28 @@ type Props = React.PropsWithChildren<{
 
 const iconClassName = 'text-muted h-4 w-4';
 
+type OrgMenuPlanQuery = {
+  account: {
+    // Null on accounts without a resolved plan; the header then shows nothing.
+    plan: { name: string } | null;
+  };
+};
+
+// Only `plan.name` is selected, not the whole plan: the wider GetCurrentPlan
+// document also pulls entitlements, which reads the usage table.
+const OrgMenuPlanDocument: TypedDocumentNode<
+  OrgMenuPlanQuery,
+  Record<string, never>
+> = gql`
+  query OrgMenuPlan {
+    account {
+      plan {
+        name
+      }
+    }
+  }
+`;
+
 export const OrgMenu = ({ children, profile, showOnboardingWidget }: Props) => {
   const navigate = useNavigate();
   const { nextStep, lastCompletedStep } = useOnboardingStep();
@@ -44,7 +66,7 @@ export const OrgMenu = ({ children, profile, showOnboardingWidget }: Props) => {
   // actually opened.
   const [open, setOpen] = useState(false);
   const { data, isLoading } = useSkippableGraphQLQuery({
-    query: GetCurrentPlanDocument,
+    query: OrgMenuPlanDocument,
     variables: {},
     skip: !open,
   });

--- a/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
+++ b/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
@@ -1,4 +1,11 @@
-import { Listbox } from '@headlessui/react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@inngest/components/DropdownMenu';
 import { useNavigate } from '@tanstack/react-router';
 import {
   RiArrowLeftRightLine,
@@ -14,14 +21,14 @@ import type { FileRouteTypes } from '@/routeTree.gen';
 import type { ProfileDisplayType } from '@/queries/server/profile';
 import { pathCreator } from '@/utils/urls';
 import useOnboardingStep from '../Onboarding/useOnboardingStep';
+import OrgAvatar from './OrgAvatar';
 
 type Props = React.PropsWithChildren<{
   profile: ProfileDisplayType;
   showOnboardingWidget: () => void;
 }>;
 
-const itemClassName =
-  'text-muted hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]';
+const iconClassName = 'text-muted h-4 w-4';
 
 export const OrgMenu = ({ children, profile, showOnboardingWidget }: Props) => {
   const navigate = useNavigate();
@@ -34,101 +41,88 @@ export const OrgMenu = ({ children, profile, showOnboardingWidget }: Props) => {
   });
 
   return (
-    <Listbox>
-      <div className="relative flex h-8 items-center">
-        <Listbox.Button className="text-basis hover:bg-canvasMuted flex h-8 cursor-pointer items-center gap-2 rounded px-2 text-sm leading-none ring-0">
-          {children}
-        </Listbox.Button>
-        <Listbox.Options className="bg-canvasBase border-muted shadow-primary absolute left-0 top-full z-50 mt-2 w-[240px] rounded border ring-0 focus:outline-none">
-          <div
-            className="text-basis px-3 pt-3 pb-2 text-sm font-medium"
+    <DropdownMenu>
+      <DropdownMenuTrigger className="text-basis hover:bg-canvasMuted flex h-8 cursor-pointer items-center gap-2 rounded px-2 text-sm leading-none ring-0">
+        {children}
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent className="w-[212px]">
+        <DropdownMenuLabel className="flex items-center gap-2.5 p-2">
+          <OrgAvatar profile={profile} size="lg" />
+          <span
+            className="text-basis min-w-0 truncate text-sm font-medium"
             title={orgName}
           >
             {orgName}
-          </div>
-          <hr className="border-subtle" />
+          </span>
+        </DropdownMenuLabel>
 
-          <Listbox.Option
-            className={itemClassName}
-            value="settings"
-            onClick={() =>
-              navigate({ to: '/settings/organization' as FileRouteTypes['to'] })
-            }
-          >
-            <RiEqualizerLine className="text-muted mr-2 h-4 w-4" />
-            <div>Settings</div>
-          </Listbox.Option>
+        <DropdownMenuItem
+          onSelect={() =>
+            navigate({ to: '/settings/organization' as FileRouteTypes['to'] })
+          }
+        >
+          <RiEqualizerLine className={iconClassName} />
+          Settings
+        </DropdownMenuItem>
 
-          <Listbox.Option
-            className={itemClassName}
-            value="members"
-            onClick={() =>
-              navigate({
-                to: '/settings/organization/organization-members' as FileRouteTypes['to'],
-              })
-            }
-          >
-            <RiGroupLine className="text-muted mr-2 h-4 w-4" />
-            <div>Members</div>
-          </Listbox.Option>
+        <DropdownMenuItem
+          onSelect={() =>
+            navigate({
+              to: '/settings/organization/organization-members' as FileRouteTypes['to'],
+            })
+          }
+        >
+          <RiGroupLine className={iconClassName} />
+          Members
+        </DropdownMenuItem>
 
-          <Listbox.Option
-            className={itemClassName}
-            value="billing"
-            onClick={() => navigate({ to: pathCreator.billing() })}
-          >
-            <RiBillLine className="text-muted mr-2 h-4 w-4" />
-            <div>Billing</div>
-          </Listbox.Option>
+        <DropdownMenuItem
+          onSelect={() => navigate({ to: pathCreator.billing() })}
+        >
+          <RiBillLine className={iconClassName} />
+          Billing
+        </DropdownMenuItem>
 
-          <Listbox.Option
-            className={itemClassName}
-            value="integrations"
-            onClick={() =>
-              navigate({ to: '/settings/integrations' as FileRouteTypes['to'] })
-            }
-          >
-            <RiPlugLine className="text-muted mr-2 h-4 w-4" />
-            <div>Integrations</div>
-          </Listbox.Option>
+        <DropdownMenuItem
+          onSelect={() =>
+            navigate({ to: '/settings/integrations' as FileRouteTypes['to'] })
+          }
+        >
+          <RiPlugLine className={iconClassName} />
+          Integrations
+        </DropdownMenuItem>
 
-          <Listbox.Option
-            className={itemClassName}
-            value="apiKeys"
-            onClick={() =>
-              navigate({ to: '/settings/api-keys' as FileRouteTypes['to'] })
-            }
-          >
-            <RiKey2Line className="text-muted mr-2 h-4 w-4" />
-            <div>API keys</div>
-          </Listbox.Option>
+        <DropdownMenuItem
+          onSelect={() =>
+            navigate({ to: '/settings/api-keys' as FileRouteTypes['to'] })
+          }
+        >
+          <RiKey2Line className={iconClassName} />
+          API keys
+        </DropdownMenuItem>
 
-          <Listbox.Option
-            className={itemClassName}
-            value="onboardingGuide"
-            onClick={() => {
-              showOnboardingWidget();
-              navigate({ to: onboardingTo });
-            }}
-          >
-            <RiBookReadLine className="text-muted mr-2 h-4 w-4" />
-            <div>Onboarding guide</div>
-          </Listbox.Option>
+        <DropdownMenuItem
+          onSelect={() => {
+            showOnboardingWidget();
+            navigate({ to: onboardingTo });
+          }}
+        >
+          <RiBookReadLine className={iconClassName} />
+          Onboarding guide
+        </DropdownMenuItem>
 
-          <hr className="border-subtle mt-2" />
+        <DropdownMenuSeparator />
 
-          <Listbox.Option
-            className={`${itemClassName} mb-2`}
-            value="switchOrg"
-            onClick={() =>
-              navigate({ to: '/organization-list' as FileRouteTypes['to'] })
-            }
-          >
-            <RiArrowLeftRightLine className="text-muted mr-2 h-4 w-4" />
-            <div>Switch organisations</div>
-          </Listbox.Option>
-        </Listbox.Options>
-      </div>
-    </Listbox>
+        <DropdownMenuItem
+          onSelect={() =>
+            navigate({ to: '/organization-list' as FileRouteTypes['to'] })
+          }
+        >
+          <RiArrowLeftRightLine className={iconClassName} />
+          Switch organisations
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };

--- a/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
+++ b/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import { Skeleton } from '@inngest/components/Skeleton/Skeleton';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,7 +20,9 @@ import {
 } from '@remixicon/react';
 
 import type { FileRouteTypes } from '@/routeTree.gen';
+import { GetCurrentPlanDocument } from '@/gql/graphql';
 import type { ProfileDisplayType } from '@/queries/server/profile';
+import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 import { pathCreator } from '@/utils/urls';
 import useOnboardingStep from '../Onboarding/useOnboardingStep';
 import OrgAvatar from './OrgAvatar';
@@ -35,13 +39,23 @@ export const OrgMenu = ({ children, profile, showOnboardingWidget }: Props) => {
   const { nextStep, lastCompletedStep } = useOnboardingStep();
   const orgName = profile.orgName ?? '';
 
+  // The top bar renders on every page, so hold the plan query until the menu is
+  // actually opened.
+  const [open, setOpen] = useState(false);
+  const { data, isLoading } = useSkippableGraphQLQuery({
+    query: GetCurrentPlanDocument,
+    variables: {},
+    skip: !open,
+  });
+  const planName = data?.account.plan?.name;
+
   const onboardingTo = pathCreator.onboardingSteps({
     step: nextStep ? nextStep.name : lastCompletedStep?.name,
     ref: 'app-org-menu-onboarding',
   });
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger className="text-basis hover:bg-canvasMuted flex h-8 cursor-pointer items-center gap-2 rounded px-2 text-sm leading-none ring-0">
         {children}
       </DropdownMenuTrigger>
@@ -49,12 +63,23 @@ export const OrgMenu = ({ children, profile, showOnboardingWidget }: Props) => {
       <DropdownMenuContent className="w-[212px]">
         <DropdownMenuLabel className="flex items-center gap-2.5 p-2">
           <OrgAvatar profile={profile} size="lg" />
-          <span
-            className="text-basis min-w-0 truncate text-sm font-medium"
-            title={orgName}
-          >
-            {orgName}
-          </span>
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <span
+              className="text-basis truncate text-sm font-medium"
+              title={orgName}
+            >
+              {orgName}
+            </span>
+            {isLoading ? (
+              <Skeleton className="h-3 w-16" />
+            ) : (
+              planName && (
+                <span className="text-muted truncate text-xs" title={planName}>
+                  {planName}
+                </span>
+              )
+            )}
+          </div>
         </DropdownMenuLabel>
 
         <DropdownMenuItem

--- a/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
+++ b/ui/apps/dashboard/src/components/Layout/OrgMenu.tsx
@@ -109,19 +109,30 @@ export const OrgMenu = ({ children, profile, showOnboardingWidget }: Props) => {
             button would be a dead end for them. */}
         {!profile.isMarketplace && (
           <div className="px-1.5 pb-1">
-            <Button
-              kind="secondary"
-              appearance="outlined"
-              label="Upgrade"
-              className="w-full"
-              onClick={() => {
-                setOpen(false);
+            {/* Rendered through DropdownMenuItem so it joins Radix's
+                roving-focus group - a bare button is skipped by arrow keys.
+                Radix's Slot appends the item's classes after the child's, and
+                Button merges them last, so p-0 and text-basis are needed here
+                to stop the menu-row padding and muted text from overriding the
+                button's own. */}
+            <DropdownMenuItem
+              asChild
+              className="text-basis p-0"
+              onSelect={() =>
                 navigate({
                   to: '/billing/plans' as FileRouteTypes['to'],
                   search: { ref: 'app-org-menu-upgrade' },
-                });
-              }}
-            />
+                })
+              }
+            >
+              <Button
+                raw
+                kind="secondary"
+                appearance="outlined"
+                label="Upgrade"
+                className="w-full"
+              />
+            </DropdownMenuItem>
           </div>
         )}
 

--- a/ui/apps/dashboard/src/components/Layout/TopBar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/TopBar.tsx
@@ -20,7 +20,7 @@ export default function TopBar({
 }) {
   return (
     <header className="bg-canvasSubtle relative z-[60] flex h-[48px] shrink-0 items-center justify-between gap-3 px-5">
-      <div className="flex h-8 items-center gap-1">
+      <div className="-ml-1 flex h-8 items-center gap-1">
         {profile && (
           <>
             <OrgMenu

--- a/ui/packages/components/src/DropdownMenu/DropdownMenu.tsx
+++ b/ui/packages/components/src/DropdownMenu/DropdownMenu.tsx
@@ -63,3 +63,18 @@ export const DropdownMenuItem = forwardRef<
     </DropdownMenuPrimitive.Item>
   );
 });
+
+export const DropdownMenuSeparator = forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>((props, forwardedRef) => {
+  return (
+    <DropdownMenuPrimitive.Separator
+      {...props}
+      ref={forwardedRef}
+      // The negative inline margin cancels the content's p-0.5 so the rule
+      // spans the full width of the panel.
+      className={cn('border-subtle -mx-0.5 my-1 border-t', props.className)}
+    />
+  );
+});

--- a/ui/packages/components/src/DropdownMenu/DropdownMenu.tsx
+++ b/ui/packages/components/src/DropdownMenu/DropdownMenu.tsx
@@ -34,7 +34,7 @@ export const DropdownMenuContent = forwardRef<
         collisionPadding={8}
         sideOffset={props.sideOffset ?? 8}
         className={cn(
-          'shadow-primary bg-canvasBase border-muted z-50 min-w-40 rounded-md border p-0.5 [&>*:not(:last-child)]:mb-0.5',
+          'shadow-primary bg-canvasBase border-muted z-50 min-w-40 rounded-md border p-0.5 outline-none [&>*:not(:last-child)]:mb-0.5',
           props.className
         )}
       >
@@ -55,7 +55,11 @@ export const DropdownMenuItem = forwardRef<
       {...props}
       ref={forwardedRef}
       className={cn(
-        'text-muted hover:bg-canvasSubtle flex cursor-pointer select-none flex-row items-center gap-2 rounded-md p-2 text-[0.8125rem]',
+        // Radix moves DOM focus onto the hovered item (roving focus), so the
+        // browser's default ring would show on hover. Suppress it and express
+        // the active row through data-highlighted, which covers both pointer
+        // and keyboard navigation.
+        'text-muted hover:bg-canvasSubtle data-[highlighted]:bg-canvasSubtle flex cursor-pointer select-none flex-row items-center gap-2 rounded-md p-2 text-[0.8125rem] outline-none',
         props.className
       )}
     >

--- a/ui/packages/components/src/DropdownMenu/index.ts
+++ b/ui/packages/components/src/DropdownMenu/index.ts
@@ -3,4 +3,6 @@ export {
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
 } from './DropdownMenu';


### PR DESCRIPTION
## Description

Redesigns the top-bar org menu: new header with the org avatar, org name, and current plan, plus an Upgrade button linking to the billing plans tab. Hidden for marketplace accounts, who can't change plans in-app.

Rebuilt on the shared `DropdownMenu` instead of the hand-rolled Headless UI `Listbox` it was using. Adds a `DropdownMenuSeparator` to `@inngest/components` (it had none) and fixes a pre-existing bug where Radix's roving focus made the browser focus ring appear on hover — that one affects all 13 menus on the shared component.

Plan name comes from a narrow `account.plan.name` query, skipped until the menu opens.
<img width="339" height="465" alt="Screenshot 2026-09-03 at 21 01 07" src="https://github.com/user-attachments/assets/4089439d-3f4e-4e72-9ad3-bce42dce036e" />
<img width="331" height="450" alt="Screenshot 2026-09-03 at 21 00 32" src="https://github.com/user-attachments/assets/3538c454-1763-4ff5-bebd-51a0dee0b95b" />

## Release note

None.

## Migration note
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
