### PR TITLE
feat: Simplify plan comparison

### DIFF
--- a/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
+++ b/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
@@ -483,7 +483,7 @@ function InfraPlanDropdown({
                 return (
                   <button
                     className={cn(
-                      'border-subtle text-basis grid w-full grid-cols-[4.25rem_1fr_1fr_6.75rem] items-center gap-x-3 border-t px-3 py-2.5 text-left text-xs disabled:cursor-default disabled:opacity-100',
+                      'border-subtle text-basis grid w-full grid-cols-[4.25rem_1fr_6.75rem] items-center gap-x-3 border-t px-3 py-2.5 text-left text-xs disabled:cursor-default disabled:opacity-100',
                       isCurrent && 'bg-canvasSubtle',
                       isActionable &&
                         'hover:bg-canvasSubtle focus:bg-canvasSubtle focus:outline-none',

--- a/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
+++ b/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
@@ -456,7 +456,6 @@ function InfraPlanDropdown({
             <div className="min-w-[360px]">
               <div className="bg-canvasSubtle text-muted grid grid-cols-[4.25rem_1fr_1fr_6.75rem] gap-x-3 px-3 py-2 text-left text-[11px] font-medium uppercase">
                 <span>SKU</span>
-                <span>Queue depth</span>
                 <span>Concurrency</span>
                 <span className="text-right">Price / mo</span>
               </div>
@@ -506,7 +505,6 @@ function InfraPlanDropdown({
                         {plan.sku}
                       </span>
                     </span>
-                    <PlanMetric value={plan.queueDepth} />
                     <PlanMetric value={plan.execConcurrency} />
                     <span className="flex min-w-0 items-center justify-end gap-2">
                       {isCurrent ? <YourPlanBadge /> : null}

--- a/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
+++ b/ui/apps/dashboard/src/components/InfraDashboard/InfraDashboard.tsx
@@ -454,7 +454,7 @@ function InfraPlanDropdown({
 
           <div className="overflow-x-auto">
             <div className="min-w-[360px]">
-              <div className="bg-canvasSubtle text-muted grid grid-cols-[4.25rem_1fr_1fr_6.75rem] gap-x-3 px-3 py-2 text-left text-[11px] font-medium uppercase">
+              <div className="bg-canvasSubtle text-muted grid grid-cols-[4.25rem_1fr_6.75rem] gap-x-3 px-3 py-2 text-left text-[11px] font-medium uppercase">
                 <span>SKU</span>
                 <span>Concurrency</span>
                 <span className="text-right">Price / mo</span>


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This removes the queue depth metric from the quick plan comparison as it was causing confusion.

<img width="452" height="388" alt="image" src="https://github.com/user-attachments/assets/0037a29e-676b-4dfc-9375-c2230866d285" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
