### PR TITLE
fix(deps): remove stale Tencent SDK replacement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/inngest/inngest
 
 go 1.26.4
 
-replace github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible => github.com/tencentcloud/tencentcloud-sdk-go v1.0.191
-
 require (
 	connectrpc.com/connect v1.16.1
 	cuelang.org/go v0.4.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1843,4 +1843,3 @@ modernc.org/memory
 modernc.org/sqlite
 modernc.org/sqlite/lib
 modernc.org/sqlite/vtab
-# github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible => github.com/tencentcloud/tencentcloud-sdk-go v1.0.191


### PR DESCRIPTION
## Description

https://github.com/inngest/inngest/pull/60 added Terraform v0.15.3 in May 2022 for pkg/inngest's DAG implementation. Terraform's module graph referenced github.com/tencentcloud/tencentcloud-sdk-go v3.0.82+incompatible, and https://github.com/inngest/inngest/pull/599 later carried over a cloud-repository replacement to v1.0.191 in September 2023.

https://github.com/inngest/inngest/pull/1711 removed the Terraform-backed graph code and direct Terraform dependency in September 2024. That also removed Tencent from the module graph, but the standalone replacement remained. Go intentionally preserves standalone replace directives during tidy and writes this versioned replacement to vendor/modules.txt.

The vendor target has used goware/modvendor since https://github.com/inngest/inngest/pull/485 in July 2023. modvendor v0.5.0 treats the six-field replacement entry as a module whose replacement source must exist under GOPATH/pkg/mod. Once Terraform no longer caused the Tencent module to be downloaded, a clean module cache made modvendor fail with 'module path does not exist'. Warm developer caches could conceal the stale directive.

The automated inngestgo vendoring workflow added by https://github.com/inngest/inngest/pull/4223 in May 2026 runs on clean GitHub-hosted runners and has therefore failed in make vendor from its first run. This is not a recent Go strictness change: modvendor v0.5.0 dates to 2021, and the workflow produced the same error on Go 1.25.9 before the repository moved to Go 1.26.4.

Remove the orphaned replacement and its generated vendor metadata. Neither Terraform nor Tencent is present in the current module graph.

Verified with GOWORK=off make vendor while the Tencent replacement directory was absent from the module cache.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
