### PR TITLE
fix(billing): share current plan constants

### DIFF
--- a/ui/apps/dashboard/src/components/Billing/Plans/constants.ts
+++ b/ui/apps/dashboard/src/components/Billing/Plans/constants.ts
@@ -1,0 +1,3 @@
+export const HOBBY_PLAN_SLUG = 'hobby-free-2025-08-08';
+export const PRO_PLAN_SLUG = 'pro-2026-06-29';
+export const PRO_PLAN_AMOUNT_CENTS = 9_900;

--- a/ui/apps/dashboard/src/components/InfraDashboard/utils.test.ts
+++ b/ui/apps/dashboard/src/components/InfraDashboard/utils.test.ts
@@ -105,7 +105,7 @@ describe('infra dashboard billing plan merge', () => {
       inferInfraPlanSku({
         concurrencyLimit: 56,
         defaultSku: 'IN-S',
-        plan: { isFree: false, name: 'Pro', slug: 'pro-2025-08-08' },
+        plan: { isFree: false, name: 'Pro', slug: 'pro-2026-06-29' },
         plans,
       }),
     ).toBe('IN-XS');
@@ -120,7 +120,7 @@ describe('infra dashboard billing plan merge', () => {
       },
       defaultSku: 'IN-S',
       plan: {
-        amount: 7_500,
+        amount: 9_900,
         entitlements: {
           concurrency: { limit: 100 },
           events: { limit: 1_000_000 },
@@ -128,7 +128,7 @@ describe('infra dashboard billing plan merge', () => {
         },
         isFree: false,
         name: 'Pro',
-        slug: 'pro-2025-08-08',
+        slug: 'pro-2026-06-29',
       },
       plans: INFRA_DASHBOARD_PLACEHOLDERS.infraPlans,
     });
@@ -141,7 +141,7 @@ describe('infra dashboard billing plan merge', () => {
       execConcurrency: '256',
       execConcurrencyLimit: 256,
       isCurrent: true,
-      priceMonthly: '$75',
+      priceMonthly: '$99',
       queueDepth: '5M',
       queueDepthLimit: 5_000_000,
       sku: 'IN-M',
@@ -246,11 +246,11 @@ describe('infra dashboard billing plan merge', () => {
         slug: 'hobby-free-2025-08-08',
       },
       plans: INFRA_DASHBOARD_PLACEHOLDERS.infraPlans,
-      proPlanAmountCents: 7_500,
+      proPlanAmountCents: 9_900,
     });
 
     expect(result.plans.find((plan) => plan.sku === 'IN-S')).toMatchObject({
-      priceMonthly: '$75',
+      priceMonthly: '$99',
     });
   });
 
@@ -278,10 +278,10 @@ describe('infra dashboard billing actions', () => {
     slug: 'hobby-free-2025-08-08',
   };
   const proPlan = {
-    amount: 7_500,
+    amount: 9_900,
     isFree: false,
     name: 'Pro',
-    slug: 'pro-2025-08-08',
+    slug: 'pro-2026-06-29',
   };
 
   it('opens Pro checkout when a free account selects IN-S', () => {
@@ -296,9 +296,9 @@ describe('infra dashboard billing actions', () => {
     ).toEqual({
       addonUpdate: null,
       item: {
-        amount: 7_500,
+        amount: 9_900,
         name: 'Pro',
-        planSlug: 'pro-2025-08-08',
+        planSlug: 'pro-2026-06-29',
         quantity: 1,
       },
       type: 'upgrade-base-plan',
@@ -318,7 +318,7 @@ describe('infra dashboard billing actions', () => {
     ).toMatchObject({
       item: {
         amount: 6_500,
-        planSlug: 'pro-2025-08-08',
+        planSlug: 'pro-2026-06-29',
       },
       type: 'upgrade-base-plan',
     });
@@ -522,7 +522,7 @@ describe('infra dashboard billing actions', () => {
         targetSku: 'IN-L',
       },
       item: {
-        planSlug: 'pro-2025-08-08',
+        planSlug: 'pro-2026-06-29',
       },
       type: 'upgrade-base-plan',
     });
@@ -562,7 +562,7 @@ describe('infra dashboard billing actions', () => {
     ).toMatchObject({
       addonUpdate: null,
       item: {
-        planSlug: 'pro-2025-08-08',
+        planSlug: 'pro-2026-06-29',
       },
       type: 'upgrade-base-plan',
     });
@@ -584,7 +584,7 @@ describe('infra dashboard billing actions', () => {
         targetSku: 'IN-M',
       },
       item: {
-        planSlug: 'pro-2025-08-08',
+        planSlug: 'pro-2026-06-29',
       },
       type: 'upgrade-base-plan',
     });
@@ -606,7 +606,7 @@ describe('infra dashboard billing actions', () => {
         targetSku: 'IN-L',
       },
       item: {
-        planSlug: 'pro-2025-08-08',
+        planSlug: 'pro-2026-06-29',
       },
       type: 'upgrade-base-plan',
     });
@@ -628,7 +628,7 @@ describe('infra dashboard billing actions', () => {
         targetSku: 'IN-XL',
       },
       item: {
-        planSlug: 'pro-2025-08-08',
+        planSlug: 'pro-2026-06-29',
       },
       type: 'upgrade-base-plan',
     });

--- a/ui/apps/dashboard/src/components/InfraDashboard/utils.ts
+++ b/ui/apps/dashboard/src/components/InfraDashboard/utils.ts
@@ -4,6 +4,11 @@ import type {
   MetricsData,
   TimeSeriesPoint,
 } from '@/gql/graphql';
+import {
+  HOBBY_PLAN_SLUG,
+  PRO_PLAN_AMOUNT_CENTS,
+  PRO_PLAN_SLUG,
+} from '@/components/Billing/Plans/constants';
 import { concurrencyLimitReachedBySlot } from '@/components/Functions/concurrency';
 import type { Function as FunctionRow } from '@inngest/components/types/function';
 import type { InfraPlan, InfraPlanSku, InfraTierId } from './placeholderData';
@@ -102,10 +107,10 @@ type AccountEntitlementsSource = {
   functionBacklogSize?: { limit?: number | null } | null;
 };
 
-export const FREE_INFRA_PLAN_SLUG = 'hobby-free-2025-08-08';
-export const PRO_INFRA_PLAN_SLUG = 'pro-2025-08-08';
+export const FREE_INFRA_PLAN_SLUG = HOBBY_PLAN_SLUG;
+export const PRO_INFRA_PLAN_SLUG = PRO_PLAN_SLUG;
 
-const PRO_PLAN_BASE_AMOUNT_CENTS = 7_500;
+const PRO_PLAN_BASE_AMOUNT_CENTS = PRO_PLAN_AMOUNT_CENTS;
 
 export type InfraConcurrencyAddonSource = {
   available?: boolean | null;
@@ -164,7 +169,7 @@ const INFRA_PLAN_BILLING_TARGETS: Record<
   },
   'IN-S': {
     basePlanSlug: PRO_INFRA_PLAN_SLUG,
-    monthlyAmountCents: 9_900,
+    monthlyAmountCents: PRO_PLAN_AMOUNT_CENTS,
     targetConcurrency: 100,
   },
   'IN-M': {

--- a/ui/apps/dashboard/src/routes/_authed/billing/plans/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/billing/plans/index.tsx
@@ -7,6 +7,11 @@ import {
   HorizontalPlanCard,
   VerticalPlanCard,
 } from '@/components/Billing/Plans/PlanCard';
+import {
+  HOBBY_PLAN_SLUG,
+  PRO_PLAN_AMOUNT_CENTS,
+  PRO_PLAN_SLUG,
+} from '@/components/Billing/Plans/constants';
 import { type Plan } from '@/components/Billing/Plans/utils';
 import { currentPlan as getCurrentPlan } from '@/queries/server/billing';
 import { pathCreator } from '@/utils/urls';
@@ -38,7 +43,7 @@ function BillingPlansPage() {
   const plans: Plan[] = [
     {
       id: 'n/a',
-      slug: 'hobby-free-2025-08-08',
+      slug: HOBBY_PLAN_SLUG,
       name: 'Hobby',
       amount: 0,
       billingPeriod: 'month',
@@ -52,9 +57,9 @@ function BillingPlansPage() {
     },
     {
       id: 'n/a',
-      slug: 'pro-2026-06-29',
+      slug: PRO_PLAN_SLUG,
       name: 'Pro',
-      amount: 9900,
+      amount: PRO_PLAN_AMOUNT_CENTS,
       billingPeriod: 'month',
       entitlements: {
         concurrency: { limit: 100 },


### PR DESCRIPTION
## Description

Use one source for Hobby and Pro slugs and pricing across Billing Plans and the Infra Dashboard.

This updates Infra checkout to the current $99 Pro plan and prevents the two frontend surfaces from drifting independently.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
