### PR TITLE
fix(connect): derive gateway session JWT secret from the signing key

### DIFF
--- a/pkg/connect/auth/jwt.go
+++ b/pkg/connect/auth/jwt.go
@@ -2,7 +2,9 @@ package auth
 
 import (
 	"context"
+	"crypto/hkdf"
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"time"
 
@@ -14,6 +16,33 @@ import (
 
 const wellKnownClaimIssuer = "connect.inngest.com"
 const wellKnownClaimAudience = "gateway.connect.inngest.com"
+
+const (
+	// sessionJwtSecretSalt and sessionJwtSecretInfo domain-separate the HKDF
+	// derivation below from any other use of the signing key.
+	sessionJwtSecretSalt = "inngest-connect-gateway-session-jwt"
+	sessionJwtSecretInfo = "v1"
+	sessionJwtSecretSize = 32
+)
+
+// DeriveSessionJwtSecret derives the HS256 secret used to mint and verify
+// connect gateway session tokens from the instance's signing key.
+//
+// The dev server wires both the session-token signer (POST /v0/connect/start,
+// which is authenticated with the signing key) and the gateway's token
+// verifier with the same secret, so clients that legitimately hold the
+// signing key always receive tokens minted from this derived secret, while
+// attackers who only know the public repo-wide dev constant cannot forge
+// tokens.
+func DeriveSessionJwtSecret(signingKey string) ([]byte, error) {
+	return hkdf.Key(
+		sha256.New,
+		[]byte(signingKey),
+		[]byte(sessionJwtSecretSalt),
+		sessionJwtSecretInfo,
+		sessionJwtSecretSize,
+	)
+}
 
 const DefaultExpiry = time.Minute * 5
 

--- a/pkg/connect/auth/jwt_test.go
+++ b/pkg/connect/auth/jwt_test.go
@@ -156,8 +156,8 @@ func TestSessionToken(t *testing.T) {
 				Subject:  accountId.String(),
 				Audience: []string{wellKnownClaimAudience},
 				// ExpiresAt: jwt.NewNumericDate(time.Now().Add(DefaultExpiry)),
-				IssuedAt: jwt.NewNumericDate(time.Now()),
-				ID:       "fake-token",
+				// IssuedAt:  jwt.NewNumericDate(time.Now()),
+				ID: "fake-token",
 			},
 			Env: envId,
 		})
@@ -173,4 +173,55 @@ func TestSessionToken(t *testing.T) {
 		require.Nil(t, response)
 	})
 
+}
+
+func TestDeriveSessionJwtSecret(t *testing.T) {
+	accountId, envId := uuid.New(), uuid.New()
+	signingKey := "aabbccddeeff00112233445566778899"
+
+	derived, err := DeriveSessionJwtSecret(signingKey)
+	require.NoError(t, err)
+	require.Len(t, derived, sessionJwtSecretSize)
+	require.NotEqual(t, []byte(signingKey), derived)
+
+	// Deterministic: the same signing key derives the same secret across
+	// restarts, so existing deployments keep verifying after a restart.
+	again, err := DeriveSessionJwtSecret(signingKey)
+	require.NoError(t, err)
+	require.Equal(t, derived, again)
+
+	// Distinct per signing key.
+	other, err := DeriveSessionJwtSecret("00112233445566778899aabbccddeeff")
+	require.NoError(t, err)
+	require.NotEqual(t, derived, other)
+
+	t.Run("tokens signed with derived secret are rejected under the public dev constant", func(t *testing.T) {
+		// A token minted by an instance that derived its secret from the
+		// signing key must not verify against the public repo-wide constant.
+		created, err := signSessionToken(derived, accountId, envId, DefaultExpiry, Entitlements{})
+		require.NoError(t, err)
+
+		_, err = VerifySessionToken([]byte("this-does-not-need-to-be-secret"), created)
+		require.Error(t, err)
+	})
+
+	t.Run("tokens forged with the public dev constant are rejected under the derived secret", func(t *testing.T) {
+		// The attack direction: an attacker who only knows the public repo
+		// constant cannot mint a token that verifies against the derived secret.
+		forged, err := signSessionToken([]byte("this-does-not-need-to-be-secret"), accountId, envId, DefaultExpiry, Entitlements{})
+		require.NoError(t, err)
+
+		_, err = VerifySessionToken(derived, forged)
+		require.Error(t, err)
+	})
+
+	t.Run("tokens minted with the derived secret verify against it", func(t *testing.T) {
+		created, err := signSessionToken(derived, accountId, envId, DefaultExpiry, Entitlements{})
+		require.NoError(t, err)
+
+		response, err := VerifySessionToken(derived, created)
+		require.NoError(t, err)
+		require.Equal(t, accountId, response.AccountID)
+		require.Equal(t, envId, response.EnvID)
+	})
 }

--- a/pkg/consts/devserver.go
+++ b/pkg/consts/devserver.go
@@ -32,6 +32,13 @@ var (
 	DevServerAccountID = uuid.MustParse("00000000-0000-4000-a000-000000000000")
 	DevServerEnvID     = uuid.MustParse("00000000-0000-4000-b000-000000000000")
 
+	// DevServerConnectJwtSecret is the connect gateway session-token secret
+	// used ONLY when no signing key is configured, i.e. single-user `inngest
+	// dev` runs. When a signing key is present, a per-instance secret is
+	// derived from it instead (see auth.DeriveSessionJwtSecret) so that
+	// forged HS256 tokens signed with this public constant are rejected on
+	// production-posture `inngest start`. This value is public by design and
+	// must never be treated as secret.
 	DevServerConnectJwtSecret  = []byte("this-does-not-need-to-be-secret")
 	DevServerRealtimeJWTSecret = []byte("dev-mode-is-not-secret")
 	DevServerRunJWTSecret      = []byte("dev-mode-is-not-secret")

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -617,6 +617,24 @@ func start(ctx context.Context, opts StartOpts) error {
 	// registering functions.
 	devAPI := NewDevAPI(ds, DevAPIOptions{AuthMiddleware: authn.SigningKeyMiddleware(opts.SigningKey), disableUI: opts.NoUI})
 
+	// The connect gateway binds all interfaces and its only authentication is
+	// session-JWT verification, so the signing secret must not be a public
+	// repo-wide constant. Whenever a signing key is configured (`inngest start`
+	// requires one; `inngest dev` may set one) derive a per-instance secret
+	// from it; both the token signer and the gateway verifier below share the
+	// same derived secret, so legitimately minted tokens keep working while
+	// tokens forged with the public dev constant are rejected. The public
+	// constant remains only as an escape hatch for single-user `inngest dev`
+	// runs with no signing key configured.
+	connectJwtSecret := consts.DevServerConnectJwtSecret
+	if opts.SigningKey != nil && *opts.SigningKey != "" {
+		derived, err := auth.DeriveSessionJwtSecret(*opts.SigningKey)
+		if err != nil {
+			return fmt.Errorf("failed to derive connect gateway session jwt secret: %w", err)
+		}
+		connectJwtSecret = derived
+	}
+
 	core, err := coreapi.NewCoreApi(coreapi.Options{
 		AuthMiddleware: authn.SigningKeyMiddleware(opts.SigningKey),
 		Data:           ds.Data,
@@ -633,7 +651,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			GroupManager:               connectionManager,
 			ConnectManager:             connectionManager,
 			ConnectRequestStateManager: connectionManager,
-			Signer:                     auth.NewJWTSessionTokenSigner(consts.DevServerConnectJwtSecret),
+			Signer:                     auth.NewJWTSessionTokenSigner(connectJwtSecret),
 			RequestAuther:              ds,
 			ConnectGatewayRetriever:    ds,
 			Dev:                        true,
@@ -691,7 +709,7 @@ func start(ctx context.Context, opts StartOpts) error {
 
 	connGateway := connect.NewConnectGatewayService(
 		connect.WithConnectionStateManager(connectionManager),
-		connect.WithGatewayAuthHandler(auth.NewJWTAuthHandler(consts.DevServerConnectJwtSecret)),
+		connect.WithGatewayAuthHandler(auth.NewJWTAuthHandler(connectJwtSecret)),
 		connect.WithDev(),
 		connect.WithGatewayPublicPort(opts.ConnectGatewayPort),
 		connect.WithGRPCConfig(opts.ConnectGRPCConfig),


### PR DESCRIPTION
## Description

On `inngest start` (self-hosted production posture), the connect gateway's session-token signer (`POST /v0/connect/start`) and its verifier were both wired with the hardcoded, public repo-wide constant `DevServerConnectJwtSecret` (`"this-does-not-need-to-be-secret"`). The gateway WebSocket endpoint binds all interfaces (`:8289`), and JWT verification is its only authentication, so anyone who read the source could mint a session token and register a READY worker connection with no credentials. From a harness run against a local `inngest start`:

```
[*] ATTACKER: forging session JWT with public constant 'this-does-not-need-to-be-secret'
    -> GATEWAY_CONNECTION_READY: forged worker ACCEPTED with NO signing key
    -> attacker joined the victim's worker group (state-registered, READY)
```

This PR derives the session secret from the signing key instead:

- New `auth.DeriveSessionJwtSecret(signingKey)` in `pkg/connect/auth/jwt.go`: HKDF-SHA256 via the stdlib `crypto/hkdf`, domain-separated (dedicated salt/info) from every other use of the signing key, which continues to sign requests.
- `pkg/devserver/devserver.go`: when `opts.SigningKey` is set, both the token signer and the gateway auth handler use the derived secret. `inngest start` requires a signing key, so production posture always gets a per-instance secret.
- The public constant remains only for single-user `inngest dev` runs with no signing key, now documented as such in `pkg/consts/devserver.go`.

Why HKDF from the signing key: no new persisted state; deterministic, so the secret is stable across restarts and across replicas sharing the signing key; rotating the signing key rotates the session secret (acceptable — session tokens are short-lived at 5 minutes and re-minted per connection).

After the fix, the forged-token connection is rejected — the gateway closes the WebSocket with `1008 connect_authentication_failed` — while tokens legitimately minted via `/v0/connect/start` still reach `GATEWAY_CONNECTION_READY`.

## Test matrix

`TestDeriveSessionJwtSecret` in `pkg/connect/auth/jwt_test.go`:

- Deterministic: the same signing key derives the same secret, so tokens keep verifying across restarts.
- Distinct per signing key.
- Token minted with the derived secret is **rejected** under the public dev constant.
- Token forged with the public dev constant is **rejected** under the derived secret (the attack direction).
- Token minted with the derived secret verifies against it (happy path).

## Edge cases

- Existing legit workers: SDKs obtain tokens via `/v0/connect/start`, which is signing-key authenticated and mints from the same derived secret — no change.
- `inngest dev` with no signing key: public constant retained by design (single-user local escape hatch); `inngest dev --signing-key X` upgrades to the derived secret automatically. Existing dev workflows are unchanged.

## Release note

- Self-hosted `inngest start` now derives the connect gateway session-token secret from the signing key (HKDF-SHA256) instead of a public repo-wide constant, so session tokens can no longer be forged from knowledge of the source. Single-user `inngest dev` without a signing key is unchanged.

## Migration note

None. No new configuration or persisted state; tokens are short-lived and re-minted per connection, so rolling restarts need no coordination.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
