### PR TITLE
fix(cel): Improve certain classes of cel filter errors

### DIFF
--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -3793,15 +3793,17 @@ func spanRunCELFilters(
 		run.WithExpressionSQLConverter(h.CELConverter()),
 	)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("%w: %v", cqrs.ErrInvalidRunExpression, err)
 	}
+	// CEL parsing can succeed for identifiers this SQL backend cannot filter on.
+	// Reject those expressions instead of silently returning unfiltered runs.
 	if !expHandler.HasFilters() {
-		return celFilters, useJoin, nil
+		return nil, false, fmt.Errorf("%w: expression has no supported predicates", cqrs.ErrInvalidRunExpression)
 	}
 
 	celFilters, err = expHandler.ToSQLFilters(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf("%w: %v", cqrs.ErrInvalidRunExpression, err)
 	}
 	useJoin = needsEventJoin(opt.Filter.CEL)
 

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -2358,6 +2358,29 @@ func TestCQRSGetSpanRunsCELJoinQualifiesTenantFilters(t *testing.T) {
 	assert.Equal(t, 1, count)
 }
 
+func TestCQRSGetSpanRunsRejectsUnsupportedCELPredicates(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	for _, expression := range []string{
+		`foo.bar == 1`,
+		`event.data.tenant == "target" || foo.bar == 1`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			_, err := cm.GetTraceRuns(t.Context(), cqrs.GetTraceRunOpt{
+				Filter: cqrs.GetTraceRunFilter{
+					TimeField: enums.TraceRunTimeStartedAt,
+					From:      time.Now().Add(-time.Hour),
+					Until:     time.Now().Add(time.Hour),
+					CEL:       expression,
+				},
+				Preview: true,
+			})
+			require.ErrorIs(t, err, cqrs.ErrInvalidRunExpression)
+		})
+	}
+}
+
 // Root-page results must derive end_time/status from EXTEND spans.
 func TestCQRSGetSpanRunsEnrichmentFromExtendSpans(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -16,6 +17,8 @@ import (
 	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/oklog/ulid/v2"
 )
+
+var ErrInvalidRunExpression = errors.New("invalid run expression")
 
 type SpanStatus int
 

--- a/pkg/run/cel.go
+++ b/pkg/run/cel.go
@@ -91,7 +91,7 @@ func (h *ExpressionHandler) add(ctx context.Context, cel []string) error {
 
 	for _, e := range cel {
 		// empty string, skip
-		for len(e) == 0 {
+		if len(e) == 0 {
 			continue
 		}
 

--- a/pkg/run/cel_sql.go
+++ b/pkg/run/cel_sql.go
@@ -92,7 +92,7 @@ func EventFieldConverter(ctx context.Context, n *expr.Node) ([]sq.Expression, er
 	if f != nil {
 		return []sq.Expression{f}, nil
 	}
-	return []sq.Expression{}, nil
+	return nil, fmt.Errorf("unsupported event field or operator: %s %s", n.Predicate.Ident, n.Predicate.Operator)
 }
 
 // dbDialect contains database-specific SQL generation settings for span+event queries.

--- a/pkg/run/cel_test.go
+++ b/pkg/run/cel_test.go
@@ -265,6 +265,27 @@ func TestToSQLFiltersWithSQLiteConverter(t *testing.T) {
 	}
 }
 
+func TestSpanEventConverterRejectsUnsupportedPredicates(t *testing.T) {
+	tests := []string{
+		`event.unknown == 1`,
+		`event.name > "app/"`,
+	}
+
+	for _, expression := range tests {
+		t.Run(expression, func(t *testing.T) {
+			handler, err := NewExpressionHandler(t.Context(),
+				WithExpressionHandlerExpressions([]string{expression}),
+				WithExpressionSQLConverter(SpanEventSQLiteConverter),
+			)
+			require.NoError(t, err)
+
+			filters, err := handler.ToSQLFilters(t.Context())
+			require.Error(t, err)
+			require.Empty(t, filters)
+		})
+	}
+}
+
 func TestToSQLFiltersWithPostgresConverter(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/run/cel_test.go
+++ b/pkg/run/cel_test.go
@@ -23,6 +23,10 @@ func TestValidateExpressionHandler(t *testing.T) {
 			cel:  []string{`event.name == "test/hello"`, `output.success == true`},
 		},
 		{
+			name: "empty lines are ignored",
+			cel:  []string{`event.name == "test/hello"`, ""},
+		},
+		{
 			name:   "invalid AND",
 			cel:    []string{`event.name == "test/hello" and event.ts > 1727291508963`},
 			errStr: "mismatched input 'and'",


### PR DESCRIPTION
## Description

Hardens the existing CEL run-filtering path by:

- Skipping empty expression lines instead of looping indefinitely.
- Rejecting predicates the SQL backend cannot apply instead of silently returning unfiltered runs.
- Returning a sentinel invalid-expression error so callers can identify these failures without matching error strings.

## Release note

- CEL run searches now return an explicit error for unsupported fields or operators instead of silently ignoring the filter and returning unfiltered runs. 
- Blank lines in CEL expressions are now safely ignored.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
