### PR TITLE
fix(queue): route requeues to current shard

### DIFF
--- a/pkg/execution/queue/requeue.go
+++ b/pkg/execution/queue/requeue.go
@@ -2,33 +2,55 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
 func (q *queueProducer) Requeue(ctx context.Context, shardName string, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return err
+	// Account routing may have changed while this item was leased. Prefer the
+	// current shard so a migrated copy is requeued at its destination. During
+	// the copy window the destination may not contain the item yet; falling back
+	// to the named source preserves it for the migration reader.
+	current, resolveErr := q.selectShard(ctx, "", i)
+	if resolveErr == nil {
+		err := current.Requeue(ctx, i, at, opts...)
+		if err == nil || current.Name() == shardName || !errors.Is(err, ErrQueueItemNotFound) {
+			return err
+		}
 	}
 
-	return shard.Requeue(ctx, i, at, opts...)
+	source, err := q.shards.ByName(shardName)
+	if err != nil {
+		if resolveErr != nil {
+			return resolveErr
+		}
+		return err
+	}
+	return source.Requeue(ctx, i, at, opts...)
 }
 
 // RequeueByJobID requires scope to include account, environment, and function
-// IDs, preserving the producer interface contract used by wrappers. This
-// producer does not use scope for lookup or shard selection: shardName selects
-// the shard and jobID identifies the item within that shard. Other producer
-// implementations, such as Cloud rollout wrappers, may use scope before
-// delegating for account-level feature flag or routing decisions.
+// IDs. It prefers the account's current shard and falls back to shardName while
+// a migration has not copied the item yet.
 func (q *queueProducer) RequeueByJobID(ctx context.Context, scope Scope, shardName string, jobID string, at time.Time) error {
 	if err := scope.ValidateIDs(); err != nil {
 		return err
 	}
 
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return err
+	current, resolveErr := q.shards.Resolve(ctx, scope, nil)
+	if resolveErr == nil {
+		err := current.RequeueByJobID(ctx, jobID, at)
+		if err == nil || current.Name() == shardName || !errors.Is(err, ErrQueueItemNotFound) {
+			return err
+		}
 	}
 
-	return shard.RequeueByJobID(ctx, jobID, at)
+	source, err := q.shards.ByName(shardName)
+	if err != nil {
+		if resolveErr != nil {
+			return resolveErr
+		}
+		return err
+	}
+	return source.RequeueByJobID(ctx, jobID, at)
 }

--- a/pkg/execution/queue/requeue_test.go
+++ b/pkg/execution/queue/requeue_test.go
@@ -7,8 +7,28 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/stretchr/testify/require"
 )
+
+type requeueRoutingShard struct {
+	QueueShard
+	name             string
+	requeueErr       error
+	requeueByIDErr   error
+	requeueCalls     int
+	requeueByIDCalls int
+}
+
+func (s *requeueRoutingShard) Name() string { return s.name }
+func (s *requeueRoutingShard) Requeue(context.Context, QueueItem, time.Time, ...RequeueOptionFn) error {
+	s.requeueCalls++
+	return s.requeueErr
+}
+func (s *requeueRoutingShard) RequeueByJobID(context.Context, string, time.Time) error {
+	s.requeueByIDCalls++
+	return s.requeueByIDErr
+}
 
 func TestProducerRequeueByJobIDRejectsInvalidScope(t *testing.T) {
 	ctx := context.Background()
@@ -54,5 +74,77 @@ func TestProducerRequeueByJobIDRejectsInvalidScope(t *testing.T) {
 				require.EqualError(t, err, tt.wantErr)
 			})
 		}
+	}
+}
+
+func TestProducerRequeueUsesCurrentShardWithSourceFallback(t *testing.T) {
+	functionID := uuid.New()
+	item := QueueItem{
+		ID:         "job-1",
+		FunctionID: functionID,
+		Data: Item{Identifier: state.Identifier{
+			WorkflowID:  functionID,
+			WorkspaceID: uuid.New(),
+			AccountID:   uuid.New(),
+		}},
+	}
+
+	tests := []struct {
+		name            string
+		destinationErr  error
+		wantSourceCalls int
+		wantDestCalls   int
+	}{
+		{name: "destination owns migrated item", wantDestCalls: 1},
+		{name: "item not copied yet falls back to source", destinationErr: ErrQueueItemNotFound, wantSourceCalls: 1, wantDestCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := &requeueRoutingShard{name: "source"}
+			destination := &requeueRoutingShard{name: "destination", requeueErr: tt.destinationErr}
+			registry := mustShardRegistry(t,
+				map[string]QueueShard{"source": source, "destination": destination},
+				WithShardSelector(func(context.Context, Scope, *string) (QueueShard, error) {
+					return destination, nil
+				}),
+			)
+			producer := &queueProducer{shards: registry}
+
+			require.NoError(t, producer.Requeue(context.Background(), "source", item, time.Now()))
+			require.Equal(t, tt.wantSourceCalls, source.requeueCalls)
+			require.Equal(t, tt.wantDestCalls, destination.requeueCalls)
+		})
+	}
+}
+
+func TestProducerRequeueByJobIDUsesCurrentShardWithSourceFallback(t *testing.T) {
+	tests := []struct {
+		name            string
+		destinationErr  error
+		wantSourceCalls int
+		wantDestCalls   int
+	}{
+		{name: "destination owns migrated item", wantDestCalls: 1},
+		{name: "item not copied yet falls back to source", destinationErr: ErrQueueItemNotFound, wantSourceCalls: 1, wantDestCalls: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := &requeueRoutingShard{name: "source"}
+			destination := &requeueRoutingShard{name: "destination", requeueByIDErr: tt.destinationErr}
+			registry := mustShardRegistry(t,
+				map[string]QueueShard{"source": source, "destination": destination},
+				WithShardSelector(func(context.Context, Scope, *string) (QueueShard, error) {
+					return destination, nil
+				}),
+			)
+			producer := &queueProducer{shards: registry}
+			scope := Scope{AccountID: uuid.New(), EnvID: uuid.New(), FunctionID: uuid.New()}
+
+			require.NoError(t, producer.RequeueByJobID(context.Background(), scope, "source", "job-1", time.Now()))
+			require.Equal(t, tt.wantSourceCalls, source.requeueByIDCalls)
+			require.Equal(t, tt.wantDestCalls, destination.requeueByIDCalls)
+		})
 	}
 }


### PR DESCRIPTION
## Description

Queue items can be leased on one shard while account routing migrates to another. Requeue and RequeueByJobID now prefer the account current shard so an already-copied item is rescheduled at the destination. If the destination does not contain the item yet, they fall back to the caller-provided source shard so the migration reader can copy it later without losing the job.

## Release note

None

## Migration note

None

## Tests

- `go test -count=1 -run "TestProducerRequeue" ./pkg/execution/queue`