### PR TITLE
chore(deps): upgrade golangci-lint to 2.13.2

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.11.4
+          version: v2.13.2
           args: --verbose
 
   gen:

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,22 @@
         "type": "github"
       }
     },
+    "golangci-lint-override": {
+      "locked": {
+        "lastModified": 1788404924,
+        "narHash": "sha256-lhEhY8X5EgkQ/eg6IFz4cc8jRuSYSvnxx1al7d1dvZ0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0968519e14f7aa7d3e9b389682bd74d2b51c8ce8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0968519e14f7aa7d3e9b389682bd74d2b51c8ce8",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1783459476,
@@ -37,6 +53,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "golangci-lint-override": "golangci-lint-override",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,9 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=master";
     flake-utils.url = "github:numtide/flake-utils";
+    # Temporary until the next nixpkgs lock update provides golangci-lint 2.13.2.
+    golangci-lint-override.url =
+      "github:nixos/nixpkgs/0968519e14f7aa7d3e9b389682bd74d2b51c8ce8";
   };
 
   outputs =
@@ -11,6 +14,7 @@
       self,
       nixpkgs,
       flake-utils,
+      golangci-lint-override,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
@@ -21,6 +25,7 @@
 
           config.allowUnfree = true;
         };
+        golangci-lint = golangci-lint-override.legacyPackages.${system}.golangci-lint;
         corepack = pkgs.stdenv.mkDerivation {
           name = "corepack";
           buildInputs = [ pkgs.nodejs_22 ];


### PR DESCRIPTION
## Description

Use newer golangci-lint so we can enable some linters without weird regexes to disable rules

counterpart of https://github.com/inngest/monorepo/pull/8562

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
