### PR TITLE
fix(util): return an error when a crit section panics

### DIFF
--- a/pkg/util/critctx.go
+++ b/pkg/util/critctx.go
@@ -94,7 +94,10 @@ func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) 
 							"recover":   fmt.Sprintf("%v", r),
 						}),
 					)
-					if err != nil {
+					// f panicked before assigning its return values, so err is
+					// still nil here.  Surface the panic as the error, but never
+					// clobber an error f already returned.
+					if err == nil {
 						err = fmt.Errorf("panic in crit: %v", r)
 					}
 					doneCh <- pair[T]{res: res, err: err}

--- a/pkg/util/critctx_test.go
+++ b/pkg/util/critctx_test.go
@@ -117,6 +117,21 @@ func TestCrit(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("It should return an error if the crit panics", func(t *testing.T) {
+		buf := bytes.NewBuffer(nil)
+		log := logger.StdlibLogger(bg, logger.WithLoggerWriter(buf))
+		ctx := logger.WithStdlib(bg, log)
+
+		res, err := CritT(ctx, "panicky", func(ctx context.Context) (int, error) {
+			panic("everything is on fire")
+		}, WithTimeout(time.Second))
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "panic in crit: everything is on fire")
+		require.Equal(t, 0, res)
+		require.Contains(t, buf.String(), "panic in crit")
+	})
+
 	t.Run("It should return context deadline error if execution exceeds expected duration", func(t *testing.T) {
 		ctx := context.Background()
 		var called bool


### PR DESCRIPTION
## Description

`CritT` in `pkg/util/critctx.go` runs `f` in a goroutine when `WithTimeout` is set and recovers any panic it raises. The recover branch guards the error it builds with `if err != nil` (pkg/util/critctx.go:97), but `err` there is the local from `res, err = f(ctx)` on line 103, and that assignment never runs when `f` panics. So `err` is always nil inside the recover, the guard never fires, and the goroutine sends `pair{res: <zero>, err: nil}` on `doneCh`. `CritT` returns a zero value and no error, and the caller reads a panic as a success.

`pkg/execution/executor/executor.go:2201` wraps the step-run path in `CritT` with `util.WithTimeout(consts.MaxFunctionTimeout+5*time.Second)`, so a panic while running a step reached the executor as a nil `*state.DriverResponse` with a nil error instead of a failure. The panic is still reported through `logger.ReportError`, which is why this has been quiet.

The fix flips the guard to `if err == nil`, so the panic becomes the returned error and an error `f` returned on its own is never clobbered. That is the same nil guard added to `queue.RetryAtError` in #3582, the PR that introduced this recover block.

Verification, on macOS arm64 with Go 1.26.4, `TEST_MODE=true TEST_DATABASE=sqlite`:

`go test -count=1 -run 'TestCrit/It_should_return_an_error_if_the_crit_panics' ./pkg/util/` against unmodified `main` fails with `Error: An error is expected but got nil.` at critctx_test.go:129, and passes with the change.

`go test -count=1 -race ./pkg/util/...` passes: `ok github.com/inngest/inngest/pkg/util 3.072s` plus aigateway, rueidisconn, strduration, strtimeout and ttlupsert all ok.

`golangci-lint run ./pkg/util/...` (v2.11.4, the version pinned in .github/workflows/go.yaml) reports `0 issues.`, and `gofmt -l` and `go vet ./pkg/util/` are clean.

## Release note

Panics inside a critical section are now returned as errors. A panic while running a step previously surfaced to the executor as an empty successful response, so the run could advance as if the step had completed.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
