### PR TITLE
doc: fix Go version and dist path in contributing guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The following instructions will help you build and run the Inngest CLI locally.
 ### Prerequisites
 
 - [Git](https://git-scm.com/downloads)
-- [Go 1.18 or higher](https://golang.org/doc/install)
+- [Go](https://golang.org/doc/install) — version per the `go` directive in [`go.mod`](../go.mod) (currently 1.26.4)
 - [GoReleaser](https://goreleaser.com/install/)
 - [GolangCI-Lint](https://golangci-lint.run/welcome/install/#local-installation)
 
@@ -17,6 +17,6 @@ The following instructions will help you build and run the Inngest CLI locally.
 
 1. Clone this repository
 2. Build the CLI by running `make dev`
-   - Your recently built CLI will be available at `./dist/innest_[system_arch]/inngest` (e.g.
+   - Your recently built CLI will be available at `./dist/inngest_[system_arch]/inngest` (e.g.
      `./dist/inngest_darwin_arm64/inngest`)
 3. Run `./dist/inngest_[system_arch]/inngest` to see the CLI in action


### PR DESCRIPTION
## Description

Two corrections to `docs/CONTRIBUTING.md`:

1. The prerequisites listed Go 1.18 or higher, but `go.mod` declares
   `go 1.26.4`. Following the guide on 1.18 fails to build. CI already
   resolves the toolchain with `go-version-file: ./go.mod`, so the doc
   now points at go.mod rather than restating a version that drifts.
2. The build output path was written as `./dist/innest_[system_arch]/`.
   Corrected to `inngest_`, matching the path on the following line.

## Release note

None.

## Migration note

None.