### PR TITLE
refactor: use go 1.26 new expressions

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -4,6 +4,9 @@
     "timeout": "10m"
   },
   "linters": {
+    "enable": [
+      "modernize"
+    ],
     "exclusions": {
       "paths": [
         "vendor"
@@ -25,6 +28,35 @@
       ]
     },
     "settings": {
+      "modernize": {
+        "disable": [
+          "any",
+          "atomictypes",
+          "embedlit",
+          "errorsastype",
+          "forvar",
+          "importcomment",
+          "mapsloop",
+          "minmax",
+          "omitzero",
+          "plusbuild",
+          "rangeint",
+          "reflecttypeassert",
+          "reflecttypefor",
+          "slicesbackward",
+          "slicesclip",
+          "slicescontains",
+          "slicessort",
+          "stditerators",
+          "stringsbuilder",
+          "stringscut",
+          "stringscutprefix",
+          "stringsseq",
+          "testingcontext",
+          "unsafefuncs",
+          "waitgroupgo"
+        ]
+      },
       "staticcheck": {
         "checks": [
           "all",

--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -278,7 +278,7 @@ func (a checkpointAPI) CheckpointNewRun(w http.ResponseWriter, r *http.Request) 
 			}},
 			realtime.NewJWTOpts{
 				// Add a minute buffer just in case.
-				Expiry: util.ToPtr(realtime.MaxDurpStreamingRun + time.Minute),
+				Expiry: new(realtime.MaxDurpStreamingRun + time.Minute),
 			},
 		)
 		if err != nil {

--- a/pkg/api/apiv1/checkpoint_types.go
+++ b/pkg/api/apiv1/checkpoint_types.go
@@ -158,7 +158,7 @@ func (r CheckpointNewRunRequest) Fn(appID uuid.UUID) inngest.Function {
 				ID:      "step",
 				Name:    r.FnSlug(),
 				URI:     uri,
-				Retries: inngestgo.Ptr(retries),
+				Retries: new(retries),
 			},
 		},
 	}

--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -231,8 +231,8 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 	}
 
 	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
-		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, util.ToPtr(auth.AccountID()))
-		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID()))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, new(auth.AccountID()))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, new(auth.WorkspaceID()))
 		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &stateMetadata.ID.FunctionID)
 		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &stateMetadata.ID.RunID)
 		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &stateMetadata.ID.Tenant.AppID)
@@ -384,8 +384,8 @@ func (a router) addRunMetadataLegacy(ctx context.Context, auth apiv1auth.V1Auth,
 	}
 
 	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
-		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, util.ToPtr(auth.AccountID()))
-		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID()))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, new(auth.AccountID()))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, new(auth.WorkspaceID()))
 		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &parentSpan.FunctionID)
 		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &parentSpan.RunID)
 		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &parentSpan.AppID)

--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -22,7 +22,6 @@ import (
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -319,8 +318,8 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 		meta.Attr(meta.Attrs.RunID, &runID),
 		meta.Attr(meta.Attrs.AppID, &fn.AppID),
 		meta.Attr(meta.Attrs.FunctionID, &functionID),
-		meta.Attr(meta.Attrs.AccountID, util.ToPtr(auth.AccountID())),
-		meta.Attr(meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID())),
+		meta.Attr(meta.Attrs.AccountID, new(auth.AccountID())),
+		meta.Attr(meta.Attrs.EnvID, new(auth.WorkspaceID())),
 	)
 
 	// By default, the parent span is the trace ref we found.

--- a/pkg/api/v2/apiv2mcp/tools.go
+++ b/pkg/api/v2/apiv2mcp/tools.go
@@ -60,9 +60,9 @@ func tool(endpoint apiv2endpoint.Endpoint, includeEnv bool) *mcp.Tool {
 		InputSchema: inputSchema(endpoint, includeEnv),
 		Annotations: &mcp.ToolAnnotations{
 			ReadOnlyHint:    readOnly,
-			DestructiveHint: boolPointer(!readOnly),
+			DestructiveHint: new(!readOnly),
 			IdempotentHint:  readOnly || endpoint.HTTPMethod == http.MethodPut || endpoint.HTTPMethod == http.MethodDelete,
-			OpenWorldHint:   boolPointer(false),
+			OpenWorldHint:   new(false),
 		},
 	}
 }
@@ -337,6 +337,7 @@ func ToolError(message string, structured any) *mcp.CallToolResult {
 	}
 }
 
+//go:fix inline
 func boolPointer(value bool) *bool {
-	return &value
+	return new(value)
 }

--- a/pkg/api/v2/apiv2mcp/tools.go
+++ b/pkg/api/v2/apiv2mcp/tools.go
@@ -336,8 +336,3 @@ func ToolError(message string, structured any) *mcp.CallToolResult {
 		IsError:           true,
 	}
 }
-
-//go:fix inline
-func boolPointer(value bool) *bool {
-	return new(value)
-}

--- a/pkg/api/v2/endpoints_event_test.go
+++ b/pkg/api/v2/endpoints_event_test.go
@@ -64,7 +64,7 @@ func TestService_SendEvent(t *testing.T) {
 		Name: "app/user.created",
 		Data: data,
 		User: user,
-		Id:   stringPointer("event-idempotency-key"),
+		Id:   new("event-idempotency-key"),
 		Ts:   &timestamp,
 	})
 
@@ -108,7 +108,7 @@ func TestService_SendEventValidation(t *testing.T) {
 			name: "timestamp too old",
 			request: &apiv2.SendEventRequest{
 				Name: "test/event",
-				Ts:   int64Pointer(time.Date(1979, 12, 31, 23, 59, 59, 0, time.UTC).UnixMilli()),
+				Ts:   new(time.Date(1979, 12, 31, 23, 59, 59, 0, time.UTC).UnixMilli()),
 			},
 			error: "timestamp is before Jan 1, 1980",
 		},
@@ -315,10 +315,12 @@ func TestHTTPGateway_SendEventBodyLimitDoesNotApplyToOtherRoutes(t *testing.T) {
 	require.NotEqual(t, http.StatusRequestEntityTooLarge, recorder.Code)
 }
 
+//go:fix inline
 func stringPointer(value string) *string {
-	return &value
+	return new(value)
 }
 
+//go:fix inline
 func int64Pointer(value int64) *int64 {
-	return &value
+	return new(value)
 }

--- a/pkg/api/v2/endpoints_event_test.go
+++ b/pkg/api/v2/endpoints_event_test.go
@@ -314,13 +314,3 @@ func TestHTTPGateway_SendEventBodyLimitDoesNotApplyToOtherRoutes(t *testing.T) {
 
 	require.NotEqual(t, http.StatusRequestEntityTooLarge, recorder.Code)
 }
-
-//go:fix inline
-func stringPointer(value string) *string {
-	return new(value)
-}
-
-//go:fix inline
-func int64Pointer(value int64) *int64 {
-	return new(value)
-}

--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -626,11 +626,6 @@ func jsonToStruct(raw json.RawMessage) *structpb.Struct {
 	}
 }
 
-//go:fix inline
-func optionalString(value string) *string {
-	return new(value)
-}
-
 func toFunctionTrace(ctx context.Context, reader FunctionTraceReader, root *cqrs.OtelSpan, includeOutput bool) (*apiv2.FunctionTrace, error) {
 	span, err := loader.ConvertRunSpan(ctx, root)
 	if err != nil {

--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -510,11 +510,11 @@ func toFunctionRun(run *cqrs.FunctionRun, fn inngest.DeployedFunction) *apiv2.Fu
 	}
 
 	if run.BatchID != nil {
-		result.Trigger.BatchId = optionalString(run.BatchID.String())
+		result.Trigger.BatchId = new(run.BatchID.String())
 	}
 
 	if run.Cron != nil {
-		result.Trigger.CronSchedule = optionalString(*run.Cron)
+		result.Trigger.CronSchedule = new(*run.Cron)
 	}
 
 	if run.EndedAt != nil {
@@ -549,11 +549,11 @@ func toAPIRunListItem(run *RunListItem) *apiv2.FunctionRun {
 	}
 
 	if run.BatchID != nil {
-		result.Trigger.BatchId = optionalString(run.BatchID.String())
+		result.Trigger.BatchId = new(run.BatchID.String())
 	}
 
 	if run.Cron != nil {
-		result.Trigger.CronSchedule = optionalString(*run.Cron)
+		result.Trigger.CronSchedule = new(*run.Cron)
 	}
 
 	if run.EndedAt != nil {
@@ -626,8 +626,9 @@ func jsonToStruct(raw json.RawMessage) *structpb.Struct {
 	}
 }
 
+//go:fix inline
 func optionalString(value string) *string {
-	return &value
+	return new(value)
 }
 
 func toFunctionTrace(ctx context.Context, reader FunctionTraceReader, root *cqrs.OtelSpan, includeOutput bool) (*apiv2.FunctionTrace, error) {

--- a/pkg/api/v2/endpoints_runs_test.go
+++ b/pkg/api/v2/endpoints_runs_test.go
@@ -215,7 +215,7 @@ func TestJSONToStruct(t *testing.T) {
 }
 
 func TestOptionalString(t *testing.T) {
-	value := optionalString("value")
+	value := new("value")
 
 	require.NotNil(t, value)
 	require.Equal(t, "value", *value)
@@ -259,8 +259,8 @@ func TestToFunctionTraceReturnsConvertError(t *testing.T) {
 		},
 		RunID: runID,
 		Attributes: &meta.ExtractedValues{
-			IsUserland:   boolPtr(true),
-			UserlandName: strPtr("userland"),
+			IsUserland:   new(true),
+			UserlandName: new("userland"),
 		},
 	}, false)
 

--- a/pkg/api/v2/integration_test.go
+++ b/pkg/api/v2/integration_test.go
@@ -204,7 +204,7 @@ func TestGRPCIntegration_InvokeFunction(t *testing.T) {
 			AppId:          "my-app",
 			FunctionId:     "my-app-hello-world",
 			Data:           data,
-			IdempotencyKey: stringPtr("test-key-123"),
+			IdempotencyKey: new("test-key-123"),
 		}
 
 		resp, err := client.InvokeFunction(ctx, req)
@@ -302,8 +302,10 @@ func TestGRPCIntegration_InvokeFunction(t *testing.T) {
 }
 
 // Helper function to create string pointer for optional fields
+//
+//go:fix inline
 func stringPtr(s string) *string {
-	return &s
+	return new(s)
 }
 
 func BenchmarkGRPCIntegration_Health(b *testing.B) {

--- a/pkg/api/v2/integration_test.go
+++ b/pkg/api/v2/integration_test.go
@@ -300,14 +300,6 @@ func TestGRPCIntegration_InvokeFunction(t *testing.T) {
 		require.Contains(t, err.Error(), "not_implemented")
 	})
 }
-
-// Helper function to create string pointer for optional fields
-//
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}
-
 func BenchmarkGRPCIntegration_Health(b *testing.B) {
 	client, cleanup := setupGRPCTestServer(b)
 	defer cleanup()

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -251,20 +251,24 @@ func TestService_Metadata_Timestamp(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func boolPtr(value bool) *bool {
-	return &value
+	return new(value)
 }
 
+//go:fix inline
 func strPtr(value string) *string {
-	return &value
+	return new(value)
 }
 
+//go:fix inline
 func intPtr(value int) *int {
-	return &value
+	return new(value)
 }
 
+//go:fix inline
 func int32Ptr(value int32) *int32 {
-	return &value
+	return new(value)
 }
 
 func TestService_GetApp(t *testing.T) {
@@ -478,7 +482,7 @@ func TestService_GetApps(t *testing.T) {
 		})
 
 		resp, err := NewService(ServiceOptions{Apps: apps}).GetApps(context.Background(), &apiv2.GetAppsRequest{
-			Cursor: strPtr(firstID.String()),
+			Cursor: new(firstID.String()),
 			Limit:  int32Ptr(1),
 		})
 
@@ -499,7 +503,7 @@ func TestService_GetApps(t *testing.T) {
 		})
 
 		resp, err := NewService(ServiceOptions{Apps: apps}).GetApps(context.Background(), &apiv2.GetAppsRequest{
-			Archived: boolPtr(true),
+			Archived: new(true),
 		})
 
 		require.NoError(t, err)
@@ -509,7 +513,7 @@ func TestService_GetApps(t *testing.T) {
 	t.Run("requires valid cursor", func(t *testing.T) {
 		resp, err := NewService(ServiceOptions{Apps: &mockAppProvider{}}).GetApps(
 			context.Background(),
-			&apiv2.GetAppsRequest{Cursor: strPtr("not-a-uuid")},
+			&apiv2.GetAppsRequest{Cursor: new("not-a-uuid")},
 		)
 
 		require.Nil(t, resp)
@@ -575,7 +579,7 @@ func TestService_GetFunction(t *testing.T) {
 			Slug: "my-app-test-fn",
 			Steps: []inngest.Step{{
 				ID:      "step",
-				Retries: intPtr(retries),
+				Retries: new(retries),
 			}},
 			Triggers: inngest.MultipleTriggers{
 				{EventTrigger: &inngest.EventTrigger{Event: "user.created", Expression: &condition}},
@@ -803,7 +807,7 @@ func TestService_GetFunctions(t *testing.T) {
 		service := NewService(ServiceOptions{Functions: functions})
 		resp, err := service.GetFunctions(context.Background(), &apiv2.GetFunctionsRequest{
 			AppId:  "my-app",
-			Cursor: strPtr(firstID.String()),
+			Cursor: new(firstID.String()),
 			Limit:  int32Ptr(1),
 		})
 
@@ -817,7 +821,7 @@ func TestService_GetFunctions(t *testing.T) {
 		service := NewService(ServiceOptions{Functions: &mockFunctionProvider{}})
 		resp, err := service.GetFunctions(context.Background(), &apiv2.GetFunctionsRequest{
 			AppId:  "my-app",
-			Cursor: strPtr("not-a-uuid"),
+			Cursor: new("not-a-uuid"),
 		})
 
 		require.Nil(t, resp)
@@ -893,7 +897,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 	t.Run("returns mapped run data", func(t *testing.T) {
 		resp, err := service.GetFunctionRun(context.Background(), &apiv2.GetFunctionRunRequest{
 			RunId:         runID.String(),
-			IncludeOutput: boolPtr(true),
+			IncludeOutput: new(true),
 		})
 		require.NoError(t, err)
 		require.Equal(t, runID.String(), resp.Data.Id)
@@ -972,7 +976,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 		outputIdentifier := cqrs.SpanIdentifier{
 			SpanID:      "output-span",
 			InputSpanID: &inputSpanID,
-			Preview:     boolPtr(true),
+			Preview:     new(true),
 		}
 		outputID, err := outputIdentifier.Encode()
 		require.NoError(t, err)
@@ -1011,7 +1015,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 
 		resp, err := service.GetFunctionRun(context.Background(), &apiv2.GetFunctionRunRequest{
 			RunId:         runID.String(),
-			IncludeOutput: boolPtr(true),
+			IncludeOutput: new(true),
 		})
 
 		require.NoError(t, err)
@@ -1044,7 +1048,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 
 		resp, err := service.GetFunctionRun(context.Background(), &apiv2.GetFunctionRunRequest{
 			RunId:         runID.String(),
-			IncludeOutput: boolPtr(true),
+			IncludeOutput: new(true),
 		})
 
 		require.NoError(t, err)
@@ -1102,9 +1106,9 @@ func TestService_ListRuns(t *testing.T) {
 
 		service := NewService(ServiceOptions{Runs: reader})
 		resp, err := service.ListRuns(context.Background(), &apiv2.ListRunsRequest{
-			Cursor:        strPtr(pageCursor),
+			Cursor:        new(pageCursor),
 			Limit:         &limit,
-			IncludeOutput: boolPtr(true),
+			IncludeOutput: new(true),
 			From:          timestamppb.New(from),
 			Until:         timestamppb.New(until),
 			TimeField:     "startedAt",
@@ -1163,7 +1167,7 @@ func TestService_ListRuns(t *testing.T) {
 	t.Run("validates cursor", func(t *testing.T) {
 		service := NewService(ServiceOptions{Runs: &mockRunProvider{}})
 		resp, err := service.ListRuns(context.Background(), &apiv2.ListRunsRequest{
-			Cursor: strPtr("not-a-cursor"),
+			Cursor: new("not-a-cursor"),
 		})
 
 		require.Nil(t, resp)
@@ -1327,7 +1331,7 @@ func TestService_GetEventRuns(t *testing.T) {
 		service := NewService(ServiceOptions{Runs: reader})
 		resp, err := service.GetEventRuns(context.Background(), &apiv2.GetEventRunsRequest{
 			EventId:       eventID.String(),
-			IncludeOutput: boolPtr(true),
+			IncludeOutput: new(true),
 		})
 
 		require.NoError(t, err)
@@ -1439,7 +1443,7 @@ func TestService_GetEventRuns(t *testing.T) {
 		service := NewService(ServiceOptions{Runs: &mockRunProvider{}})
 		resp, err := service.GetEventRuns(context.Background(), &apiv2.GetEventRunsRequest{
 			EventId: eventID.String(),
-			Cursor:  strPtr(runID.String()),
+			Cursor:  new(runID.String()),
 		})
 
 		require.Nil(t, resp)
@@ -1727,8 +1731,8 @@ func TestService_GetFunctionTrace(t *testing.T) {
 	responseHeaders := headers.Compact{"content-type": {"application/json"}}
 	outputIdentifier := cqrs.SpanIdentifier{
 		SpanID:      "span-output",
-		InputSpanID: strPtr("span-input"),
-		Preview:     boolPtr(true),
+		InputSpanID: new("span-input"),
+		Preview:     new(true),
 	}
 	outputID := mustEncodeSpanIdentifier(t, outputIdentifier)
 
@@ -1817,7 +1821,7 @@ func TestService_GetFunctionTrace(t *testing.T) {
 
 		resp, err := service.GetFunctionTrace(context.Background(), &apiv2.GetFunctionTraceRequest{
 			RunId:         runID.String(),
-			IncludeOutput: boolPtr(true),
+			IncludeOutput: new(true),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -1862,7 +1866,7 @@ func TestService_GetFunctionTrace(t *testing.T) {
 
 		resp, err := service.GetFunctionTrace(context.Background(), &apiv2.GetFunctionTraceRequest{
 			RunId:         runID.String(),
-			IncludeOutput: boolPtr(false),
+			IncludeOutput: new(false),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -1932,7 +1936,7 @@ func TestService_GetFunctionTrace(t *testing.T) {
 
 		resp, err := service.GetFunctionTrace(context.Background(), &apiv2.GetFunctionTraceRequest{
 			RunId:         runID.String(),
-			IncludeOutput: boolPtr(true),
+			IncludeOutput: new(true),
 		})
 
 		require.Nil(t, resp)

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -251,26 +251,6 @@ func TestService_Metadata_Timestamp(t *testing.T) {
 	})
 }
 
-//go:fix inline
-func boolPtr(value bool) *bool {
-	return new(value)
-}
-
-//go:fix inline
-func strPtr(value string) *string {
-	return new(value)
-}
-
-//go:fix inline
-func intPtr(value int) *int {
-	return new(value)
-}
-
-//go:fix inline
-func int32Ptr(value int32) *int32 {
-	return new(value)
-}
-
 func TestService_GetApp(t *testing.T) {
 	appID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	createdAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
@@ -483,7 +463,7 @@ func TestService_GetApps(t *testing.T) {
 
 		resp, err := NewService(ServiceOptions{Apps: apps}).GetApps(context.Background(), &apiv2.GetAppsRequest{
 			Cursor: new(firstID.String()),
-			Limit:  int32Ptr(1),
+			Limit:  new(int32(1)),
 		})
 
 		require.NoError(t, err)
@@ -523,7 +503,7 @@ func TestService_GetApps(t *testing.T) {
 	t.Run("validates limit", func(t *testing.T) {
 		resp, err := NewService(ServiceOptions{Apps: &mockAppProvider{}}).GetApps(
 			context.Background(),
-			&apiv2.GetAppsRequest{Limit: int32Ptr(maxAppsLimit + 1)},
+			&apiv2.GetAppsRequest{Limit: new(int32(maxAppsLimit + 1))},
 		)
 
 		require.Nil(t, resp)
@@ -808,7 +788,7 @@ func TestService_GetFunctions(t *testing.T) {
 		resp, err := service.GetFunctions(context.Background(), &apiv2.GetFunctionsRequest{
 			AppId:  "my-app",
 			Cursor: new(firstID.String()),
-			Limit:  int32Ptr(1),
+			Limit:  new(int32(1)),
 		})
 
 		require.NoError(t, err)
@@ -832,7 +812,7 @@ func TestService_GetFunctions(t *testing.T) {
 		service := NewService(ServiceOptions{Functions: &mockFunctionProvider{}})
 		resp, err := service.GetFunctions(context.Background(), &apiv2.GetFunctionsRequest{
 			AppId: "my-app",
-			Limit: int32Ptr(maxFunctionsLimit + 1),
+			Limit: new(int32(maxFunctionsLimit + 1)),
 		})
 
 		require.Nil(t, resp)

--- a/pkg/conformance/runner/serve/runner.go
+++ b/pkg/conformance/runner/serve/runner.go
@@ -979,7 +979,7 @@ func runStepsSerial(ctx context.Context, h *caseHarness) error {
 		Op:          enums.OpcodeStepRun,
 		ID:          hashes["first step"],
 		Name:        "first step",
-		DisplayName: inngestgo.StrPtr("first step"),
+		DisplayName: new("first step"),
 		Data:        []byte(`"first step"`),
 	}}, 5*time.Second); err != nil {
 		return err
@@ -997,7 +997,7 @@ func runStepsSerial(ctx context.Context, h *caseHarness) error {
 		Op:          enums.OpcodeSleep,
 		ID:          hashes["sleep"],
 		Name:        "2s",
-		DisplayName: inngestgo.StrPtr("for 2s"),
+		DisplayName: new("for 2s"),
 		Data:        json.RawMessage("null"),
 	}}, 5*time.Second); err != nil {
 		return err
@@ -1015,7 +1015,7 @@ func runStepsSerial(ctx context.Context, h *caseHarness) error {
 		Op:          enums.OpcodeStepRun,
 		ID:          hashes["second step"],
 		Name:        "second step",
-		DisplayName: inngestgo.StrPtr("second step"),
+		DisplayName: new("second step"),
 		Data:        json.RawMessage(`{"first":"first step","second":true}`),
 	}}, 5*time.Second); err != nil {
 		return err
@@ -1066,7 +1066,7 @@ func runRetryBasic(ctx context.Context, h *caseHarness) error {
 		Op:          enums.OpcodeStepError,
 		ID:          hash,
 		Name:        "first step",
-		DisplayName: inngestgo.StrPtr("first step"),
+		DisplayName: new("first step"),
 		Error: &state.UserError{
 			Name:    "Error",
 			Message: "broken",
@@ -1085,7 +1085,7 @@ func runRetryBasic(ctx context.Context, h *caseHarness) error {
 		Op:          enums.OpcodeStepRun,
 		ID:          hash,
 		Name:        "first step",
-		DisplayName: inngestgo.StrPtr("first step"),
+		DisplayName: new("first step"),
 		Data:        []byte(`"yes: 2"`),
 	}}, 5*time.Second); err != nil {
 		return err
@@ -1157,7 +1157,7 @@ func runCancelBasic(ctx context.Context, h *caseHarness) error {
 		Op:          enums.OpcodeSleep,
 		ID:          "c3ca5f787365eae0dea86250e27d476406956478",
 		Name:        "10s",
-		DisplayName: inngestgo.StrPtr("sleep"),
+		DisplayName: new("sleep"),
 		Data:        json.RawMessage("null"),
 	}}, 5*time.Second); err != nil {
 		return err
@@ -1217,7 +1217,7 @@ func runWaitForEventBasic(ctx context.Context, h *caseHarness) error {
 		Op:          enums.OpcodeWaitForEvent,
 		ID:          waitHash,
 		Name:        "wait",
-		DisplayName: inngestgo.StrPtr("test/resume"),
+		DisplayName: new("test/resume"),
 		Data:        json.RawMessage("null"),
 		Opts: map[string]any{
 			"event":   "test/resume",

--- a/pkg/connect/gateway_drain_test.go
+++ b/pkg/connect/gateway_drain_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/coder/websocket"
 	"github.com/inngest/inngest/pkg/connect/types"
 	"github.com/inngest/inngest/pkg/connect/wsproto"
@@ -314,7 +313,7 @@ func TestForwardDuringGatewayDrainReturnsFalse(t *testing.T) {
 			AppName:        res.appName,
 			FunctionId:     res.fnID.String(),
 			FunctionSlug:   res.fnSlug,
-			StepId:         ptr.String("step"),
+			StepId:         new("step"),
 			RequestPayload: []byte("should not be delivered while draining"),
 			RunId:          res.runID.String(),
 			LeaseId:        "test-lease",
@@ -413,7 +412,7 @@ func TestLeaseExtensionDuringGatewayDrain_IsProcessed(t *testing.T) {
 		AppName:        res.appName,
 		FunctionId:     res.fnID.String(),
 		FunctionSlug:   res.fnSlug,
-		StepId:         ptr.String("step"),
+		StepId:         new("step"),
 		RequestPayload: []byte("lease ext test"),
 		RunId:          res.runID.String(),
 		LeaseId:        leaseID.String(),

--- a/pkg/connect/gateway_msg_extend_lease.go
+++ b/pkg/connect/gateway_msg_extend_lease.go
@@ -94,7 +94,7 @@ func (c *connectionHandler) handleWorkerRequestExtendLease(msg *connectpb.Connec
 
 	var newLeaseIDStr *string
 	if newLeaseID != nil {
-		newLeaseIDStr = proto.String(newLeaseID.String())
+		newLeaseIDStr = new(newLeaseID.String())
 	}
 
 	serr := c.writeWorkerRequestExtendLeaseAck(&data, newLeaseIDStr, "failed to marshal nack payload")

--- a/pkg/connect/gateway_msg_extend_lease_test.go
+++ b/pkg/connect/gateway_msg_extend_lease_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/syscode"
 	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
@@ -27,7 +26,7 @@ func TestHandleWorkerRequestExtendLeaseExtendsLease(t *testing.T) {
 		EnvId:          res.envID.String(),
 		AppId:          res.appID.String(),
 		FunctionSlug:   res.fnSlug,
-		StepId:         ptr.String("step"),
+		StepId:         new("step"),
 		RunId:          res.runID.String(),
 		LeaseId:        leaseID.String(),
 		SystemTraceCtx: []byte("system"),

--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/aws/smithy-go/ptr"
 	"github.com/coder/websocket"
 	"github.com/google/uuid"
 	connectConfig "github.com/inngest/inngest/pkg/config/connect"
@@ -96,7 +95,7 @@ func TestLeaseRenewal(t *testing.T) {
 		AppName:        res.appName,
 		FunctionId:     res.fnID.String(),
 		FunctionSlug:   res.fnSlug,
-		StepId:         ptr.String("step"),
+		StepId:         new("step"),
 		RequestPayload: []byte("hello world"),
 		RunId:          res.runID.String(),
 		LeaseId:        leaseID.String(),
@@ -174,7 +173,7 @@ func TestLeaseRenewalWithInvalidLeaseShouldNotClose(t *testing.T) {
 		AppName:        res.appName,
 		FunctionId:     res.fnID.String(),
 		FunctionSlug:   res.fnSlug,
-		StepId:         ptr.String("step"),
+		StepId:         new("step"),
 		RequestPayload: []byte("hello world"),
 		RunId:          res.runID.String(),
 		LeaseId:        leaseID.String(),
@@ -284,7 +283,7 @@ func TestLeaseRenewalWithDeletedLeaseShouldNotClose(t *testing.T) {
 		AppName:        res.appName,
 		FunctionId:     res.fnID.String(),
 		FunctionSlug:   res.fnSlug,
-		StepId:         ptr.String("step"),
+		StepId:         new("step"),
 		RequestPayload: []byte("hello world"),
 		RunId:          res.runID.String(),
 		LeaseId:        leaseID.String(),
@@ -392,7 +391,7 @@ func TestExecutorMessageForwardingGRPC(t *testing.T) {
 		AppName:        res.appName,
 		FunctionId:     res.fnID.String(),
 		FunctionSlug:   res.fnSlug,
-		StepId:         ptr.String("step"),
+		StepId:         new("step"),
 		RequestPayload: []byte("hello world"),
 		RunId:          res.runID.String(),
 		LeaseId:        "lease-test",
@@ -1192,7 +1191,7 @@ func createTestingGateway(t *testing.T, params ...testingParameters) testingReso
 
 	testApp := &connect.AppConfiguration{
 		AppName:    appName,
-		AppVersion: ptr.String("v1"),
+		AppVersion: new("v1"),
 		Functions:  fns,
 	}
 

--- a/pkg/connect/lifecycles/history.go
+++ b/pkg/connect/lifecycles/history.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/inngest/inngest/pkg/connect"
 	"github.com/inngest/inngest/pkg/connect/state"
 	"github.com/inngest/inngest/pkg/cqrs"
@@ -77,7 +76,7 @@ func getMaxWorkerConcurrency(conn *state.Connection) int64 {
 func (h *historyLifecycles) OnDisconnected(ctx context.Context, conn *state.Connection, closeReason string) {
 	var disconnectReason *string
 	if closeReason != "" {
-		disconnectReason = ptr.String(closeReason)
+		disconnectReason = new(closeReason)
 	}
 	system := conn.Data.GetSystemAttributes()
 
@@ -98,8 +97,8 @@ func (h *historyLifecycles) OnDisconnected(ctx context.Context, conn *state.Conn
 			MaxWorkerConcurrency: getMaxWorkerConcurrency(conn),
 
 			ConnectedAt:     ulid.Time(conn.ConnectionId.Time()),
-			LastHeartbeatAt: ptr.Time(time.Now()),
-			DisconnectedAt:  ptr.Time(time.Now()),
+			LastHeartbeatAt: new(time.Now()),
+			DisconnectedAt:  new(time.Now()),
 			RecordedAt:      time.Now(),
 
 			DisconnectReason: disconnectReason,
@@ -153,7 +152,7 @@ func (h *historyLifecycles) upsertConnection(ctx context.Context, conn *state.Co
 			MaxWorkerConcurrency: getMaxWorkerConcurrency(conn),
 
 			ConnectedAt:     ulid.Time(conn.ConnectionId.Time()),
-			LastHeartbeatAt: ptr.Time(lastHeartbeatAt),
+			LastHeartbeatAt: new(lastHeartbeatAt),
 			DisconnectedAt:  nil,
 			RecordedAt:      time.Now(),
 

--- a/pkg/connect/lifecycles/history_test.go
+++ b/pkg/connect/lifecycles/history_test.go
@@ -114,7 +114,7 @@ func TestHistoryLifecycle_OnConnected(t *testing.T) {
 			"group1": {
 				AppName:       "test-app",
 				AppID:         &appId,
-				AppVersion:    ptr.String("1.0.0"),
+				AppVersion:    new("1.0.0"),
 				SyncID:        &syncId,
 				FunctionSlugs: []string{"func1", "func2"},
 			},
@@ -228,7 +228,7 @@ func TestHistoryLifecycle_OnDisconnected(t *testing.T) {
 		{
 			name:           "with close reason",
 			closeReason:    "client_disconnect",
-			expectedReason: ptr.String("client_disconnect"),
+			expectedReason: new("client_disconnect"),
 			expectedStatus: connectpb.ConnectionStatus_DISCONNECTED,
 		},
 		{
@@ -419,7 +419,7 @@ func createTestConnection() *state.Connection {
 			"group1": {
 				AppName:       "test-app",
 				AppID:         &appId,
-				AppVersion:    ptr.String("1.0.0"),
+				AppVersion:    new("1.0.0"),
 				SyncID:        &syncId,
 				FunctionSlugs: []string{"func1"},
 			},

--- a/pkg/connect/routing/router_test.go
+++ b/pkg/connect/routing/router_test.go
@@ -143,7 +143,7 @@ func setup(t *testing.T, stateMan state.StateManager, opts setupOpts, connsToCre
 
 	app1Config := &connectpb.AppConfiguration{
 		AppName:    appName,
-		AppVersion: util.StrPtr("v1"),
+		AppVersion: new("v1"),
 		Functions:  fnBytes,
 	}
 

--- a/pkg/coreapi/graph/loaders/trace_test.go
+++ b/pkg/coreapi/graph/loaders/trace_test.go
@@ -72,8 +72,11 @@ func TestRunTraceEnded(t *testing.T) {
 	}
 }
 
-func boolPtr(b bool) *bool    { return &b }
-func strPtr(s string) *string { return &s }
+//go:fix inline
+func boolPtr(b bool) *bool { return new(b) }
+
+//go:fix inline
+func strPtr(s string) *string { return new(s) }
 
 func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 	tr := &traceReader{}
@@ -87,8 +90,8 @@ func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 				{
 					RawOtelSpan: cqrs.RawOtelSpan{Name: "GET"},
 					Attributes: &meta.ExtractedValues{
-						IsUserland:   boolPtr(true),
-						UserlandName: strPtr("GET"),
+						IsUserland:   new(true),
+						UserlandName: new("GET"),
 					},
 				},
 			},
@@ -109,15 +112,15 @@ func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 				{
 					RawOtelSpan: cqrs.RawOtelSpan{Name: SDKExecutionSpanName},
 					Attributes: &meta.ExtractedValues{
-						IsUserland:   boolPtr(true),
-						UserlandName: strPtr(SDKExecutionSpanName),
+						IsUserland:   new(true),
+						UserlandName: new(SDKExecutionSpanName),
 					},
 					Children: []*cqrs.OtelSpan{
 						{
 							RawOtelSpan: cqrs.RawOtelSpan{Name: "GET"},
 							Attributes: &meta.ExtractedValues{
-								IsUserland:   boolPtr(true),
-								UserlandName: strPtr("GET"),
+								IsUserland:   new(true),
+								UserlandName: new("GET"),
 							},
 						},
 					},
@@ -139,15 +142,15 @@ func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 				{
 					RawOtelSpan: cqrs.RawOtelSpan{Name: "my-span"},
 					Attributes: &meta.ExtractedValues{
-						IsUserland:   boolPtr(true),
-						UserlandName: strPtr("my-span"),
+						IsUserland:   new(true),
+						UserlandName: new("my-span"),
 					},
 					Children: []*cqrs.OtelSpan{
 						{
 							RawOtelSpan: cqrs.RawOtelSpan{Name: "child-span"},
 							Attributes: &meta.ExtractedValues{
-								IsUserland:   boolPtr(true),
-								UserlandName: strPtr("child-span"),
+								IsUserland:   new(true),
+								UserlandName: new("child-span"),
 							},
 						},
 					},
@@ -230,7 +233,7 @@ func TestConvertRunSpanToGQL_MetadataPromotion(t *testing.T) {
 					Attributes: &meta.ExtractedValues{
 						DynamicStatus: &completedStatus,
 						StepOp:        &stepOpRun,
-						StepID:        strPtr("step-a"),
+						StepID:        new("step-a"),
 					},
 				},
 			},
@@ -260,7 +263,7 @@ func TestConvertRunSpanToGQL_MetadataPromotion(t *testing.T) {
 					Attributes: &meta.ExtractedValues{
 						DynamicStatus: &completedStatus,
 						StepOp:        &stepOpRun,
-						StepID:        strPtr("step-a"),
+						StepID:        new("step-a"),
 					},
 				},
 				{
@@ -275,7 +278,7 @@ func TestConvertRunSpanToGQL_MetadataPromotion(t *testing.T) {
 					Attributes: &meta.ExtractedValues{
 						DynamicStatus: &completedStatus,
 						StepOp:        &stepOpRun,
-						StepID:        strPtr("step-b"),
+						StepID:        new("step-b"),
 					},
 				},
 			},
@@ -324,7 +327,7 @@ func TestConvertRunSpanToGQL_MetadataPromotion(t *testing.T) {
 							Attributes: &meta.ExtractedValues{
 								DynamicStatus: &executionStatus,
 								StepOp:        &executionOp,
-								StepID:        strPtr("visible-discovery"),
+								StepID:        new("visible-discovery"),
 							},
 						},
 					},
@@ -335,7 +338,7 @@ func TestConvertRunSpanToGQL_MetadataPromotion(t *testing.T) {
 					Attributes: &meta.ExtractedValues{
 						DynamicStatus: &completedStatus,
 						StepOp:        &stepOpRun,
-						StepID:        strPtr("step-a"),
+						StepID:        new("step-a"),
 					},
 				},
 			},
@@ -376,7 +379,7 @@ func TestConvertRunSpanToGQL_MetadataPromotion(t *testing.T) {
 					Attributes: &meta.ExtractedValues{
 						DynamicStatus: &completedStatus,
 						StepOp:        &stepOpRun,
-						StepID:        strPtr("step-a"),
+						StepID:        new("step-a"),
 					},
 				},
 				{
@@ -410,13 +413,13 @@ func TestConvertRunSpanToGQL_FinalizationGroup(t *testing.T) {
 			StepAttempt:   intPtr(attempt),
 		}
 		if functionOutput {
-			attrs.IsFunctionOutput = boolPtr(true)
-			attrs.StepID = strPtr("fn-hash")
+			attrs.IsFunctionOutput = new(true)
+			attrs.StepID = new("fn-hash")
 		}
 		return &cqrs.OtelSpan{
 			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameExecution, SpanID: spanID},
 			Attributes:  attrs,
-			OutputID:    strPtr(outputID),
+			OutputID:    new(outputID),
 		}
 	}
 
@@ -470,13 +473,13 @@ func TestConvertRunSpanToGQL_FinalizationGroup(t *testing.T) {
 		// Guard against over-clearing: a step span whose exec child is NOT a
 		// function output must keep step identity and output.
 		child := execChild("exec-0", 0, completed, false, "step-output")
-		child.Attributes.StepID = strPtr("step-1")
+		child.Attributes.StepID = new("step-1")
 
 		step := &cqrs.OtelSpan{
 			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameStep, SpanID: "step"},
 			Attributes: &meta.ExtractedValues{
-				StepName: strPtr("my-step"),
-				StepID:   strPtr("step-1"),
+				StepName: new("my-step"),
+				StepID:   new("step-1"),
 			},
 			Children: []*cqrs.OtelSpan{child},
 		}

--- a/pkg/coreapi/graph/loaders/trace_test.go
+++ b/pkg/coreapi/graph/loaders/trace_test.go
@@ -72,12 +72,6 @@ func TestRunTraceEnded(t *testing.T) {
 	}
 }
 
-//go:fix inline
-func boolPtr(b bool) *bool { return new(b) }
-
-//go:fix inline
-func strPtr(s string) *string { return new(s) }
-
 func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 	tr := &traceReader{}
 	ctx := context.Background()
@@ -405,12 +399,10 @@ func TestConvertRunSpanToGQL_FinalizationGroup(t *testing.T) {
 	completed := enums.StepStatusCompleted
 	failed := enums.StepStatusFailed
 
-	intPtr := func(i int) *int { return &i }
-
 	execChild := func(spanID string, attempt int, status enums.StepStatus, functionOutput bool, outputID string) *cqrs.OtelSpan {
 		attrs := &meta.ExtractedValues{
 			DynamicStatus: &status,
-			StepAttempt:   intPtr(attempt),
+			StepAttempt:   new(attempt),
 		}
 		if functionOutput {
 			attrs.IsFunctionOutput = new(true)

--- a/pkg/coreapi/graph/models/function_configuration_serializer.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer.go
@@ -23,7 +23,7 @@ func ToFunctionConfiguration(fn *inngest.Function, planConcurrencyLimit int) *Fu
 				Scope: mapScope(conc.Scope),
 				Limit: &ConcurrencyLimitConfiguration{
 					Value:       concLimit,
-					IsPlanLimit: boolPtr(concLimit == planConcurrencyLimit),
+					IsPlanLimit: new(concLimit == planConcurrencyLimit),
 				},
 				Key: conc.Key,
 			}
@@ -34,7 +34,7 @@ func ToFunctionConfiguration(fn *inngest.Function, planConcurrencyLimit int) *Fu
 				Scope: ConcurrencyScopeAccount,
 				Limit: &ConcurrencyLimitConfiguration{
 					Value:       planConcurrencyLimit, // TODO: render -1 as infinite on frontend?
-					IsPlanLimit: boolPtr(true),
+					IsPlanLimit: new(true),
 				},
 			},
 		}
@@ -72,7 +72,7 @@ func ToFunctionConfiguration(fn *inngest.Function, planConcurrencyLimit int) *Fu
 		Cancellations: mapCancellations(fn.Cancel),
 		Retries: &RetryConfiguration{
 			Value:     fn.Steps[0].RetryCount(),
-			IsDefault: boolPtr(fn.Steps[0].RetryCount() == consts.DefaultRetryCount),
+			IsDefault: new(fn.Steps[0].RetryCount() == consts.DefaultRetryCount),
 		},
 		Priority:    priority,
 		EventsBatch: mapEventsBatch(fn.EventBatch),
@@ -154,6 +154,7 @@ func mapSingletonMode(internalEnum enums.SingletonMode) SingletonMode {
 	return SingletonModeSkip
 }
 
+//go:fix inline
 func boolPtr(b bool) *bool {
-	return &b
+	return new(b)
 }

--- a/pkg/coreapi/graph/models/function_configuration_serializer.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer.go
@@ -153,8 +153,3 @@ func mapSingletonMode(internalEnum enums.SingletonMode) SingletonMode {
 
 	return SingletonModeSkip
 }
-
-//go:fix inline
-func boolPtr(b bool) *bool {
-	return new(b)
-}

--- a/pkg/coreapi/graph/models/function_configuration_serializer_test.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/inngest"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/jinzhu/copier"
 )
 
@@ -27,8 +26,8 @@ func TestToFunctionConfiguration(t *testing.T) {
 				Cancel: []inngest.Cancel{
 					{
 						Event:   "test/cancel",
-						Timeout: util.StrPtr("30m"),
-						If:      util.StrPtr("event.data.id == 2"),
+						Timeout: new("30m"),
+						If:      new("event.data.id == 2"),
 					},
 				},
 			}),
@@ -37,8 +36,8 @@ func TestToFunctionConfiguration(t *testing.T) {
 				Cancellations: []*CancellationConfiguration{
 					{
 						Event:     "test/cancel",
-						Timeout:   util.StrPtr("30m"),
-						Condition: util.StrPtr("event.data.id == 2"),
+						Timeout:   new("30m"),
+						Condition: new("event.data.id == 2"),
 					},
 				},
 			}),
@@ -52,7 +51,7 @@ func TestToFunctionConfiguration(t *testing.T) {
 						ID:      "test-step",
 						Name:    "test-step",
 						URI:     "https://example.com/api/inngest?step=foo",
-						Retries: intPtr(10),
+						Retries: new(10),
 					},
 				},
 			}),
@@ -60,7 +59,7 @@ func TestToFunctionConfiguration(t *testing.T) {
 			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
 				Retries: &RetryConfiguration{
 					Value:     10,
-					IsDefault: boolPtr(false),
+					IsDefault: new(false),
 				},
 			}),
 		},
@@ -68,12 +67,12 @@ func TestToFunctionConfiguration(t *testing.T) {
 			name: "priority",
 			fn: mergeWithDefaultFunction(&inngest.Function{
 				Priority: &inngest.Priority{
-					Run: util.StrPtr("event.data.plan == 'enterprise' ? 180 : 0"),
+					Run: new("event.data.plan == 'enterprise' ? 180 : 0"),
 				},
 			}),
 			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
 			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
-				Priority: util.StrPtr("event.data.plan == 'enterprise' ? 180 : 0"),
+				Priority: new("event.data.plan == 'enterprise' ? 180 : 0"),
 			}),
 		},
 		{
@@ -82,7 +81,7 @@ func TestToFunctionConfiguration(t *testing.T) {
 				EventBatch: &inngest.EventBatchConfig{
 					MaxSize: 50,
 					Timeout: "30s",
-					Key:     util.StrPtr("event.data.customer_id"),
+					Key:     new("event.data.customer_id"),
 				},
 			}),
 			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
@@ -90,7 +89,7 @@ func TestToFunctionConfiguration(t *testing.T) {
 				EventsBatch: &EventsBatchConfiguration{
 					MaxSize: 50,
 					Timeout: "30s",
-					Key:     util.StrPtr("event.data.customer_id"),
+					Key:     new("event.data.customer_id"),
 				},
 			}),
 		},
@@ -102,12 +101,12 @@ func TestToFunctionConfiguration(t *testing.T) {
 						{
 							Scope: enums.ConcurrencyScopeAccount,
 							Limit: 20,
-							Key:   util.StrPtr("event.data.id == 2"),
+							Key:   new("event.data.id == 2"),
 						},
 						{
 							Scope: enums.ConcurrencyScopeFn,
 							Limit: 5,
-							Key:   util.StrPtr("event.data.id == 2"),
+							Key:   new("event.data.id == 2"),
 						},
 					},
 				},
@@ -119,17 +118,17 @@ func TestToFunctionConfiguration(t *testing.T) {
 						Scope: ConcurrencyScopeAccount,
 						Limit: &ConcurrencyLimitConfiguration{
 							Value:       20,
-							IsPlanLimit: boolPtr(false),
+							IsPlanLimit: new(false),
 						},
-						Key: util.StrPtr("event.data.id == 2"),
+						Key: new("event.data.id == 2"),
 					},
 					{
 						Scope: ConcurrencyScopeFunction,
 						Limit: &ConcurrencyLimitConfiguration{
 							Value:       5,
-							IsPlanLimit: boolPtr(false),
+							IsPlanLimit: new(false),
 						},
-						Key: util.StrPtr("event.data.id == 2"),
+						Key: new("event.data.id == 2"),
 					},
 				},
 			}),
@@ -142,12 +141,12 @@ func TestToFunctionConfiguration(t *testing.T) {
 						{
 							Scope: enums.ConcurrencyScopeAccount,
 							Limit: 20,
-							Key:   util.StrPtr("event.data.id == 2"),
+							Key:   new("event.data.id == 2"),
 						},
 						{
 							Scope: enums.ConcurrencyScopeFn,
 							Limit: 5,
-							Key:   util.StrPtr("event.data.id == 2"),
+							Key:   new("event.data.id == 2"),
 						},
 					},
 				},
@@ -159,17 +158,17 @@ func TestToFunctionConfiguration(t *testing.T) {
 						Scope: ConcurrencyScopeAccount,
 						Limit: &ConcurrencyLimitConfiguration{
 							Value:       10,
-							IsPlanLimit: boolPtr(true),
+							IsPlanLimit: new(true),
 						},
-						Key: util.StrPtr("event.data.id == 2"),
+						Key: new("event.data.id == 2"),
 					},
 					{
 						Scope: ConcurrencyScopeFunction,
 						Limit: &ConcurrencyLimitConfiguration{
 							Value:       5,
-							IsPlanLimit: boolPtr(false),
+							IsPlanLimit: new(false),
 						},
-						Key: util.StrPtr("event.data.id == 2"),
+						Key: new("event.data.id == 2"),
 					},
 				},
 			}),
@@ -180,7 +179,7 @@ func TestToFunctionConfiguration(t *testing.T) {
 				RateLimit: &inngest.RateLimit{
 					Limit:  10,
 					Period: "30s",
-					Key:    util.StrPtr("event.data.customer_id"),
+					Key:    new("event.data.customer_id"),
 				},
 			}),
 			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
@@ -188,7 +187,7 @@ func TestToFunctionConfiguration(t *testing.T) {
 				RateLimit: &RateLimitConfiguration{
 					Limit:  10,
 					Period: "30s",
-					Key:    util.StrPtr("event.data.customer_id"),
+					Key:    new("event.data.customer_id"),
 				},
 			}),
 		},
@@ -215,7 +214,7 @@ func TestToFunctionConfiguration(t *testing.T) {
 					Limit:  10,
 					Period: 30 * time.Minute,
 					Burst:  3,
-					Key:    util.StrPtr("event.data.customer_id"),
+					Key:    new("event.data.customer_id"),
 				},
 			}),
 			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
@@ -224,7 +223,7 @@ func TestToFunctionConfiguration(t *testing.T) {
 					Limit:  10,
 					Period: "30m0s",
 					Burst:  3,
-					Key:    util.StrPtr("event.data.customer_id"),
+					Key:    new("event.data.customer_id"),
 				},
 			}),
 		},
@@ -233,14 +232,14 @@ func TestToFunctionConfiguration(t *testing.T) {
 			fn: mergeWithDefaultFunction(&inngest.Function{
 				Singleton: &inngest.Singleton{
 					Mode: enums.SingletonModeSkip,
-					Key:  util.StrPtr("event.data.id == 2"),
+					Key:  new("event.data.id == 2"),
 				},
 			}),
 			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
 			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
 				Singleton: &SingletonConfiguration{
 					Mode: SingletonModeSkip,
-					Key:  util.StrPtr("event.data.id == 2"),
+					Key:  new("event.data.id == 2"),
 				},
 			}),
 		},
@@ -291,14 +290,14 @@ func mergeWithDefaultFunctionConfiguration(overlay *FunctionConfiguration) *Func
 		Cancellations: []*CancellationConfiguration{},
 		Retries: &RetryConfiguration{
 			Value:     4,
-			IsDefault: boolPtr(true),
+			IsDefault: new(true),
 		},
 		Concurrency: []*ConcurrencyConfiguration{
 			{
 				Scope: ConcurrencyScopeAccount,
 				Limit: &ConcurrencyLimitConfiguration{
 					Value:       UnknownPlanConcurrencyLimit,
-					IsPlanLimit: boolPtr(true),
+					IsPlanLimit: new(true),
 				},
 			},
 		},
@@ -310,6 +309,7 @@ func mergeWithDefaultFunctionConfiguration(overlay *FunctionConfiguration) *Func
 	return base
 }
 
+//go:fix inline
 func intPtr(b int) *int {
-	return &b
+	return new(b)
 }

--- a/pkg/coreapi/graph/models/function_configuration_serializer_test.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer_test.go
@@ -308,8 +308,3 @@ func mergeWithDefaultFunctionConfiguration(overlay *FunctionConfiguration) *Func
 	}
 	return base
 }
-
-//go:fix inline
-func intPtr(b int) *int {
-	return new(b)
-}

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -21,7 +21,6 @@ import (
 	"github.com/inngest/inngest/pkg/history_reader"
 	"github.com/inngest/inngest/pkg/run"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -127,7 +126,7 @@ func (r *functionRunResolver) Event(ctx context.Context, obj *models.FunctionRun
 		CreatedAt: &evt.ReceivedAt,
 		ID:        evt.InternalID(),
 		Name:      &evt.EventName,
-		Payload:   util.StrPtr(string(payload)),
+		Payload:   new(string(payload)),
 	}, nil
 }
 
@@ -169,7 +168,7 @@ func (r *functionRunResolver) Events(ctx context.Context, obj *models.FunctionRu
 			ID:        e.InternalID(),
 			Name:      &e.EventName,
 			CreatedAt: &e.ReceivedAt,
-			Payload:   util.StrPtr(string(payload)),
+			Payload:   new(string(payload)),
 		}
 	}
 

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/smithy-go/ptr"
 	sq "github.com/doug-martin/goqu/v9"
 	_ "github.com/doug-martin/goqu/v9/dialect/postgres"
 	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
@@ -2907,11 +2906,11 @@ func (w wrapper) GetWorkerConnection(ctx context.Context, id cqrs.WorkerConnecti
 
 	var disconnectedAt, lastHeartbeatAt *time.Time
 	if conn.DisconnectedAt.Valid {
-		disconnectedAt = ptr.Time(time.UnixMilli(conn.DisconnectedAt.Int64))
+		disconnectedAt = new(time.UnixMilli(conn.DisconnectedAt.Int64))
 	}
 
 	if conn.LastHeartbeatAt.Valid {
-		lastHeartbeatAt = ptr.Time(time.UnixMilli(conn.LastHeartbeatAt.Int64))
+		lastHeartbeatAt = new(time.UnixMilli(conn.LastHeartbeatAt.Int64))
 	}
 
 	var appVersion *string
@@ -3231,10 +3230,10 @@ func (w wrapper) GetWorkerConnections(ctx context.Context, opt cqrs.GetWorkerCon
 
 		var disconnectedAt, lastHeartbeatAt *time.Time
 		if data.DisconnectedAt.Valid {
-			disconnectedAt = ptr.Time(time.UnixMilli(data.DisconnectedAt.Int64))
+			disconnectedAt = new(time.UnixMilli(data.DisconnectedAt.Int64))
 		}
 		if data.LastHeartbeatAt.Valid {
-			lastHeartbeatAt = ptr.Time(time.UnixMilli(data.LastHeartbeatAt.Int64))
+			lastHeartbeatAt = new(time.UnixMilli(data.LastHeartbeatAt.Int64))
 		}
 
 		var appVersion *string

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -303,7 +303,7 @@ func TestGetDebounceInfoHandler(t *testing.T) {
 		Debounce: &inngest.Debounce{
 			Key:     nil,
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 
@@ -961,7 +961,7 @@ func TestDeleteDebounceHandler(t *testing.T) {
 		Debounce: &inngest.Debounce{
 			Key:     nil,
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 
@@ -1027,7 +1027,7 @@ func TestRunDebounceHandler(t *testing.T) {
 		Debounce: &inngest.Debounce{
 			Key:     nil,
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 
@@ -1081,7 +1081,7 @@ func TestDeleteDebounceByIDHandler(t *testing.T) {
 		Debounce: &inngest.Debounce{
 			Key:     nil,
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 

--- a/pkg/devserver/api_test.go
+++ b/pkg/devserver/api_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/util"
 	sdkfeatureobs "github.com/inngest/inngest/proto/gen/sdk_feature_observations/v1"
-	"github.com/inngest/inngestgo"
 	"github.com/stretchr/testify/require"
 )
 
@@ -316,7 +315,7 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 
 			// change function config in each iteration
 			sdkFunction1.Timeouts = &inngest.Timeouts{
-				Start: inngestgo.StrPtr(fmt.Sprintf("%dm", i)),
+				Start: new(fmt.Sprintf("%dm", i)),
 			}
 			req.Functions[0] = sdkFunction1
 
@@ -397,7 +396,7 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 
 		// update fn config for sdkFunction1
 		sdkFunction1.Timeouts = &inngest.Timeouts{
-			Start: inngestgo.StrPtr("2m"),
+			Start: new("2m"),
 		}
 		req.Functions[0] = sdkFunction1
 

--- a/pkg/execution/batch/batch_test.go
+++ b/pkg/execution/batch/batch_test.go
@@ -479,7 +479,7 @@ func TestGetBatchInfo(t *testing.T) {
 			EventBatch: &inngest.EventBatchConfig{
 				MaxSize: 10,
 				Timeout: "60s",
-				Key:     strPtr("event.data.user_id"),
+				Key:     new("event.data.user_id"),
 			},
 		}
 
@@ -570,8 +570,9 @@ func TestGetBatchInfo(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func strPtr(s string) *string {
-	return &s
+	return new(s)
 }
 
 // TestPerEventIdempotenceKeys verifies that per-event SET keys are used for dedup
@@ -916,7 +917,7 @@ func TestDeleteBatch(t *testing.T) {
 			EventBatch: &inngest.EventBatchConfig{
 				MaxSize: 10,
 				Timeout: "60s",
-				Key:     strPtr("event.data.tenant_id"),
+				Key:     new("event.data.tenant_id"),
 			},
 		}
 

--- a/pkg/execution/batch/batch_test.go
+++ b/pkg/execution/batch/batch_test.go
@@ -570,11 +570,6 @@ func TestGetBatchInfo(t *testing.T) {
 	})
 }
 
-//go:fix inline
-func strPtr(s string) *string {
-	return new(s)
-}
-
 // TestPerEventIdempotenceKeys verifies that per-event SET keys are used for dedup
 // instead of the legacy sorted set, and that they expire independently.
 func TestPerEventIdempotenceKeys(t *testing.T) {

--- a/pkg/execution/batch/buffer_test.go
+++ b/pkg/execution/batch/buffer_test.go
@@ -1034,7 +1034,7 @@ func TestBufferedBatchManagerMultipleBufferKeys(t *testing.T) {
 		EventBatch: &inngest.EventBatchConfig{
 			MaxSize: 10,
 			Timeout: "60s",
-			Key:     strPtr("event.data.tenant"),
+			Key:     new("event.data.tenant"),
 		},
 	}
 

--- a/pkg/execution/checkpoint/util.go
+++ b/pkg/execution/checkpoint/util.go
@@ -4,7 +4,6 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/tracing/meta"
-	"github.com/inngest/inngestgo"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -16,7 +15,7 @@ func stepRunAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID
 			meta.Attr(meta.Attrs.QueuedAt, new(op.Timing.Start())),
 			meta.Attr(meta.Attrs.StartedAt, new(op.Timing.Start())),
 			meta.Attr(meta.Attrs.EndedAt, new(op.Timing.End())),
-			meta.Attr(meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusCompleted)),
+			meta.Attr(meta.Attrs.DynamicStatus, new(enums.StepStatusCompleted)),
 			meta.Attr(meta.Attrs.IsCheckpoint, new(true)),
 		),
 	)
@@ -27,7 +26,7 @@ func stepPlannedAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, r
 		meta.NewAttrSet(
 			meta.Attr(meta.Attrs.QueuedAt, new(op.Timing.Start())),
 			meta.Attr(meta.Attrs.StartedAt, new(op.Timing.Start())),
-			meta.Attr(meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusRunning)),
+			meta.Attr(meta.Attrs.DynamicStatus, new(enums.StepStatusRunning)),
 		),
 	)
 }

--- a/pkg/execution/checkpoint/util.go
+++ b/pkg/execution/checkpoint/util.go
@@ -11,13 +11,13 @@ import (
 func stepRunAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID) *meta.SerializableAttrs {
 	return attrs.Merge(
 		meta.NewAttrSet(
-			meta.Attr(meta.Attrs.StepName, inngestgo.Ptr(op.UserDefinedName())),
+			meta.Attr(meta.Attrs.StepName, new(op.UserDefinedName())),
 			meta.Attr(meta.Attrs.RunID, &runID),
-			meta.Attr(meta.Attrs.QueuedAt, inngestgo.Ptr(op.Timing.Start())),
-			meta.Attr(meta.Attrs.StartedAt, inngestgo.Ptr(op.Timing.Start())),
-			meta.Attr(meta.Attrs.EndedAt, inngestgo.Ptr(op.Timing.End())),
+			meta.Attr(meta.Attrs.QueuedAt, new(op.Timing.Start())),
+			meta.Attr(meta.Attrs.StartedAt, new(op.Timing.Start())),
+			meta.Attr(meta.Attrs.EndedAt, new(op.Timing.End())),
 			meta.Attr(meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusCompleted)),
-			meta.Attr(meta.Attrs.IsCheckpoint, inngestgo.Ptr(true)),
+			meta.Attr(meta.Attrs.IsCheckpoint, new(true)),
 		),
 	)
 }
@@ -25,8 +25,8 @@ func stepRunAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID
 func stepPlannedAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID) *meta.SerializableAttrs {
 	return attrs.Merge(
 		meta.NewAttrSet(
-			meta.Attr(meta.Attrs.QueuedAt, inngestgo.Ptr(op.Timing.Start())),
-			meta.Attr(meta.Attrs.StartedAt, inngestgo.Ptr(op.Timing.Start())),
+			meta.Attr(meta.Attrs.QueuedAt, new(op.Timing.Start())),
+			meta.Attr(meta.Attrs.StartedAt, new(op.Timing.Start())),
 			meta.Attr(meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusRunning)),
 		),
 	)
@@ -35,13 +35,13 @@ func stepPlannedAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, r
 func stepErrorAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID, status enums.StepStatus) *meta.SerializableAttrs {
 	return attrs.Merge(
 		meta.NewAttrSet(
-			meta.Attr(meta.Attrs.StepName, inngestgo.Ptr(op.UserDefinedName())),
+			meta.Attr(meta.Attrs.StepName, new(op.UserDefinedName())),
 			meta.Attr(meta.Attrs.RunID, &runID),
-			meta.Attr(meta.Attrs.QueuedAt, inngestgo.Ptr(op.Timing.Start())),
-			meta.Attr(meta.Attrs.StartedAt, inngestgo.Ptr(op.Timing.Start())),
-			meta.Attr(meta.Attrs.EndedAt, inngestgo.Ptr(op.Timing.End())),
+			meta.Attr(meta.Attrs.QueuedAt, new(op.Timing.Start())),
+			meta.Attr(meta.Attrs.StartedAt, new(op.Timing.Start())),
+			meta.Attr(meta.Attrs.EndedAt, new(op.Timing.End())),
 			meta.Attr(meta.Attrs.DynamicStatus, &status),
-			meta.Attr(meta.Attrs.IsCheckpoint, inngestgo.Ptr(true)),
+			meta.Attr(meta.Attrs.IsCheckpoint, new(true)),
 		),
 	)
 }

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 	"github.com/inngest/inngest/pkg/inngest"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/jonboulle/clockwork"
 	"github.com/oklog/ulid/v2"
 	"github.com/redis/rueidis"
@@ -179,7 +178,7 @@ func TestDebounce(t *testing.T) {
 		Debounce: &inngest.Debounce{
 			Key:     nil,
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 
@@ -473,7 +472,7 @@ func TestJITDebounceMigration(t *testing.T) {
 		Debounce: &inngest.Debounce{
 			Key:     nil,
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 
@@ -979,7 +978,7 @@ func TestDebounceTimeoutIsPreserved(t *testing.T) {
 		ID: functionId,
 		Debounce: &inngest.Debounce{
 			Period:  "4s",
-			Timeout: util.StrPtr("6s"),
+			Timeout: new("6s"),
 		},
 	}
 
@@ -1622,7 +1621,7 @@ func TestDebounceExecutionDuringMigrationWorks(t *testing.T) {
 		Debounce: &inngest.Debounce{
 			Key:     nil,
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 
@@ -1826,7 +1825,7 @@ func TestDebounceExecutionShouldNotRaceMigration(t *testing.T) {
 		Debounce: &inngest.Debounce{
 			Key:     nil,
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 
@@ -2003,7 +2002,7 @@ func TestRollbackPreparedMigrationKeepsMigratingFlagWhenPointerRestoreFails(t *t
 		ID: functionID,
 		Debounce: &inngest.Debounce{
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 	key := functionID.String()
@@ -2112,7 +2111,7 @@ func TestFinalizePreparedMigrationCommitsWhenPrimaryReadyAfterError(t *testing.T
 		ID: functionID,
 		Debounce: &inngest.Debounce{
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 	key := functionID.String()
@@ -2244,7 +2243,7 @@ func TestCompletePreparedMigrationKeepsMigratingFlagWhenSecondaryCleanupFails(t 
 		ID: functionID,
 		Debounce: &inngest.Debounce{
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 	key := functionID.String()
@@ -2377,7 +2376,7 @@ func TestDebounceMigrationFailurePreservesExistingDebounce(t *testing.T) {
 		ID: functionID,
 		Debounce: &inngest.Debounce{
 			Period:  "10s",
-			Timeout: util.StrPtr("60s"),
+			Timeout: new("60s"),
 		},
 	}
 
@@ -2496,7 +2495,7 @@ func TestGetDebounceInfo(t *testing.T) {
 			Debounce: &inngest.Debounce{
 				Key:     nil, // Uses function ID as key
 				Period:  "10s",
-				Timeout: util.StrPtr("60s"),
+				Timeout: new("60s"),
 			},
 		}
 
@@ -2535,9 +2534,9 @@ func TestGetDebounceInfo(t *testing.T) {
 		fn := inngest.Function{
 			ID: customFnId,
 			Debounce: &inngest.Debounce{
-				Key:     util.StrPtr("event.data.debounce_key"),
+				Key:     new("event.data.debounce_key"),
 				Period:  "10s",
-				Timeout: util.StrPtr("60s"),
+				Timeout: new("60s"),
 			},
 		}
 
@@ -2580,7 +2579,7 @@ func TestGetDebounceInfo(t *testing.T) {
 			Debounce: &inngest.Debounce{
 				Key:     nil,
 				Period:  "10s",
-				Timeout: util.StrPtr("60s"),
+				Timeout: new("60s"),
 			},
 		}
 
@@ -2684,7 +2683,7 @@ func TestDeleteDebounce(t *testing.T) {
 			Debounce: &inngest.Debounce{
 				Key:     nil,
 				Period:  "10s",
-				Timeout: util.StrPtr("60s"),
+				Timeout: new("60s"),
 			},
 		}
 
@@ -2779,7 +2778,7 @@ func TestRunDebounce(t *testing.T) {
 			Debounce: &inngest.Debounce{
 				Key:     nil,
 				Period:  "10s",
-				Timeout: util.StrPtr("60s"),
+				Timeout: new("60s"),
 			},
 		}
 
@@ -2860,7 +2859,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 			Debounce: &inngest.Debounce{
 				Key:     nil,
 				Period:  "10s",
-				Timeout: util.StrPtr("60s"),
+				Timeout: new("60s"),
 			},
 		}
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1906,9 +1906,9 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 		Attempt:     item.Attempt,
 		MaxAttempts: item.MaxAttempts,
 		QueueKind:   item.Kind,
-		RequestID:   inngestgo.Ptr(requestID),
-		GroupID:     inngestgo.Ptr(item.GroupID),
-		JobID:       inngestgo.Ptr(jobID),
+		RequestID:   new(requestID),
+		GroupID:     new(item.GroupID),
+		JobID:       new(jobID),
 	})
 
 	if e.fl == nil {
@@ -3499,7 +3499,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		Identifier:  sv2id,
 		Attempt:     0,
 		MaxAttempts: pause.MaxAttempts,
-		GroupID:     inngestgo.Ptr(pause.GroupID),
+		GroupID:     new(pause.GroupID),
 	})
 
 	md, err := e.smv2.LoadMetadata(ctx, sv2id)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -57,7 +57,6 @@ import (
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/inngest/inngest/pkg/util/gateway"
 	"github.com/inngest/inngest/pkg/util/strtimeout"
-	"github.com/inngest/inngestgo"
 	"github.com/jonboulle/clockwork"
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/attribute"
@@ -4628,7 +4627,7 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 		handledAt := e.opcodeHandledAt(group)
 		tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
 	}
-	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusSleeping))
+	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusSleeping))
 
 	// Create a new span that we'll use to record the sleep as complete.
 	// This is going to be attached to the same parent (the discovery step that started this sleep).
@@ -5058,7 +5057,7 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 		handledAt := e.opcodeHandledAt(group)
 		tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
 	}
-	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusWaiting))
+	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusWaiting))
 
 	span, err := e.tracerProvider.CreateDroppableSpan(
 		ctx,
@@ -5285,7 +5284,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 	tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
 	// Always correlate the triggering event ID with the invoked step.
 	meta.AddAttr(attrs, meta.Attrs.StepInvokeTriggerEventID, &evt.ID)
-	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusInvoking))
+	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusInvoking))
 
 	lifecycleItem := runCtx.LifecycleItem()
 	span, err := e.tracerProvider.CreateDroppableSpan(
@@ -5515,7 +5514,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execu
 		handledAt := e.opcodeHandledAt(group)
 		tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
 	}
-	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusWaiting))
+	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusWaiting))
 
 	lifecycleItem := runCtx.LifecycleItem()
 	span, err := e.tracerProvider.CreateDroppableSpan(
@@ -6160,26 +6159,26 @@ func (e *executor) emitStepSpan(ctx context.Context, runCtx execution.RunContext
 	switch gen.Op {
 	case enums.OpcodeStepError:
 		if IsStepRetryable(gen, runCtx) {
-			meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusErrored))
+			meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusErrored))
 			seed = tracing.RetryStepDynamicSeed(gen.ID, runCtx.AttemptCount())
 		} else {
-			meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusFailed))
+			meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusFailed))
 		}
 	case enums.OpcodeStepFailed:
-		meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusFailed))
+		meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusFailed))
 	case enums.OpcodeGateway, enums.OpcodeAIGateway:
 		if gen.Error != nil {
 			if IsStepRetryable(gen, runCtx) {
-				meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusErrored))
+				meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusErrored))
 			} else {
-				meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusFailed))
+				meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusFailed))
 			}
 		} else {
-			meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusCompleted))
+			meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusCompleted))
 		}
 	default:
 		// TODO: handle other generator ops that should emit step spans with appropriate status
-		meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusCompleted))
+		meta.AddAttr(attrs, meta.Attrs.DynamicStatus, new(enums.StepStatusCompleted))
 	}
 
 	attrs = attrs.Merge(extraAttrs)

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -26,7 +26,6 @@ import (
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/util"
-	"github.com/inngest/inngestgo"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -678,12 +677,12 @@ func apiAttributes(res apiresult.APIResult) *meta.SerializableAttrs {
 	compactHeaders := headers.Compact(headers.Redact(h))
 
 	rawAttrs := meta.NewAttrSet()
-	meta.AddAttr(rawAttrs, meta.Attrs.IsFunctionOutput, inngestgo.Ptr(true))
+	meta.AddAttr(rawAttrs, meta.Attrs.IsFunctionOutput, new(true))
 	meta.AddAttr(rawAttrs, meta.Attrs.ResponseHeaders, &compactHeaders)
 	meta.AddAttr(rawAttrs, meta.Attrs.ResponseStatusCode, &res.StatusCode)
-	meta.AddAttr(rawAttrs, meta.Attrs.ResponseOutputSize, inngestgo.Ptr(len(res.Body)))
+	meta.AddAttr(rawAttrs, meta.Attrs.ResponseOutputSize, new(len(res.Body)))
 	// XXX: We always wrap trace output with {"data":T} or {"error":T} for consistency with steps.
-	meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, inngestgo.Ptr(util.DataWrap([]byte(res.Body))))
+	meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, new(util.DataWrap([]byte(res.Body))))
 
 	return rawAttrs
 }
@@ -691,11 +690,11 @@ func apiAttributes(res apiresult.APIResult) *meta.SerializableAttrs {
 func runCompleteAttrs(gen state.GeneratorOpcode) *meta.SerializableAttrs {
 	rawAttrs := meta.NewAttrSet()
 
-	meta.AddAttr(rawAttrs, meta.Attrs.IsFunctionOutput, inngestgo.Ptr(true))
-	meta.AddAttr(rawAttrs, meta.Attrs.ResponseStatusCode, inngestgo.Ptr(200)) // Must be to have this code.  It's an async fn.
-	meta.AddAttr(rawAttrs, meta.Attrs.ResponseOutputSize, inngestgo.Ptr(len(gen.Data)))
+	meta.AddAttr(rawAttrs, meta.Attrs.IsFunctionOutput, new(true))
+	meta.AddAttr(rawAttrs, meta.Attrs.ResponseStatusCode, new(200)) // Must be to have this code.  It's an async fn.
+	meta.AddAttr(rawAttrs, meta.Attrs.ResponseOutputSize, new(len(gen.Data)))
 	// XXX: We always wrap trace output with {"data":T} or {"error":T} for consistency with steps.
-	meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, inngestgo.Ptr(util.DataWrap(gen.Data)))
+	meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, new(util.DataWrap(gen.Data)))
 
 	rawAttrs = rawAttrs.Merge(tracing.GeneratorAttrs(&gen))
 

--- a/pkg/execution/queue/convert_test.go
+++ b/pkg/execution/queue/convert_test.go
@@ -1208,11 +1208,6 @@ func assertItemEqual(t *testing.T, expected, actual Item) {
 	require.Equal(t, expected.RunInfo.ScavengeCount, actual.RunInfo.ScavengeCount)
 }
 
-//go:fix inline
-func protoStringPtr(value string) *string {
-	return new(value)
-}
-
 func validIdentifierProto() *pb.Identifier {
 	return &pb.Identifier{
 		RunId:           ulid.Make().String(),

--- a/pkg/execution/queue/convert_test.go
+++ b/pkg/execution/queue/convert_test.go
@@ -604,7 +604,7 @@ func TestQueueItemFromProtoInvalidIDs(t *testing.T) {
 	_, err = QueueItemFromProto(&pb.QueueItem{
 		FunctionId:  uuid.NewString(),
 		WorkspaceId: uuid.NewString(),
-		LeaseId:     protoStringPtr("not-a-ulid"),
+		LeaseId:     new("not-a-ulid"),
 	})
 	require.ErrorContains(t, err, "queue item lease_id")
 }
@@ -748,17 +748,17 @@ func TestIdentifierFromProtoInvalidIDs(t *testing.T) {
 		},
 		{
 			name:    "batch id",
-			mutate:  func(msg *pb.Identifier) { msg.BatchId = protoStringPtr("bad") },
+			mutate:  func(msg *pb.Identifier) { msg.BatchId = new("bad") },
 			wantErr: "identifier batch_id",
 		},
 		{
 			name:    "original run id",
-			mutate:  func(msg *pb.Identifier) { msg.OriginalRunId = protoStringPtr("bad") },
+			mutate:  func(msg *pb.Identifier) { msg.OriginalRunId = new("bad") },
 			wantErr: "identifier original_run_id",
 		},
 		{
 			name:    "replay id",
-			mutate:  func(msg *pb.Identifier) { msg.ReplayId = protoStringPtr("bad") },
+			mutate:  func(msg *pb.Identifier) { msg.ReplayId = new("bad") },
 			wantErr: "identifier replay_id",
 		},
 		{
@@ -1208,8 +1208,9 @@ func assertItemEqual(t *testing.T, expected, actual Item) {
 	require.Equal(t, expected.RunInfo.ScavengeCount, actual.RunInfo.ScavengeCount)
 }
 
+//go:fix inline
 func protoStringPtr(value string) *string {
-	return &value
+	return new(value)
 }
 
 func validIdentifierProto() *pb.Identifier {

--- a/pkg/execution/queue/item_test.go
+++ b/pkg/execution/queue/item_test.go
@@ -233,7 +233,7 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 				RateLimit: &inngest.RateLimit{
 					Limit:  10,
 					Period: "60s",
-					Key:    stringPtr("event.user.id"),
+					Key:    new("event.user.id"),
 				},
 			},
 			expected: constraintapi.ConstraintConfig{
@@ -292,13 +292,13 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 						},
 						{
 							Limit: 3,
-							Key:   stringPtr("event.user.id"),
+							Key:   new("event.user.id"),
 							Scope: enums.ConcurrencyScopeAccount,
 							Hash:  "user-key-hash",
 						},
 						{
 							Limit: 2,
-							Key:   stringPtr("event.organization.id"),
+							Key:   new("event.organization.id"),
 							Scope: enums.ConcurrencyScopeEnv,
 							Hash:  "org-key-hash",
 						},
@@ -368,7 +368,7 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 					Limit:  15,
 					Burst:  3,
 					Period: 30 * time.Second,
-					Key:    stringPtr("event.tenant.id"),
+					Key:    new("event.tenant.id"),
 				},
 			},
 			expected: constraintapi.ConstraintConfig{
@@ -398,7 +398,7 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 				RateLimit: &inngest.RateLimit{
 					Limit:  25,
 					Period: "120s",
-					Key:    stringPtr("event.api_key"),
+					Key:    new("event.api_key"),
 				},
 				Concurrency: &inngest.ConcurrencyLimits{
 					Limits: []inngest.StepConcurrency{
@@ -408,7 +408,7 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 						},
 						{
 							Limit: 5,
-							Key:   stringPtr("event.user.id"),
+							Key:   new("event.user.id"),
 							Scope: enums.ConcurrencyScopeAccount,
 							Hash:  "complete-user-hash",
 						},
@@ -418,7 +418,7 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 					Limit:  50,
 					Burst:  10,
 					Period: 90 * time.Second,
-					Key:    stringPtr("event.organization.slug"),
+					Key:    new("event.organization.slug"),
 				},
 			},
 			expected: constraintapi.ConstraintConfig{
@@ -491,6 +491,8 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 }
 
 // Helper function to create string pointers
+//
+//go:fix inline
 func stringPtr(s string) *string {
-	return &s
+	return new(s)
 }

--- a/pkg/execution/queue/item_test.go
+++ b/pkg/execution/queue/item_test.go
@@ -489,10 +489,3 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 		})
 	}
 }
-
-// Helper function to create string pointers
-//
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}

--- a/pkg/execution/ratelimit/ratelimit_test.go
+++ b/pkg/execution/ratelimit/ratelimit_test.go
@@ -17,7 +17,7 @@ func TestRateLimitKey(t *testing.T) {
 			ctx,
 			id,
 			inngest.RateLimit{
-				Key: str("event.data.orderId"),
+				Key: new("event.data.orderId"),
 			},
 			map[string]any{
 				"data": map[string]any{
@@ -34,7 +34,7 @@ func TestRateLimitKey(t *testing.T) {
 			ctx,
 			id,
 			inngest.RateLimit{
-				Key: str("event.data.name + '--' + event.data.id"),
+				Key: new("event.data.name + '--' + event.data.id"),
 			},
 			map[string]any{
 				"data": map[string]any{
@@ -52,7 +52,7 @@ func TestRateLimitKey(t *testing.T) {
 			ctx,
 			id,
 			inngest.RateLimit{
-				Key: str("event.data.name + '--' + event.data.id"),
+				Key: new("event.data.name + '--' + event.data.id"),
 			},
 			map[string]any{
 				"data": map[string]any{
@@ -65,6 +65,7 @@ func TestRateLimitKey(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func str(s string) *string {
-	return &s
+	return new(s)
 }

--- a/pkg/execution/ratelimit/ratelimit_test.go
+++ b/pkg/execution/ratelimit/ratelimit_test.go
@@ -64,8 +64,3 @@ func TestRateLimitKey(t *testing.T) {
 		require.EqualValues(t, hash("jj--", id), key)
 	})
 }
-
-//go:fix inline
-func str(s string) *string {
-	return new(s)
-}

--- a/pkg/execution/realtime/token_test.go
+++ b/pkg/execution/realtime/token_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/execution/realtime/streamingtypes"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +49,7 @@ func TestNewJWT_CustomExpiry(t *testing.T) {
 		Name:    streamingtypes.TopicNameStream,
 		EnvID:   envID,
 	}}, NewJWTOpts{
-		Expiry: util.ToPtr(customExpiry),
+		Expiry: new(customExpiry),
 	})
 	r.NoError(err)
 	r.NotEmpty(token)

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -27,14 +27,14 @@ func TestDriverResponseFinal(t *testing.T) {
 		{
 			name: "error is not final",
 			r: DriverResponse{
-				Err: strptr("some err"),
+				Err: new("some err"),
 			},
 			expected: false,
 		},
 		{
 			name: "error marked as final is final",
 			r: DriverResponse{
-				Err:   strptr("some err"),
+				Err:   new("some err"),
 				final: true,
 			},
 			expected: true,
@@ -57,7 +57,7 @@ func TestDriverResponseFormatError(t *testing.T) {
 	}{
 		{
 			name: "with no Output and Err",
-			r:    DriverResponse{Output: nil, Err: strptr("something went wrong")},
+			r:    DriverResponse{Output: nil, Err: new("something went wrong")},
 			expected: StandardError{
 				Error:   "something went wrong",
 				Name:    "Error",
@@ -136,7 +136,7 @@ func TestDriverResponseFormatError(t *testing.T) {
 
 		{
 			name: "non map Output with error",
-			r:    DriverResponse{Output: "YOLO", Err: strptr("502 broken")},
+			r:    DriverResponse{Output: "YOLO", Err: new("502 broken")},
 			expected: StandardError{
 				Error:   "502 broken",
 				Name:    "Error",
@@ -212,7 +212,7 @@ func TestFatalUpstreamError(t *testing.T) {
 		// This mirrors what the driver does: set Output + keep the status Err.
 		dr := DriverResponse{
 			Output: json.RawMessage(out),
-			Err:    strptr("invalid status code: 502"),
+			Err:    new("invalid status code: 502"),
 		}
 		se := dr.StandardError()
 		require.Equal(t, FatalServerErrorName, se.Name)
@@ -274,7 +274,7 @@ func TestGetTraceFunctionOutput(t *testing.T) {
 			name: "HTML output wrapped in error with quoted string",
 			r: DriverResponse{
 				Generator: []*GeneratorOpcode{},
-				Err:       strptr("failed"),
+				Err:       new("failed"),
 				Output:    "<html><body>502 Bad Gateway</body></html>",
 			},
 			expected: `{"error":"<html><body>502 Bad Gateway</body></html>"}`,
@@ -315,7 +315,7 @@ func TestGetTraceFunctionOutput(t *testing.T) {
 			name: "error with non-JSON output",
 			r: DriverResponse{
 				Generator: []*GeneratorOpcode{},
-				Err:       strptr("request failed"),
+				Err:       new("request failed"),
 				Output:    "<html>Error page</html>",
 			},
 			expected: `{"error":"<html>Error page</html>"}`,
@@ -324,7 +324,7 @@ func TestGetTraceFunctionOutput(t *testing.T) {
 			name: "already wrapped error returned as-is",
 			r: DriverResponse{
 				Generator: []*GeneratorOpcode{},
-				Err:       strptr("failed"),
+				Err:       new("failed"),
 				Output:    `{"error":{"message":"SDK error"}}`,
 			},
 			expected: `{"error":{"message":"SDK error"}}`,
@@ -344,7 +344,7 @@ func TestGetTraceFunctionOutput(t *testing.T) {
 			name: "StandardError serialized output passes through as-is",
 			r: DriverResponse{
 				Generator: []*GeneratorOpcode{},
-				Err:       strptr("Unable to reach SDK URL"),
+				Err:       new("Unable to reach SDK URL"),
 				Output: StandardError{
 					Error:   "Unable to reach SDK URL",
 					Name:    DefaultErrorName,
@@ -358,7 +358,7 @@ func TestGetTraceFunctionOutput(t *testing.T) {
 			name: "syscode StandardError serialized output passes through as-is",
 			r: DriverResponse{
 				Generator: []*GeneratorOpcode{},
-				Err:       strptr("output_too_large"),
+				Err:       new("output_too_large"),
 				Output: StandardError{
 					Error:   "output_too_large: response too large",
 					Name:    "output_too_large",
@@ -372,7 +372,7 @@ func TestGetTraceFunctionOutput(t *testing.T) {
 			name: "V2 driver internal error StandardError passes through as-is",
 			r: DriverResponse{
 				Generator: []*GeneratorOpcode{},
-				Err:       strptr("Unable to reach SDK: connection refused"),
+				Err:       new("Unable to reach SDK: connection refused"),
 				Output: StandardError{
 					Error:   "Unable to reach SDK: connection refused",
 					Name:    DefaultErrorName,
@@ -455,6 +455,7 @@ func TestStandardErrorSerialize(t *testing.T) {
 	}
 }
 
+//go:fix inline
 func strptr(s string) *string {
-	return &s
+	return new(s)
 }

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -454,8 +454,3 @@ func TestStandardErrorSerialize(t *testing.T) {
 		})
 	}
 }
-
-//go:fix inline
-func strptr(s string) *string {
-	return new(s)
-}

--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -96,11 +96,6 @@ func activeRoleLease(q queueImpl, roleName string) *ulid.ULID {
 	return nil
 }
 
-//go:fix inline
-func max(i int) *int {
-	return new(i)
-}
-
 func TestQueueRunBasic(t *testing.T) {
 	customQueueName := "custom-queue-name"
 

--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -96,8 +96,9 @@ func activeRoleLease(q queueImpl, roleName string) *ulid.ULID {
 	return nil
 }
 
+//go:fix inline
 func max(i int) *int {
-	return &i
+	return new(i)
 }
 
 func TestQueueRunBasic(t *testing.T) {
@@ -129,7 +130,7 @@ func TestQueueRunBasic(t *testing.T) {
 			FunctionID: idA,
 			Data: osqueue.Item{
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(3),
+				MaxAttempts: new(3),
 				Identifier: state.Identifier{
 					AccountID:  accountId,
 					WorkflowID: idA,
@@ -141,7 +142,7 @@ func TestQueueRunBasic(t *testing.T) {
 			FunctionID: idB,
 			Data: osqueue.Item{
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(1),
+				MaxAttempts: new(1),
 				Identifier: state.Identifier{
 					AccountID:  accountId,
 					WorkflowID: idB,
@@ -154,7 +155,7 @@ func TestQueueRunBasic(t *testing.T) {
 			QueueName:  &customQueueName,
 			Data: osqueue.Item{
 				Kind:        "test-kind",
-				MaxAttempts: max(1),
+				MaxAttempts: new(1),
 				Identifier: state.Identifier{
 					AccountID:  accountId,
 					WorkflowID: idB,
@@ -221,7 +222,7 @@ func TestQueueRunRetry(t *testing.T) {
 			FunctionID: idA,
 			Data: osqueue.Item{
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(3),
+				MaxAttempts: new(3),
 				Identifier: state.Identifier{
 					AccountID:  accountId,
 					WorkflowID: idA,
@@ -472,7 +473,7 @@ func TestRunPriorityFactor(t *testing.T) {
 		{
 			WorkspaceID: idA,
 			Kind:        osqueue.KindEdge,
-			MaxAttempts: max(1),
+			MaxAttempts: new(1),
 			Identifier: state.Identifier{
 				AccountID:  accountId,
 				WorkflowID: idA,
@@ -482,7 +483,7 @@ func TestRunPriorityFactor(t *testing.T) {
 		{
 			WorkspaceID: idB,
 			Kind:        osqueue.KindEdge,
-			MaxAttempts: max(1),
+			MaxAttempts: new(1),
 			Identifier: state.Identifier{
 				AccountID:  accountId,
 				WorkflowID: idB,
@@ -575,7 +576,7 @@ func TestQueueAllowList(t *testing.T) {
 			Data: osqueue.Item{
 				QueueName:   &allowedQueueName,
 				Kind:        osqueue.KindPause,
-				MaxAttempts: max(3),
+				MaxAttempts: new(3),
 			},
 		},
 		{
@@ -584,7 +585,7 @@ func TestQueueAllowList(t *testing.T) {
 			Data: osqueue.Item{
 				QueueName:   &otherQueueName,
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(1),
+				MaxAttempts: new(1),
 				Identifier: state.Identifier{
 					AccountID: accountId,
 					RunID:     ulid.MustNew(ulid.Now(), rand.Reader),
@@ -595,7 +596,7 @@ func TestQueueAllowList(t *testing.T) {
 			ID: "i3",
 			Data: osqueue.Item{
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(1),
+				MaxAttempts: new(1),
 				Identifier: state.Identifier{
 					AccountID: accountId,
 					RunID:     ulid.MustNew(ulid.Now(), rand.Reader),
@@ -689,7 +690,7 @@ func TestQueueDenyList(t *testing.T) {
 			Data: osqueue.Item{
 				QueueName:   &deniedQueueName,
 				Kind:        osqueue.KindPause,
-				MaxAttempts: max(3),
+				MaxAttempts: new(3),
 			},
 		},
 		{
@@ -698,7 +699,7 @@ func TestQueueDenyList(t *testing.T) {
 			Data: osqueue.Item{
 				QueueName:   &otherQueueName,
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(1),
+				MaxAttempts: new(1),
 				Identifier: state.Identifier{
 					AccountID: accountId,
 					RunID:     ulid.MustNew(ulid.Now(), rand.Reader),
@@ -709,7 +710,7 @@ func TestQueueDenyList(t *testing.T) {
 			ID: "i3",
 			Data: osqueue.Item{
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(1),
+				MaxAttempts: new(1),
 				Identifier: state.Identifier{
 					AccountID: accountId,
 					RunID:     ulid.MustNew(ulid.Now(), rand.Reader),
@@ -788,7 +789,7 @@ func TestQueueRunAccount(t *testing.T) {
 			FunctionID: idA,
 			Data: osqueue.Item{
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(3),
+				MaxAttempts: new(3),
 				Identifier: state.Identifier{
 					WorkflowID: idA,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
@@ -800,7 +801,7 @@ func TestQueueRunAccount(t *testing.T) {
 			FunctionID: idB,
 			Data: osqueue.Item{
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(1),
+				MaxAttempts: new(1),
 				Identifier: state.Identifier{
 					WorkflowID: idB,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
@@ -812,7 +813,7 @@ func TestQueueRunAccount(t *testing.T) {
 			FunctionID: idB,
 			Data: osqueue.Item{
 				Kind:        osqueue.KindEdge,
-				MaxAttempts: max(1),
+				MaxAttempts: new(1),
 				Identifier: state.Identifier{
 					WorkflowID: idB,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -86,7 +86,7 @@ func TestQueueItemScore(t *testing.T) {
 					Kind: kind,
 					Identifier: state.Identifier{
 						RunID:          runID,
-						PriorityFactor: int64ptr(-60),
+						PriorityFactor: new(int64(-60)),
 					},
 				},
 			}
@@ -113,7 +113,7 @@ func TestQueueItemScore(t *testing.T) {
 				Kind: osqueue.KindSleep,
 				Identifier: state.Identifier{
 					RunID:          runID,
-					PriorityFactor: int64ptr(-60),
+					PriorityFactor: new(int64(-60)),
 				},
 			},
 		}
@@ -2412,9 +2412,6 @@ func createConcurrencyKey(scope enums.ConcurrencyScope, scopeID uuid.UUID, value
 		UnhashedEvaluatedKeyValue: value,
 	}
 }
-
-//go:fix inline
-func int64ptr(i int64) *int64 { return new(i) }
 
 func TestQueueEnqueueToBacklog(t *testing.T) {
 	t.Run("simple item", func(t *testing.T) {

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -2413,7 +2413,8 @@ func createConcurrencyKey(scope enums.ConcurrencyScope, scopeID uuid.UUID, value
 	}
 }
 
-func int64ptr(i int64) *int64 { return &i }
+//go:fix inline
+func int64ptr(i int64) *int64 { return new(i) }
 
 func TestQueueEnqueueToBacklog(t *testing.T) {
 	t.Run("simple item", func(t *testing.T) {

--- a/pkg/execution/state/redis_state/v2_adapter_test.go
+++ b/pkg/execution/state/redis_state/v2_adapter_test.go
@@ -765,8 +765,9 @@ func TestV2AdapterWithDisabledRetries(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func int64Ptr(v int64) *int64 {
-	return &v
+	return new(v)
 }
 
 // mustV2Service spins up a miniredis, wires a sharded manager against it, and

--- a/pkg/execution/state/redis_state/v2_adapter_test.go
+++ b/pkg/execution/state/redis_state/v2_adapter_test.go
@@ -98,7 +98,7 @@ func TestV2Adapter(t *testing.T) {
 					RequestVersion:  1,
 					HasAI:           true,
 					ForceStepPlan:   true,
-					PriorityFactor:  int64Ptr(100),
+					PriorityFactor:  new(int64(100)),
 					CustomConcurrencyKeys: []statev2.CustomConcurrency{
 						{
 							Key:   "f:" + functionID.String() + ":user-123",
@@ -763,11 +763,6 @@ func TestV2AdapterWithDisabledRetries(t *testing.T) {
 		_, err = v2svc.SaveStep(ctx, createdState.Metadata.ID, "no-retry-step", stepData)
 		require.NoError(t, err)
 	})
-}
-
-//go:fix inline
-func int64Ptr(v int64) *int64 {
-	return new(v)
 }
 
 // mustV2Service spins up a miniredis, wires a sharded manager against it, and

--- a/pkg/inngest/batch_test.go
+++ b/pkg/inngest/batch_test.go
@@ -129,7 +129,7 @@ func TestEventBatchConfigIsValid(t *testing.T) {
 		{
 			name: "should return error if key expression is invalid",
 			config: &EventBatchConfig{
-				Key:     strptr("me-bad"),
+				Key:     new("me-bad"),
 				MaxSize: 10,
 				Timeout: "2s",
 			},
@@ -140,7 +140,7 @@ func TestEventBatchConfigIsValid(t *testing.T) {
 			config: &EventBatchConfig{
 				MaxSize: 10,
 				Timeout: "2s",
-				If:      strptr("event.data.num = 5"),
+				If:      new("event.data.num = 5"),
 			},
 			expected: errors.New("conditional batch expression is invalid"),
 		},

--- a/pkg/inngest/concurrency_test.go
+++ b/pkg/inngest/concurrency_test.go
@@ -46,14 +46,14 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 				Step: []StepConcurrency{
 					{
 						Limit: 0,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Hash:  hashConcurrencyKey("what"),
 					},
 				},
 				Limits: []StepConcurrency{
 					{
 						Limit: 0,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Hash:  hashConcurrencyKey("what"),
 					},
 				},
@@ -65,14 +65,14 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 				Step: []StepConcurrency{
 					{
 						Limit: 10,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Hash:  hashConcurrencyKey("what"),
 					},
 				},
 				Limits: []StepConcurrency{
 					{
 						Limit: 10,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Hash:  hashConcurrencyKey("what"),
 					},
 				},
@@ -84,14 +84,14 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 				Step: []StepConcurrency{
 					{
 						Limit: 10,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Hash:  hashConcurrencyKey("what"),
 					},
 				},
 				Limits: []StepConcurrency{
 					{
 						Limit: 10,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Hash:  hashConcurrencyKey("what"),
 					},
 				},
@@ -103,7 +103,7 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 				Step: []StepConcurrency{
 					{
 						Limit: 10,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Scope: enums.ConcurrencyScopeAccount,
 						Hash:  hashConcurrencyKey("what"),
 					},
@@ -111,7 +111,7 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 				Limits: []StepConcurrency{
 					{
 						Limit: 10,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Scope: enums.ConcurrencyScopeAccount,
 						Hash:  hashConcurrencyKey("what"),
 					},
@@ -125,12 +125,12 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 					// ordered low to high
 					{
 						Limit: 10,
-						Key:   strptr("event.data.foo"),
+						Key:   new("event.data.foo"),
 						Hash:  hashConcurrencyKey("event.data.foo"),
 					},
 					{
 						Limit: 25,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Scope: enums.ConcurrencyScopeAccount,
 						Hash:  hashConcurrencyKey("what"),
 					},
@@ -139,12 +139,12 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 					// ordered low to high
 					{
 						Limit: 10,
-						Key:   strptr("event.data.foo"),
+						Key:   new("event.data.foo"),
 						Hash:  hashConcurrencyKey("event.data.foo"),
 					},
 					{
 						Limit: 25,
-						Key:   strptr("what"),
+						Key:   new("what"),
 						Scope: enums.ConcurrencyScopeAccount,
 						Hash:  hashConcurrencyKey("what"),
 					},
@@ -163,14 +163,14 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 				Step: []StepConcurrency{
 					{
 						Limit: 10,
-						Key:   strptr("event.data.userId"),
+						Key:   new("event.data.userId"),
 						Hash:  hashConcurrencyKey("event.data.userId"),
 					},
 				},
 				Limits: []StepConcurrency{
 					{
 						Limit: 10,
-						Key:   strptr("event.data.userId"),
+						Key:   new("event.data.userId"),
 						Hash:  hashConcurrencyKey("event.data.userId"),
 					},
 				},
@@ -183,7 +183,7 @@ func TestConcurrencyLimits_Unmarshal(t *testing.T) {
 				Fn: []FnConcurrency{
 					{
 						Limit: 3,
-						Key:   strptr("event.data.customerId"),
+						Key:   new("event.data.customerId"),
 						ID:    hashConcurrencyKey("event.data.customerId"),
 					},
 				},
@@ -214,7 +214,7 @@ func TestConcurrencyEvaluate(t *testing.T) {
 		{
 			limit: StepConcurrency{
 				Limit: 10,
-				Key:   strptr("event.data.user_id"),
+				Key:   new("event.data.user_id"),
 				Scope: enums.ConcurrencyScopeFn,
 			},
 			scopeID: uuidA,
@@ -229,7 +229,7 @@ func TestConcurrencyEvaluate(t *testing.T) {
 		{
 			limit: StepConcurrency{
 				Limit: 10,
-				Key:   strptr("event.data.user_id"),
+				Key:   new("event.data.user_id"),
 				Scope: enums.ConcurrencyScopeFn,
 			},
 			scopeID: uuidB,
@@ -244,7 +244,7 @@ func TestConcurrencyEvaluate(t *testing.T) {
 		{
 			limit: StepConcurrency{
 				Limit: 10,
-				Key:   strptr("event.data.user_id"),
+				Key:   new("event.data.user_id"),
 				Scope: enums.ConcurrencyScopeFn,
 			},
 			scopeID: uuidA,
@@ -259,7 +259,7 @@ func TestConcurrencyEvaluate(t *testing.T) {
 		{
 			limit: StepConcurrency{
 				Limit: 10,
-				Key:   strptr("event.data.user_id"),
+				Key:   new("event.data.user_id"),
 				Scope: enums.ConcurrencyScopeAccount,
 			},
 			scopeID: uuidA,

--- a/pkg/inngest/function_test.go
+++ b/pkg/inngest/function_test.go
@@ -86,7 +86,7 @@ func TestValidate(t *testing.T) {
 					Limits: []StepConcurrency{
 						{
 							Limit: 5,
-							Key:   strptr("invalid because not a string"),
+							Key:   new("invalid because not a string"),
 						},
 					},
 				},
@@ -133,7 +133,7 @@ func TestRunPriorityFactor(t *testing.T) {
 
 	t.Run("With ternaries", func(t *testing.T) {
 		f.Priority = &Priority{
-			Run: strptr("event.data.plan == 'paid' ? 100 : 0"),
+			Run: new("event.data.plan == 'paid' ? 100 : 0"),
 		}
 
 		pf, err := f.RunPriorityFactor(ctx, map[string]any{
@@ -151,7 +151,7 @@ func TestRunPriorityFactor(t *testing.T) {
 
 	t.Run("With an int return value in the expression", func(t *testing.T) {
 		f.Priority = &Priority{
-			Run: strptr("event.data.priority"),
+			Run: new("event.data.priority"),
 		}
 
 		pf, err := f.RunPriorityFactor(ctx, map[string]any{
@@ -187,7 +187,7 @@ func TestRunPriorityFactor(t *testing.T) {
 
 	t.Run("With missing data", func(t *testing.T) {
 		f.Priority = &Priority{
-			Run: strptr("event.data.priority"),
+			Run: new("event.data.priority"),
 		}
 
 		pf, err := f.RunPriorityFactor(ctx, map[string]any{
@@ -199,7 +199,7 @@ func TestRunPriorityFactor(t *testing.T) {
 
 	t.Run("With an invalid expression", func(t *testing.T) {
 		f.Priority = &Priority{
-			Run: strptr("event.data.priority = 123"),
+			Run: new("event.data.priority = 123"),
 		}
 
 		pf, err := f.RunPriorityFactor(ctx, map[string]any{
@@ -528,4 +528,5 @@ func TestDuplicateCronExpressionRejected(t *testing.T) {
 	require.ErrorContains(t, err, "duplicate cron expression")
 }
 
-func strptr(s string) *string { return &s }
+//go:fix inline
+func strptr(s string) *string { return new(s) }

--- a/pkg/inngest/function_test.go
+++ b/pkg/inngest/function_test.go
@@ -527,6 +527,3 @@ func TestDuplicateCronExpressionRejected(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "duplicate cron expression")
 }
-
-//go:fix inline
-func strptr(s string) *string { return new(s) }

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/inngest/inngest/pkg/util/aigateway"
 )
 
@@ -128,14 +127,14 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 		aiMd,
 		&HTTPMetadata{
 			Method:             http.MethodPost,
-			Domain:             util.ToPtr(u.Host),
-			Path:               util.ToPtr(u.Path),
-			RequestContentType: util.ToPtr("application/json"),
-			RequestSize:        util.ToPtr(int64(len(req.Body))),
+			Domain:             new(u.Host),
+			Path:               new(u.Path),
+			RequestContentType: new("application/json"),
+			RequestSize:        new(int64(len(req.Body))),
 
-			ResponseContentType: util.ToPtr("application/json"),
-			ResponseSize:        util.ToPtr(int64(len(resp))),
-			ResponseStatus:      util.ToPtr(int64(respStatus)),
+			ResponseContentType: new("application/json"),
+			ResponseSize:        new(int64(len(resp))),
+			ResponseStatus:      new(int64(respStatus)),
 		},
 	}, nil
 }

--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -376,7 +376,7 @@ func TestBackfillEstimatedCostInValues(t *testing.T) {
 				"response_model": "gpt-4o",
 			},
 			wantCost:  true,
-			wantExact: util.ToPtr(12.5),
+			wantExact: new(12.5),
 		},
 		{
 			name: "falls back to request model when response model absent",
@@ -386,7 +386,7 @@ func TestBackfillEstimatedCostInValues(t *testing.T) {
 				"request_model": "gpt-4o",
 			},
 			wantCost:  true,
-			wantExact: util.ToPtr(12.5),
+			wantExact: new(12.5),
 		},
 		{
 			name: "leaves an existing non-null cost untouched",
@@ -397,7 +397,7 @@ func TestBackfillEstimatedCostInValues(t *testing.T) {
 				"estimated_cost": 42.0,
 			},
 			wantCost:  true,
-			wantExact: util.ToPtr(42.0),
+			wantExact: new(42.0),
 		},
 		{
 			name: "overwrites an explicit null cost",
@@ -408,7 +408,7 @@ func TestBackfillEstimatedCostInValues(t *testing.T) {
 				"estimated_cost": nil,
 			},
 			wantCost:  true,
-			wantExact: util.ToPtr(12.5),
+			wantExact: new(12.5),
 		},
 		{
 			name: "no model means no cost",

--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
@@ -155,14 +154,14 @@ func TestExtractAIMetadata_TotalTokens(t *testing.T) {
 				// 100 != 17 + 44
 				intAttr("gen_ai.usage.total_tokens", 100),
 			},
-			want: util.ToPtr[int64](100),
+			want: new(int64(100)),
 		},
 		{
 			name: "computed from input only when total absent",
 			attrs: []*commonv1.KeyValue{
 				intAttr("gen_ai.usage.input_tokens", 10),
 			},
-			want: util.ToPtr[int64](10),
+			want: new(int64(10)),
 		},
 		{
 			name: "computed from input+output when total absent",
@@ -170,7 +169,7 @@ func TestExtractAIMetadata_TotalTokens(t *testing.T) {
 				intAttr("gen_ai.usage.input_tokens", 56),
 				intAttr("gen_ai.usage.output_tokens", 30),
 			},
-			want: util.ToPtr[int64](86),
+			want: new(int64(86)),
 		},
 	}
 

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -4,8 +4,6 @@ import (
 	"strconv"
 
 	v1 "go.opentelemetry.io/proto/otlp/common/v1"
-
-	"github.com/inngest/inngest/pkg/util"
 )
 
 // extractAIMetadataFromAttributes reads the OpenTelemetry GenAI semantic
@@ -34,7 +32,7 @@ func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) 
 
 	read("gen_ai.usage.input_tokens", func(v *v1.AnyValue) { md.InputTokens = v.GetIntValue() })
 	read("gen_ai.usage.output_tokens", func(v *v1.AnyValue) { md.OutputTokens = v.GetIntValue() })
-	read("gen_ai.usage.total_tokens", func(v *v1.AnyValue) { md.TotalTokens = util.ToPtr(v.GetIntValue()) })
+	read("gen_ai.usage.total_tokens", func(v *v1.AnyValue) { md.TotalTokens = new(v.GetIntValue()) })
 
 	read("gen_ai.response.finish_reasons", func(v *v1.AnyValue) {
 		// semconv defines finish_reasons as an array (one entry per choice), but
@@ -86,12 +84,12 @@ func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) 
 func intFromAny(v *v1.AnyValue) *int64 {
 	switch v.GetValue().(type) {
 	case *v1.AnyValue_IntValue:
-		return util.ToPtr(v.GetIntValue())
+		return new(v.GetIntValue())
 	case *v1.AnyValue_DoubleValue:
-		return util.ToPtr(int64(v.GetDoubleValue()))
+		return new(int64(v.GetDoubleValue()))
 	case *v1.AnyValue_StringValue:
 		if n, err := strconv.ParseFloat(v.GetStringValue(), 64); err == nil {
-			return util.ToPtr(int64(n))
+			return new(int64(n))
 		}
 	}
 	return nil
@@ -103,12 +101,12 @@ func intFromAny(v *v1.AnyValue) *int64 {
 func floatFromAny(v *v1.AnyValue) *float64 {
 	switch v.GetValue().(type) {
 	case *v1.AnyValue_DoubleValue:
-		return util.ToPtr(v.GetDoubleValue())
+		return new(v.GetDoubleValue())
 	case *v1.AnyValue_IntValue:
-		return util.ToPtr(float64(v.GetIntValue()))
+		return new(float64(v.GetIntValue()))
 	case *v1.AnyValue_StringValue:
 		if n, err := strconv.ParseFloat(v.GetStringValue(), 64); err == nil {
-			return util.ToPtr(n)
+			return new(n)
 		}
 	}
 	return nil

--- a/pkg/tracing/metadata/extractors/http.go
+++ b/pkg/tracing/metadata/extractors/http.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
-	"github.com/inngest/inngest/pkg/util"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
@@ -83,23 +82,23 @@ func (e *HTTPMetadataExtractor) extractHTTPMetadata(span *tracev1.Span) HTTPMeta
 	for _, attr := range span.Attributes {
 		switch attr.Key {
 		case "http.request.header.content-type":
-			metadata.RequestContentType = util.ToPtr(attr.Value.GetStringValue())
+			metadata.RequestContentType = new(attr.Value.GetStringValue())
 		case "http.response.header.content-type":
-			metadata.ResponseContentType = util.ToPtr(attr.Value.GetStringValue())
+			metadata.ResponseContentType = new(attr.Value.GetStringValue())
 		case "http.request.method":
 			metadata.Method = attr.Value.GetStringValue()
 		case "http.request.size":
-			metadata.RequestSize = util.ToPtr(attr.Value.GetIntValue())
+			metadata.RequestSize = new(attr.Value.GetIntValue())
 		case "http.response.size":
-			metadata.ResponseSize = util.ToPtr(attr.Value.GetIntValue())
+			metadata.ResponseSize = new(attr.Value.GetIntValue())
 		case "http.response.status_code":
-			metadata.ResponseStatus = util.ToPtr(attr.Value.GetIntValue())
+			metadata.ResponseStatus = new(attr.Value.GetIntValue())
 		case "url.domain":
-			metadata.Domain = util.ToPtr(attr.Value.GetStringValue())
+			metadata.Domain = new(attr.Value.GetStringValue())
 		case "server.address":
-			metadata.Domain = util.ToPtr(attr.Value.GetStringValue())
+			metadata.Domain = new(attr.Value.GetStringValue())
 		case "url.path":
-			metadata.Path = util.ToPtr(attr.Value.GetStringValue())
+			metadata.Path = new(attr.Value.GetStringValue())
 		}
 	}
 

--- a/pkg/tracing/util.go
+++ b/pkg/tracing/util.go
@@ -17,7 +17,6 @@ import (
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/util/aigateway"
-	"github.com/inngest/inngestgo"
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -93,7 +92,7 @@ func DriverResponseOutputAttrs(resp *state.DriverResponse) *meta.SerializableAtt
 	}
 
 	if resp.Retryable() {
-		meta.AddAttr(rawAttrs, meta.Attrs.Retryable, inngestgo.Ptr(true))
+		meta.AddAttr(rawAttrs, meta.Attrs.Retryable, new(true))
 	}
 
 	size := resp.OutputSize
@@ -154,7 +153,7 @@ func DriverResponseAttrs(
 	}
 
 	if resp.Retryable() {
-		meta.AddAttr(rawAttrs, meta.Attrs.Retryable, inngestgo.Ptr(true))
+		meta.AddAttr(rawAttrs, meta.Attrs.Retryable, new(true))
 	}
 
 	size := resp.OutputSize

--- a/pkg/util/pointer.go
+++ b/pkg/util/pointer.go
@@ -1,5 +1,6 @@
 package util
 
+//go:fix inline
 func ToPtr[T any](s T) *T {
-	return &s
+	return new(s)
 }

--- a/pkg/util/pointer.go
+++ b/pkg/util/pointer.go
@@ -1,6 +1,0 @@
-package util
-
-//go:fix inline
-func ToPtr[T any](s T) *T {
-	return new(s)
-}

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -2,11 +2,6 @@ package util
 
 import "strings"
 
-//go:fix inline
-func StrPtr(s string) *string {
-	return new(s)
-}
-
 var logSanitizer = strings.NewReplacer(
 	"\r", "",
 	"\n", "",

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -2,8 +2,9 @@ package util
 
 import "strings"
 
+//go:fix inline
 func StrPtr(s string) *string {
-	return &s
+	return new(s)
 }
 
 var logSanitizer = strings.NewReplacer(

--- a/tests/api/v2_invoke_test.go
+++ b/tests/api/v2_invoke_test.go
@@ -61,7 +61,7 @@ func TestV2InvokeFunction(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      fnID,
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("none", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -112,7 +112,7 @@ func TestV2InvokeFunctionIdempotency(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      fnID,
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("none", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/batch/batch_test.go
+++ b/tests/batch/batch_test.go
@@ -127,7 +127,7 @@ func TestMunsonRepro(t *testing.T) {
 		// 	-event.data.promotional
 		//  -event.data.notificationNotMeeting
 		//  -event.data.notificationMeeting
-		inngestgo.EventTrigger("test/batch", inngestgo.StrPtr("!( (has(event.data.promotional) && event.data.promotional) || (has(event.data.notificationNotMeeting) && event.data.notificationNotMeeting) || (has(event.data.notificationMeeting) && event.data.notificationMeeting) )")),
+		inngestgo.EventTrigger("test/batch", new("!( (has(event.data.promotional) && event.data.promotional) || (has(event.data.notificationNotMeeting) && event.data.notificationNotMeeting) || (has(event.data.notificationMeeting) && event.data.notificationMeeting) )")),
 		func(ctx context.Context, input inngestgo.Input[BatchEvent]) (any, error) {
 			if runID == "" {
 				runID = input.InputCtx.RunID
@@ -181,7 +181,7 @@ func TestBatchWithConditionalTrigger(t *testing.T) {
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
 		inngestgo.FunctionOpts{ID: "batch-test", BatchEvents: &inngestgo.ConfigBatchEvents{MaxSize: 5, Timeout: 5 * time.Second}},
-		inngestgo.EventTrigger("test/batch", inngestgo.StrPtr("has(event.data.num) && int(event.data.num) % 2 == 0")),
+		inngestgo.EventTrigger("test/batch", new("has(event.data.num) && int(event.data.num) % 2 == 0")),
 		func(ctx context.Context, input inngestgo.Input[BatchEvent]) (any, error) {
 			if runID == "" {
 				runID = input.InputCtx.RunID
@@ -224,7 +224,7 @@ func TestConditionalBatching(t *testing.T) {
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
 		// only even values of event.data.num are eligible for batching. Other events are scheduled for execution immediately.
-		inngestgo.FunctionOpts{ID: "conditional-batch-test", BatchEvents: &inngestgo.ConfigBatchEvents{MaxSize: 5, Timeout: 5 * time.Second, If: inngestgo.StrPtr("int(event.data.num) % 2 == 0")}},
+		inngestgo.FunctionOpts{ID: "conditional-batch-test", BatchEvents: &inngestgo.ConfigBatchEvents{MaxSize: 5, Timeout: 5 * time.Second, If: new("int(event.data.num) % 2 == 0")}},
 		inngestgo.EventTrigger("test/batch", nil),
 		func(ctx context.Context, input inngestgo.Input[BatchEvent]) (any, error) {
 			if runID == "" {
@@ -269,8 +269,8 @@ func TestConditionalBatchingWithEventTriggerCondition(t *testing.T) {
 
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
-		inngestgo.FunctionOpts{ID: "conditional-batch-test-with-event-trigger", BatchEvents: &inngestgo.ConfigBatchEvents{MaxSize: 5, Timeout: 5 * time.Second, If: inngestgo.StrPtr("has(event.data.num) && int(event.data.num) % 2 == 0")}},
-		inngestgo.EventTrigger("test/batch", inngestgo.StrPtr("event.data.promotional")),
+		inngestgo.FunctionOpts{ID: "conditional-batch-test-with-event-trigger", BatchEvents: &inngestgo.ConfigBatchEvents{MaxSize: 5, Timeout: 5 * time.Second, If: new("has(event.data.num) && int(event.data.num) % 2 == 0")}},
+		inngestgo.EventTrigger("test/batch", new("event.data.promotional")),
 		func(ctx context.Context, input inngestgo.Input[BatchEvent]) (any, error) {
 			if runID == "" {
 				runID = input.InputCtx.RunID

--- a/tests/conformance/golang/main.go
+++ b/tests/conformance/golang/main.go
@@ -37,8 +37,8 @@ func main() {
 
 	client, err := inngestgo.NewClient(inngestgo.ClientOpts{
 		AppID:      appID,
-		EventKey:   inngestgo.StrPtr(eventKey),
-		SigningKey: inngestgo.StrPtr(signingKey),
+		EventKey:   new(eventKey),
+		SigningKey: new(signingKey),
 		Dev:        &devMode,
 	})
 	if err != nil {
@@ -136,7 +136,7 @@ func registerFunctions(client inngestgo.Client) {
 	mustCreate(client, inngestgo.FunctionOpts{
 		ID: "test-suite-cancel-test",
 		Cancel: []inngestgo.ConfigCancel{
-			{Event: "cancel/please", If: inngestgo.StrPtr("async.data.request_id == event.data.request_id")},
+			{Event: "cancel/please", If: new("async.data.request_id == event.data.request_id")},
 		},
 	},
 		inngestgo.EventTrigger("tests/cancel.test", nil),
@@ -162,7 +162,7 @@ func registerFunctions(client inngestgo.Client) {
 		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
 			payload, err := step.WaitForEvent[map[string]any](ctx, "wait", step.WaitForEventOpts{
 				Event:   "test/resume",
-				If:      inngestgo.StrPtr("async.data.resume == true && async.data.id == event.data.id"),
+				If:      new("async.data.resume == true && async.data.id == event.data.id"),
 				Timeout: 10 * time.Second,
 			})
 			if err == step.ErrEventNotReceived {

--- a/tests/execution/state_store/state_migration_test.go
+++ b/tests/execution/state_store/state_migration_test.go
@@ -100,7 +100,7 @@ func TestStateOperationsAcrossBackends(t *testing.T) {
 					HasAI:           true,
 					ForceStepPlan:   true,
 					EventIDs:        []ulid.ULID{eventID},
-					PriorityFactor:  int64Ptr(50),
+					PriorityFactor:  new(int64(50)),
 					CustomConcurrencyKeys: []statev2.CustomConcurrency{
 						{
 							Key:   "f:" + functionID.String() + ":user-test",
@@ -402,9 +402,4 @@ func TestStateOperationsAcrossBackends(t *testing.T) {
 		_, err = svc.LoadMetadata(ctx, id)
 		assert.Error(t, err, "LoadMetadata should error after delete")
 	})
-}
-
-//go:fix inline
-func int64Ptr(v int64) *int64 {
-	return new(v)
 }

--- a/tests/execution/state_store/state_migration_test.go
+++ b/tests/execution/state_store/state_migration_test.go
@@ -404,6 +404,7 @@ func TestStateOperationsAcrossBackends(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func int64Ptr(v int64) *int64 {
-	return &v
+	return new(v)
 }

--- a/tests/golang/app_url_change_test.go
+++ b/tests/golang/app_url_change_test.go
@@ -41,8 +41,8 @@ func TestAppURLChange(t *testing.T) {
 		ic, err := inngestgo.NewClient(
 			inngestgo.ClientOpts{
 				AppID:       randomSuffix("app"),
-				Dev:         inngestgo.BoolPtr(true),
-				RegisterURL: inngestgo.StrPtr(fmt.Sprintf("%s/fn/register", DEV_URL)),
+				Dev:         new(true),
+				RegisterURL: new(fmt.Sprintf("%s/fn/register", DEV_URL)),
 			},
 		)
 		r.NoError(err)
@@ -51,7 +51,7 @@ func TestAppURLChange(t *testing.T) {
 			ic,
 			inngestgo.FunctionOpts{
 				ID:      "fn",
-				Retries: inngestgo.IntPtr(0),
+				Retries: new(0),
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/basic_step_test.go
+++ b/tests/golang/basic_step_test.go
@@ -72,7 +72,7 @@ func TestFunctionSteps(t *testing.T) {
 			// Wait for an event with an expression
 			_, err = step.WaitForEvent[any](ctx, "wait2", step.WaitForEventOpts{
 				Event:   "api/new.event",
-				If:      inngestgo.StrPtr(`async.data.ok == "yes" && async.data.id == event.data.id`),
+				If:      new(`async.data.ok == "yes" && async.data.id == event.data.id`),
 				Timeout: 5 * time.Second,
 			})
 			if err == step.ErrEventNotReceived {

--- a/tests/golang/cancel_pause_test.go
+++ b/tests/golang/cancel_pause_test.go
@@ -77,7 +77,7 @@ func TestPauseCancelFunction(t *testing.T) {
 		inngestgo.FunctionOpts{ID: "handle-cancel"},
 		inngestgo.EventTrigger(
 			"inngest/function.cancelled",
-			inngestgo.StrPtr(fmt.Sprintf("event.data.function_id == '%s'", fnSlug)),
+			new(fmt.Sprintf("event.data.function_id == '%s'", fnSlug)),
 		),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
 			fmt.Println("CANCELLED")

--- a/tests/golang/cancel_test.go
+++ b/tests/golang/cancel_test.go
@@ -40,7 +40,7 @@ func TestEventCancellation(t *testing.T) {
 		inngestgo.FunctionOpts{
 			ID: "test-cancel",
 			Cancel: []inngestgo.ConfigCancel{
-				{Event: cancelEvtName, If: inngestgo.StrPtr("async.data.cancel == event.data.cancel")},
+				{Event: cancelEvtName, If: new("async.data.cancel == event.data.cancel")},
 			},
 		},
 		inngestgo.EventTrigger(triggerEvtName, nil),
@@ -70,7 +70,7 @@ func TestEventCancellation(t *testing.T) {
 		inngestgo.FunctionOpts{ID: "handle-cancel"},
 		inngestgo.EventTrigger(
 			"inngest/function.cancelled",
-			inngestgo.StrPtr(fmt.Sprintf(
+			new(fmt.Sprintf(
 				"event.data.function_id == '%s-test-cancel'",
 				appName,
 			)),

--- a/tests/golang/concurrency_acct_scope_test.go
+++ b/tests/golang/concurrency_acct_scope_test.go
@@ -52,7 +52,7 @@ func TestConcurrency_ScopeAccount(t *testing.T) {
 					{
 						Limit: 1,
 						Scope: enums.ConcurrencyScopeAccount,
-						Key:   inngestgo.StrPtr("'global'"),
+						Key:   new("'global'"),
 					},
 				},
 			},
@@ -70,7 +70,7 @@ func TestConcurrency_ScopeAccount(t *testing.T) {
 					{
 						Limit: 1,
 						Scope: enums.ConcurrencyScopeAccount,
-						Key:   inngestgo.StrPtr("'global'"),
+						Key:   new("'global'"),
 					},
 				},
 			},

--- a/tests/golang/concurrency_fn_concurrency_test.go
+++ b/tests/golang/concurrency_fn_concurrency_test.go
@@ -44,7 +44,7 @@ func TestFnConcurrency(t *testing.T) {
 					},
 				},
 			},
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(trigger, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -135,11 +135,11 @@ func TestFnConcurrency_Key(t *testing.T) {
 				Fn: []inngestgo.ConfigFnConcurrency{
 					{
 						Limit: 1,
-						Key:   inngestgo.StrPtr("event.data.customer_id"),
+						Key:   new("event.data.customer_id"),
 					},
 				},
 			},
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(trigger, nil),
 		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {

--- a/tests/golang/concurrency_fn_scope_test.go
+++ b/tests/golang/concurrency_fn_scope_test.go
@@ -208,7 +208,7 @@ func TestConcurrency_ScopeFunction_Key(t *testing.T) {
 				Step: []inngestgo.ConfigStepConcurrency{
 					{
 						Limit: 1,
-						Key:   inngestgo.StrPtr("event.data.num"),
+						Key:   new("event.data.num"),
 					},
 				},
 			},
@@ -301,11 +301,11 @@ func TestConcurrency_ScopeFunction_Key_Fn(t *testing.T) {
 					},
 					{
 						Limit: 1,
-						Key:   inngestgo.StrPtr("event.data.num"),
+						Key:   new("event.data.num"),
 					},
 				},
 			},
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(trigger, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/concurrency_worker_test.go
+++ b/tests/golang/concurrency_worker_test.go
@@ -48,7 +48,7 @@ func TestWorkerConcurrency(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "worker-concurrency-test",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(trigger, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -73,7 +73,7 @@ func TestWorkerConcurrency(t *testing.T) {
 	// Connect with MaxWorkerConcurrency=1
 	maxConcurrency := int64(1)
 	_, err = inngestgo.Connect(connectCtx, inngestgo.ConnectOpts{
-		InstanceID:           inngestgo.StrPtr("worker-concurrency-test"),
+		InstanceID:           new("worker-concurrency-test"),
 		Apps:                 []inngestgo.Client{inngestClient},
 		MaxWorkerConcurrency: &maxConcurrency,
 	})

--- a/tests/golang/connect_test.go
+++ b/tests/golang/connect_test.go
@@ -37,7 +37,7 @@ func TestEndToEnd(t *testing.T) {
 
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
-		inngestgo.FunctionOpts{ID: "connect-test", Retries: inngestgo.IntPtr(0)},
+		inngestgo.FunctionOpts{ID: "connect-test", Retries: new(0)},
 		inngestgo.EventTrigger("test/connect", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
 			if runID == "" {
@@ -52,7 +52,7 @@ func TestEndToEnd(t *testing.T) {
 
 	t.Run("with connection", func(t *testing.T) {
 		wc, err := inngestgo.Connect(connectCtx, inngestgo.ConnectOpts{
-			InstanceID: inngestgo.StrPtr("my-worker"),
+			InstanceID: new("my-worker"),
 			Apps:       []inngestgo.Client{inngestClient},
 		})
 		require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestEndToEnd(t *testing.T) {
 
 		// Reconnect the worker — semaphore capacity is restored
 		wc2, err := inngestgo.Connect(connectCtx, inngestgo.ConnectOpts{
-			InstanceID: inngestgo.StrPtr("my-worker-2"),
+			InstanceID: new("my-worker-2"),
 			Apps:       []inngestgo.Client{inngestClient},
 		})
 		require.NoError(t, err)

--- a/tests/golang/event_list_test.go
+++ b/tests/golang/event_list_test.go
@@ -25,7 +25,7 @@ func TestEventList(t *testing.T) {
 
 		ic, err := inngestgo.NewClient(inngestgo.ClientOpts{
 			AppID: "app",
-			Dev:   toPtr(true),
+			Dev:   new(true),
 		})
 		r.NoError(err)
 
@@ -100,7 +100,7 @@ func TestEventList(t *testing.T) {
 
 		ic, err := inngestgo.NewClient(inngestgo.ClientOpts{
 			AppID: "app",
-			Dev:   toPtr(true),
+			Dev:   new(true),
 		})
 		r.NoError(err)
 		event1Name := randomSuffix("foo")
@@ -173,7 +173,7 @@ func TestEventList(t *testing.T) {
 			PageSize: 10,
 			Filter: models.EventsFilter{
 				From:  time.Now().Add(-2 * time.Hour),
-				Until: toPtr(time.Now().Add(-time.Hour)),
+				Until: new(time.Now().Add(-time.Hour)),
 			},
 		})
 		r.NoError(err)
@@ -189,7 +189,7 @@ func TestEventList(t *testing.T) {
 
 			inngestClient, err := inngestgo.NewClient(inngestgo.ClientOpts{
 				AppID: "app",
-				Dev:   toPtr(true),
+				Dev:   new(true),
 			})
 			r.NoError(err)
 			eventName := randomSuffix("evt")
@@ -238,7 +238,7 @@ func TestEventList(t *testing.T) {
 
 			inngestClient, err := inngestgo.NewClient(inngestgo.ClientOpts{
 				AppID: "app",
-				Dev:   toPtr(true),
+				Dev:   new(true),
 			})
 			r.NoError(err)
 

--- a/tests/golang/event_test.go
+++ b/tests/golang/event_test.go
@@ -30,7 +30,7 @@ func TestEvent(t *testing.T) {
 		// Send 1 event and wait for it show in the API.
 		inngestClient, err := inngestgo.NewClient(inngestgo.ClientOpts{
 			AppID: "app",
-			Dev:   toPtr(true),
+			Dev:   new(true),
 		})
 		r.NoError(err)
 		eventName := randomSuffix("foo")
@@ -115,7 +115,7 @@ func TestEvent(t *testing.T) {
 
 			inngestClient, err := inngestgo.NewClient(inngestgo.ClientOpts{
 				AppID: "app",
-				Dev:   toPtr(true),
+				Dev:   new(true),
 			})
 			r.NoError(err)
 			eventName := randomSuffix("evt")

--- a/tests/golang/failure_handling_test.go
+++ b/tests/golang/failure_handling_test.go
@@ -23,7 +23,7 @@ func TestFunctionFailureHandling(t *testing.T) {
 		inngestgo.FunctionOpts{
 			ID:      "always-fail",
 			Name:    "Always fail",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("test/fail", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -42,10 +42,10 @@ func TestFunctionFailureHandling(t *testing.T) {
 	require.NoError(t, err)
 	_, err = inngestgo.CreateFunction(
 		inngestClient,
-		inngestgo.FunctionOpts{ID: "handle-failures", Retries: inngestgo.IntPtr(0)},
+		inngestgo.FunctionOpts{ID: "handle-failures", Retries: new(0)},
 		inngestgo.EventTrigger(
 			"inngest/function.finished",
-			inngestgo.StrPtr("event.data.function_id == 'fail-app-always-fail'"),
+			new("event.data.function_id == 'fail-app-always-fail'"),
 		),
 		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
 			evt := input.Event
@@ -100,7 +100,7 @@ func TestFunctionFailureHandlingWithRateLimit(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:        "failed",
-			RateLimit: &inngestgo.ConfigRateLimit{Limit: 1, Period: 24 * time.Hour, Key: inngestgo.StrPtr("event.data.number")},
+			RateLimit: &inngestgo.ConfigRateLimit{Limit: 1, Period: 24 * time.Hour, Key: new("event.data.number")},
 		},
 		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -114,9 +114,9 @@ func TestFunctionFailureHandlingWithRateLimit(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:        "failed-failure",
-			RateLimit: &inngestgo.ConfigRateLimit{Limit: 1, Period: 24 * time.Hour, Key: inngestgo.StrPtr("event.data.number")},
+			RateLimit: &inngestgo.ConfigRateLimit{Limit: 1, Period: 24 * time.Hour, Key: new("event.data.number")},
 		},
-		inngestgo.EventTrigger("inngest/function.failed", inngestgo.StrPtr(`event.data.function_id == "failed-rate-limit-failed"`)),
+		inngestgo.EventTrigger("inngest/function.failed", new(`event.data.function_id == "failed-rate-limit-failed"`)),
 		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
 			atomic.AddInt32(&handled, 1)
 			return "handled", nil

--- a/tests/golang/failure_test.go
+++ b/tests/golang/failure_test.go
@@ -33,7 +33,7 @@ func TestFunctionFailure(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "test-sdk",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("failure/run", nil),
 		func(ctx context.Context, input inngestgo.Input[FnRunTestEvt]) (any, error) {
@@ -117,7 +117,7 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "test-sdk-fail-with-retry",
-			Retries: inngestgo.IntPtr(1),
+			Retries: new(1),
 		},
 		inngestgo.EventTrigger("failure/run-retry", nil),
 		func(ctx context.Context, input inngestgo.Input[FnRunTestEvt]) (any, error) {
@@ -256,7 +256,7 @@ func TestFunctionResponseTooLargeFailure(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "test-sdk-response-too-large",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("failure/run-response-too-large", nil),
 		func(ctx context.Context, input inngestgo.Input[FnRunTestEvt]) (any, error) {
@@ -336,7 +336,7 @@ func TestFunctionResponseTooLargeFailureWithRetry(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "test-sdk-response-too-large",
-			Retries: inngestgo.IntPtr(1),
+			Retries: new(1),
 		},
 		inngestgo.EventTrigger("failure/run-response-too-large-retry", nil),
 		func(ctx context.Context, input inngestgo.Input[FnRunTestEvt]) (any, error) {

--- a/tests/golang/fn_output_test.go
+++ b/tests/golang/fn_output_test.go
@@ -29,7 +29,7 @@ func TestFnOutputTooLarge(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "my-fn",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {

--- a/tests/golang/function_runs_test.go
+++ b/tests/golang/function_runs_test.go
@@ -62,7 +62,7 @@ func TestFunctionRunList(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      fmt.Sprintf("fn-run-err-%s", failedEventName),
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(failedEventName, nil),
 		func(ctx context.Context, input inngestgo.Input[FnRunTestEvt]) (any, error) {

--- a/tests/golang/golang_sdk_util.go
+++ b/tests/golang/golang_sdk_util.go
@@ -38,7 +38,7 @@ func NewSDKHandler(t *testing.T, appID string, copts ...opt) (inngestgo.Client, 
 		AppID:       appID,
 		EventKey:    &key,
 		Logger:      slog.New(slog.DiscardHandler),
-		RegisterURL: inngestgo.StrPtr(fmt.Sprintf("%s/fn/register", DEV_URL)),
+		RegisterURL: new(fmt.Sprintf("%s/fn/register", DEV_URL)),
 	}
 
 	for _, o := range copts {
@@ -85,7 +85,7 @@ func NewSDKConnectHandler(t *testing.T, appID string, copts ...opt) inngestgo.Cl
 		AppID:       appID,
 		EventKey:    &key,
 		Logger:      logger.StdlibLogger(context.Background()).SLog(),
-		RegisterURL: inngestgo.StrPtr(fmt.Sprintf("%s/fn/register", DEV_URL)),
+		RegisterURL: new(fmt.Sprintf("%s/fn/register", DEV_URL)),
 	}
 
 	for _, o := range copts {

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -32,7 +32,7 @@ func TestInvoke(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      invokedFnName,
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("none", nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
@@ -128,7 +128,7 @@ func TestInvokeGroup(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      invokedFnName,
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("none", nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
@@ -277,7 +277,7 @@ func TestInvokeTimeout(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      invokedFnName,
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("none", nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
@@ -391,7 +391,7 @@ func TestInvokeRateLimit(t *testing.T) {
 				Limit:  1,
 				Period: 1 * time.Minute,
 			},
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("none", nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
@@ -405,7 +405,7 @@ func TestInvokeRateLimit(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "main-fn",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
@@ -468,7 +468,7 @@ func TestInvokeInProgressRunID(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      invokedFnName,
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("none", nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
@@ -484,7 +484,7 @@ func TestInvokeInProgressRunID(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "main-fn",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {

--- a/tests/golang/multi_trigger_expression_test.go
+++ b/tests/golang/multi_trigger_expression_test.go
@@ -28,8 +28,8 @@ func TestMultiTriggerExpressions(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{ID: "multi-trigger-expression-test"},
 		inngestgo.MultipleTriggers{
-			inngestgo.EventTrigger("user.created", inngestgo.StrPtr("event.data.type == 'premium'")),
-			inngestgo.EventTrigger("user.updated", inngestgo.StrPtr("event.data.type == 'standard'")),
+			inngestgo.EventTrigger("user.created", new("event.data.type == 'premium'")),
+			inngestgo.EventTrigger("user.updated", new("event.data.type == 'standard'")),
 		},
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
 			atomic.AddInt32(&executionCount, 1)
@@ -106,7 +106,7 @@ func TestMultiTriggerExpressions(t *testing.T) {
 			inngestClient,
 			inngestgo.FunctionOpts{ID: "mixed-expression-test"},
 			inngestgo.MultipleTriggers{
-				inngestgo.EventTrigger("order.created", inngestgo.StrPtr("event.data.amount > 100")),
+				inngestgo.EventTrigger("order.created", new("event.data.amount > 100")),
 				inngestgo.EventTrigger("order.cancelled", nil), // No expression
 			},
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/non_json_output_test.go
+++ b/tests/golang/non_json_output_test.go
@@ -46,7 +46,7 @@ func TestNonJSONOutput(t *testing.T) {
 			inngestgo.ClientOpts{
 				AppID:       "my-app",
 				Logger:      slog.Default(),
-				RegisterURL: inngestgo.StrPtr(fmt.Sprintf("%s/fn/register", DEV_URL)),
+				RegisterURL: new(fmt.Sprintf("%s/fn/register", DEV_URL)),
 				URL:         proxyURL,
 				EventKey:    &ekey,
 			},
@@ -56,7 +56,7 @@ func TestNonJSONOutput(t *testing.T) {
 			inngestClient,
 			inngestgo.FunctionOpts{
 				ID:      "my-fn",
-				Retries: inngestgo.IntPtr(0),
+				Retries: new(0),
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/not_sdk_response_test.go
+++ b/tests/golang/not_sdk_response_test.go
@@ -58,8 +58,8 @@ func TestNotSDKResponse(t *testing.T) {
 			ic, err := inngestgo.NewClient(
 				inngestgo.ClientOpts{
 					AppID:       randomSuffix("app"),
-					Dev:         inngestgo.BoolPtr(true),
-					RegisterURL: inngestgo.StrPtr(fmt.Sprintf("%s/fn/register", DEV_URL)),
+					Dev:         new(true),
+					RegisterURL: new(fmt.Sprintf("%s/fn/register", DEV_URL)),
 					URL:         proxyURL,
 				},
 			)
@@ -69,7 +69,7 @@ func TestNotSDKResponse(t *testing.T) {
 				ic,
 				inngestgo.FunctionOpts{
 					ID:      "fn",
-					Retries: inngestgo.IntPtr(0),
+					Retries: new(0),
 				},
 				inngestgo.EventTrigger(eventName, nil),
 				func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/parallel_test.go
+++ b/tests/golang/parallel_test.go
@@ -256,7 +256,7 @@ func TestParallelSequential(t *testing.T) {
 	rid := NewRunID()
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
-		inngestgo.FunctionOpts{ID: "fn", Retries: inngestgo.Ptr(0)},
+		inngestgo.FunctionOpts{ID: "fn", Retries: new(0)},
 		inngestgo.EventTrigger(eventName, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
 			rid.Send(input.InputCtx.RunID)
@@ -354,7 +354,7 @@ func TestParallelDisabledOptimization(t *testing.T) {
 		rid := NewRunID()
 		_, err := inngestgo.CreateFunction(
 			inngestClient,
-			inngestgo.FunctionOpts{ID: "fn", Retries: inngestgo.Ptr(0)},
+			inngestgo.FunctionOpts{ID: "fn", Retries: new(0)},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
 				rid.Send(input.InputCtx.RunID)
@@ -458,7 +458,7 @@ func TestParallelDisabledOptimization(t *testing.T) {
 				rid := NewRunID()
 				_, err := inngestgo.CreateFunction(
 					inngestClient,
-					inngestgo.FunctionOpts{ID: "fn", Retries: inngestgo.Ptr(0)},
+					inngestgo.FunctionOpts{ID: "fn", Retries: new(0)},
 					inngestgo.EventTrigger(eventName, nil),
 					func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
 						atomic.AddInt32(&counterRequest, 1)
@@ -550,7 +550,7 @@ func TestParallelStepsDuplicatePlan(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "fn",
-			Retries: inngestgo.Ptr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(eventName, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -629,7 +629,7 @@ func TestParallelStepFailuresOnFailureDeduplication(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      functionID,
-			Retries: inngestgo.Ptr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(eventName, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -668,11 +668,11 @@ func TestParallelStepFailuresOnFailureDeduplication(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      handlerID,
-			Retries: inngestgo.Ptr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(
 			"inngest/function.failed",
-			inngestgo.StrPtr(fmt.Sprintf("event.data.function_id == '%s'", expectedFunctionID)),
+			new(fmt.Sprintf("event.data.function_id == '%s'", expectedFunctionID)),
 		),
 		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
 			atomic.AddInt32(&failureCount, 1)

--- a/tests/golang/priority_test.go
+++ b/tests/golang/priority_test.go
@@ -38,7 +38,7 @@ func TestFunctionPriorityRun(t *testing.T) {
 				},
 			}},
 			Priority: &inngestgo.ConfigPriority{
-				Run: inngestgo.StrPtr(`event.data.priority == "high" ? 5 : 0`),
+				Run: new(`event.data.priority == "high" ? 5 : 0`),
 			},
 		},
 		inngestgo.EventTrigger("test/priority", nil),

--- a/tests/golang/rate_limit_test.go
+++ b/tests/golang/rate_limit_test.go
@@ -20,7 +20,7 @@ func TestFunctionWithRateLimit(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:        "rate-limit",
-			RateLimit: &inngestgo.ConfigRateLimit{Limit: 1, Period: 24 * time.Hour, Key: inngestgo.StrPtr("event.data.number")},
+			RateLimit: &inngestgo.ConfigRateLimit{Limit: 1, Period: 24 * time.Hour, Key: new("event.data.number")},
 		},
 		inngestgo.EventTrigger("test/ratelimit", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/redirect_test.go
+++ b/tests/golang/redirect_test.go
@@ -47,7 +47,7 @@ func TestRedirect(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "my-fn",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("my-event", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/retry_test.go
+++ b/tests/golang/retry_test.go
@@ -200,7 +200,7 @@ func TestMaxRetries(t *testing.T) {
 		ic,
 		inngestgo.FunctionOpts{
 			ID:      "fn",
-			Retries: inngestgo.IntPtr(consts.MaxRetries),
+			Retries: new(consts.MaxRetries),
 		},
 		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/send_idempotent_retry_test.go
+++ b/tests/golang/send_idempotent_retry_test.go
@@ -67,7 +67,7 @@ func TestSendIdempotentRetry(t *testing.T) {
 		t,
 		randomSuffix("app"),
 		func(h *inngestgo.ClientOpts) {
-			h.EventURL = inngestgo.Ptr(strings.TrimSuffix(proxyURL.String(), "/"))
+			h.EventURL = new(strings.TrimSuffix(proxyURL.String(), "/"))
 		},
 	)
 	defer server.Close()

--- a/tests/golang/singleton_test.go
+++ b/tests/golang/singleton_test.go
@@ -32,7 +32,7 @@ func TestSingletonFunction(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:        "fn-singleton",
-			Singleton: &inngestgo.ConfigSingleton{Key: inngestgo.StrPtr("event.data.user.id")},
+			Singleton: &inngestgo.ConfigSingleton{Key: new("event.data.user.id")},
 		},
 		inngestgo.EventTrigger(trigger, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -96,7 +96,7 @@ func TestSingletonFunctionWithKeyResolvingToFalse(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:        "fn-singleton",
-			Singleton: &inngestgo.ConfigSingleton{Key: inngestgo.StrPtr("event.data.decision")},
+			Singleton: &inngestgo.ConfigSingleton{Key: new("event.data.decision")},
 		},
 		inngestgo.EventTrigger(trigger, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -152,7 +152,7 @@ func TestSingletonCancelMode(t *testing.T) {
 		inngestgo.FunctionOpts{
 			ID: "fn-singleton-cancel",
 			Singleton: &inngestgo.ConfigSingleton{
-				Key:  inngestgo.StrPtr("event.data.user.id"),
+				Key:  new("event.data.user.id"),
 				Mode: enums.SingletonModeCancel,
 			},
 		},
@@ -177,7 +177,7 @@ func TestSingletonCancelMode(t *testing.T) {
 			ID: "on-cancel",
 		},
 		inngestgo.EventTrigger("inngest/function.cancelled",
-			inngestgo.StrPtr(fmt.Sprintf(
+			new(fmt.Sprintf(
 				"event.data.function_id == '%s-fn-singleton-cancel'",
 				appName,
 			))),
@@ -194,7 +194,7 @@ func TestSingletonCancelMode(t *testing.T) {
 		inngestgo.FunctionOpts{
 			ID: "on-finish",
 		},
-		inngestgo.EventTrigger("inngest/function.finished", inngestgo.StrPtr(fmt.Sprintf(
+		inngestgo.EventTrigger("inngest/function.finished", new(fmt.Sprintf(
 			"event.data.function_id == '%s-fn-singleton-cancel' && event.data.result == true",
 			appName,
 		))),
@@ -258,7 +258,7 @@ func TestSingletonDifferentKeysBothRun(t *testing.T) {
 		inngestgo.FunctionOpts{
 			ID: "fn-singleton-cancel-different-keys",
 			Singleton: &inngestgo.ConfigSingleton{
-				Key:  inngestgo.StrPtr("event.data.user.id"),
+				Key:  new("event.data.user.id"),
 				Mode: enums.SingletonModeCancel,
 			},
 		},
@@ -273,7 +273,7 @@ func TestSingletonDifferentKeysBothRun(t *testing.T) {
 	_, err = inngestgo.CreateFunction(
 		inngestClient,
 		inngestgo.FunctionOpts{ID: "on-cancel-different-keys"},
-		inngestgo.EventTrigger("inngest/function.cancelled", inngestgo.StrPtr(fmt.Sprintf(
+		inngestgo.EventTrigger("inngest/function.cancelled", new(fmt.Sprintf(
 			"event.data.function_id == '%s-fn-singleton-cancel-different-keys'",
 			appName,
 		))),
@@ -287,7 +287,7 @@ func TestSingletonDifferentKeysBothRun(t *testing.T) {
 	_, err = inngestgo.CreateFunction(
 		inngestClient,
 		inngestgo.FunctionOpts{ID: "on-success-different-keys"},
-		inngestgo.EventTrigger("inngest/function.finished", inngestgo.StrPtr(fmt.Sprintf(
+		inngestgo.EventTrigger("inngest/function.finished", new(fmt.Sprintf(
 			"event.data.function_id == '%s-fn-singleton-cancel-different-keys' && event.data.result == true",
 			appName,
 		))),

--- a/tests/golang/step_error_test.go
+++ b/tests/golang/step_error_test.go
@@ -25,7 +25,7 @@ func TestStepErrors(t *testing.T) {
 		inngestgo.FunctionOpts{
 			ID:      "always-fail",
 			Name:    "Always fail",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger("test/fail", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -84,7 +84,7 @@ func TestStepErrorCalledOnce(t *testing.T) {
 		inngestgo.FunctionOpts{
 			ID:      "always-fail",
 			Name:    "Always fail",
-			Retries: inngestgo.IntPtr(2),
+			Retries: new(2),
 		},
 		inngestgo.EventTrigger("test/fail", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/step_pause_deadlock_test.go
+++ b/tests/golang/step_pause_deadlock_test.go
@@ -44,7 +44,7 @@ func TestStepPauseDeadlockRegression(t *testing.T) {
 		inngestClient,
 		inngestgo.FunctionOpts{
 			ID:      "my-fn",
-			Retries: inngestgo.IntPtr(0),
+			Retries: new(0),
 		},
 		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {

--- a/tests/golang/step_retry_test.go
+++ b/tests/golang/step_retry_test.go
@@ -17,7 +17,7 @@ import (
 func TestStepRetry(t *testing.T) {
 	c := client.New(t)
 
-	t.Run("Step-level error with Retries: inngestgo.IntPtr(0) means no retry", func(t *testing.T) {
+	t.Run("Step-level error with Retries: new(0) means no retry", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 		r := require.New(t)
@@ -67,7 +67,7 @@ func TestStepRetry(t *testing.T) {
 		r.Equal("oh no", stepError.Error())
 	})
 
-	t.Run("Step-level error with Retries: inngestgo.IntPtr(1) means one retry", func(t *testing.T) {
+	t.Run("Step-level error with Retries: new(1) means one retry", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 		r := require.New(t)
@@ -120,7 +120,7 @@ func TestStepRetry(t *testing.T) {
 		r.Equal("oh no", stepError.Error())
 	})
 
-	t.Run("Step-level NoRetryError with Retries: inngestgo.IntPtr(1) means no retry", func(t *testing.T) {
+	t.Run("Step-level NoRetryError with Retries: new(1) means no retry", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 		r := require.New(t)
@@ -170,7 +170,7 @@ func TestStepRetry(t *testing.T) {
 		r.Equal("permanent failure", stepError.Error())
 	})
 
-	t.Run("Function-level error with Retries: inngestgo.IntPtr(0) means no retry", func(t *testing.T) {
+	t.Run("Function-level error with Retries: new(0) means no retry", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 		r := require.New(t)
@@ -210,7 +210,7 @@ func TestStepRetry(t *testing.T) {
 		r.Equal(int32(1), functionExecutions.Load(), "function should execute exactly once (no retries)")
 	})
 
-	t.Run("Function-level NoRetryError with Retries: inngestgo.IntPtr(1) means no retry", func(t *testing.T) {
+	t.Run("Function-level NoRetryError with Retries: new(1) means no retry", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
 		r := require.New(t)

--- a/tests/golang/step_retry_test.go
+++ b/tests/golang/step_retry_test.go
@@ -34,7 +34,7 @@ func TestStepRetry(t *testing.T) {
 			inngestClient,
 			inngestgo.FunctionOpts{
 				ID:      "fn",
-				Retries: inngestgo.IntPtr(0),
+				Retries: new(0),
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -84,7 +84,7 @@ func TestStepRetry(t *testing.T) {
 			inngestClient,
 			inngestgo.FunctionOpts{
 				ID:      "fn",
-				Retries: inngestgo.IntPtr(1),
+				Retries: new(1),
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -137,7 +137,7 @@ func TestStepRetry(t *testing.T) {
 			inngestClient,
 			inngestgo.FunctionOpts{
 				ID:      "fn",
-				Retries: inngestgo.IntPtr(1),
+				Retries: new(1),
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -186,7 +186,7 @@ func TestStepRetry(t *testing.T) {
 			inngestClient,
 			inngestgo.FunctionOpts{
 				ID:      "fn",
-				Retries: inngestgo.IntPtr(0),
+				Retries: new(0),
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -226,7 +226,7 @@ func TestStepRetry(t *testing.T) {
 			inngestClient,
 			inngestgo.FunctionOpts{
 				ID:      "fn",
-				Retries: inngestgo.IntPtr(1),
+				Retries: new(1),
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
@@ -268,7 +268,7 @@ func TestStepRetry(t *testing.T) {
 			inngestClient,
 			inngestgo.FunctionOpts{
 				ID:      "fn",
-				Retries: inngestgo.IntPtr(0),
+				Retries: new(0),
 			},
 			inngestgo.EventTrigger(eventName, nil),
 			func(ctx context.Context, input inngestgo.Input[any]) (any, error) {

--- a/tests/golang/streaming_test.go
+++ b/tests/golang/streaming_test.go
@@ -184,8 +184,3 @@ func TestStreaming(t *testing.T) {
 		}, 10*time.Second, time.Second)
 	})
 }
-
-//go:fix inline
-func toPtr[T any](v T) *T {
-	return new(v)
-}

--- a/tests/golang/streaming_test.go
+++ b/tests/golang/streaming_test.go
@@ -27,8 +27,8 @@ func TestStreaming(t *testing.T) {
 		c := client.New(t)
 		inngestClient, err := inngestgo.NewClient(inngestgo.ClientOpts{
 			AppID:    "my-app",
-			EventKey: toPtr("test"),
-			EventURL: toPtr("http://localhost:8288"),
+			EventKey: new("test"),
+			EventURL: new("http://localhost:8288"),
 		})
 		r.NoError(err)
 
@@ -51,7 +51,7 @@ func TestStreaming(t *testing.T) {
 					http.Error(w, "failed to unmarshal body", http.StatusInternalServerError)
 					return
 				}
-				runID = toPtr(request.Context.RunID.String())
+				runID = new(request.Context.RunID.String())
 
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusCreated)
@@ -84,7 +84,7 @@ func TestStreaming(t *testing.T) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 		}))
 		defer fakeSDK.Close()
-		appURL = toPtr(fakeSDK.URL())
+		appURL = new(fakeSDK.URL())
 
 		// Simulate an SDK syncing itself.
 		sync := func() error {
@@ -185,6 +185,7 @@ func TestStreaming(t *testing.T) {
 	})
 }
 
+//go:fix inline
 func toPtr[T any](v T) *T {
-	return &v
+	return new(v)
 }

--- a/tests/golang/throttle_test.go
+++ b/tests/golang/throttle_test.go
@@ -139,7 +139,7 @@ func TestThrottle(t *testing.T) {
 			inngestgo.FunctionOpts{
 				ID: "throttle-test-with-keys",
 				Throttle: &inngestgo.ConfigThrottle{
-					Key:    inngestgo.StrPtr("event.data.id"),
+					Key:    new("event.data.id"),
 					Limit:  1,
 					Period: 3 * time.Second,
 				},

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -337,7 +337,7 @@ func TestWaitInvalidExpression(t *testing.T) {
 				ctx,
 				"wait",
 				step.WaitForEventOpts{
-					If:      inngestgo.StrPtr("invalid"),
+					If:      new("invalid"),
 					Name:    "dummy",
 					Timeout: 30 * time.Second,
 				},
@@ -381,7 +381,7 @@ func TestWaitInvalidExpressionSyntaxError(t *testing.T) {
 				ctx,
 				"wait",
 				step.WaitForEventOpts{
-					If:      inngestgo.StrPtr("event.data.userId === async.data.userId"),
+					If:      new("event.data.userId === async.data.userId"),
 					Name:    "test/continue",
 					Timeout: 30 * time.Second,
 				},
@@ -447,7 +447,7 @@ func TestManyWaitInvalidExpressions(t *testing.T) {
 				ctx,
 				"wait",
 				step.WaitForEventOpts{
-					If:      inngestgo.StrPtr(exp),
+					If:      new(exp),
 					Name:    "match-event",
 					Timeout: time.Minute,
 				},

--- a/tests/sdk_cancel_test.go
+++ b/tests/sdk_cancel_test.go
@@ -54,7 +54,7 @@ func TestSDKCancelNotReceived(t *testing.T) {
 				Op:          enums.OpcodeSleep,
 				ID:          hashes["Sleep 10s"],
 				Name:        "10s",
-				DisplayName: inngestgo.StrPtr("sleep"),
+				DisplayName: new("sleep"),
 				Data:        json.RawMessage("null"),
 			}}),
 
@@ -85,7 +85,7 @@ func TestSDKCancelNotReceived(t *testing.T) {
 				Op:          enums.OpcodeStepRun,
 				ID:          hashes["After the sleep"],
 				Name:        "After the sleep",
-				DisplayName: inngestgo.StrPtr("After the sleep"),
+				DisplayName: new("After the sleep"),
 				Data:        []byte(`"This should be cancelled if a matching cancel event is received"`),
 			}}),
 
@@ -157,7 +157,7 @@ func TestSDKCancelReceived(t *testing.T) {
 				Op:          enums.OpcodeSleep,
 				ID:          "c3ca5f787365eae0dea86250e27d476406956478",
 				Name:        "10s",
-				DisplayName: inngestgo.StrPtr("sleep"),
+				DisplayName: new("sleep"),
 				Data:        json.RawMessage("null"),
 			}}),
 

--- a/tests/sdk_cancel_via_api_test.go
+++ b/tests/sdk_cancel_via_api_test.go
@@ -58,7 +58,7 @@ func TestCancelFunctionViaAPI(t *testing.T) {
 			test.ExpectGeneratorResponse([]state.GeneratorOpcode{{
 				Op:          enums.OpcodeSleep,
 				ID:          hashes["Sleep 10s"],
-				DisplayName: inngestgo.StrPtr("sleep"),
+				DisplayName: new("sleep"),
 				Data:        json.RawMessage("null"),
 				Name:        "10s",
 			}}),

--- a/tests/sdk_no_retry_test.go
+++ b/tests/sdk_no_retry_test.go
@@ -42,7 +42,7 @@ func TestSDKNoRetry(t *testing.T) {
 			Op:          enums.OpcodeStepError,
 			ID:          "98bf98df193bcce7c33e6bc50927cf2ac21206cb",
 			Name:        "first step",
-			DisplayName: inngestgo.StrPtr(`first step`),
+			DisplayName: new(`first step`),
 			Error: &state.UserError{
 				Name:    "NonRetriableError",
 				Message: "no retry plz",

--- a/tests/sdk_retry_test.go
+++ b/tests/sdk_retry_test.go
@@ -50,7 +50,7 @@ func TestSDKRetry(t *testing.T) {
 			Op:          enums.OpcodeStepError,
 			ID:          "98bf98df193bcce7c33e6bc50927cf2ac21206cb",
 			Name:        "first step",
-			DisplayName: inngestgo.StrPtr(`first step`),
+			DisplayName: new(`first step`),
 			Error: &state.UserError{
 				Name:    "Error",
 				Message: "broken",
@@ -67,7 +67,7 @@ func TestSDKRetry(t *testing.T) {
 			Op:          enums.OpcodeStepRun,
 			ID:          hashes["first step"],
 			Name:        "first step",
-			DisplayName: inngestgo.StrPtr("first step"),
+			DisplayName: new("first step"),
 			Data:        []byte(`"yes: 2"`),
 		}}),
 		// Stack is updated

--- a/tests/sdk_step_test.go
+++ b/tests/sdk_step_test.go
@@ -60,7 +60,7 @@ func TestSDKSteps(t *testing.T) {
 			Op:          enums.OpcodeStepRun,
 			ID:          hashes["first step"],
 			Name:        "first step",
-			DisplayName: inngestgo.StrPtr("first step"),
+			DisplayName: new("first step"),
 			Data:        []byte(`"first step"`),
 		}}),
 		// Stack is updated
@@ -80,7 +80,7 @@ func TestSDKSteps(t *testing.T) {
 			ID:          hashes["sleep"],
 			Data:        json.RawMessage("null"),
 			Name:        "2s",
-			DisplayName: inngestgo.StrPtr("for 2s"),
+			DisplayName: new("for 2s"),
 		}}),
 		// Update stack and state
 		test.AddRequestStack(driver.FunctionStack{
@@ -96,7 +96,7 @@ func TestSDKSteps(t *testing.T) {
 		test.ExpectGeneratorResponse([]state.GeneratorOpcode{{
 			Op:          enums.OpcodeStepRun,
 			ID:          hashes["second step"],
-			DisplayName: inngestgo.StrPtr("second step"),
+			DisplayName: new("second step"),
 			Name:        "second step",
 			Data:        json.RawMessage(`{"first":"first step","second":true}`),
 		}}),

--- a/tests/sdk_wait_for_event_test.go
+++ b/tests/sdk_wait_for_event_test.go
@@ -66,7 +66,7 @@ func TestSDKWaitForEvent_WithEvent(t *testing.T) {
 				Op:          enums.OpcodeWaitForEvent,
 				ID:          hashes["wait"],
 				Name:        "test/resume",
-				DisplayName: inngestgo.StrPtr("test/resume"),
+				DisplayName: new("test/resume"),
 				Data:        json.RawMessage("null"),
 				Opts: map[string]any{
 					"if":      "async.data.resume == true && async.data.id == event.data.id",
@@ -160,7 +160,7 @@ func TestSDKWaitForEvent_NoEvent(t *testing.T) {
 				Op:          enums.OpcodeWaitForEvent,
 				ID:          hashes["wait"],
 				Name:        "test/resume",
-				DisplayName: inngestgo.StrPtr("test/resume"),
+				DisplayName: new("test/resume"),
 				Data:        json.RawMessage("null"),
 				Opts: map[string]any{
 					"if":      "async.data.resume == true && async.data.id == event.data.id",


### PR DESCRIPTION
## Description

- Run `go fix -newexpr ./...` to replace pointer-helper calls with Go 1.26 `new(expr)` expressions.
- Convert analyzer-skipped call sites and remove obsolete local pointer helpers, including `util.ToPtr` and `util.StrPtr`.
- Enable `modernize/newexpr` in golangci-lint while explicitly disabling unrelated modernization checks.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
