### PR TITLE
fix(queue): close migration requeue routing window

### DIFF
--- a/pkg/execution/queue/requeue.go
+++ b/pkg/execution/queue/requeue.go
@@ -26,7 +26,19 @@ func (q *queueProducer) Requeue(ctx context.Context, shardName string, i QueueIt
 		}
 		return err
 	}
-	return source.Requeue(ctx, i, at, opts...)
+	err = source.Requeue(ctx, i, at, opts...)
+	if err == nil || !errors.Is(err, ErrQueueItemNotFound) {
+		return err
+	}
+
+	// Ownership can flip after the first current-shard attempt but before the
+	// source fallback. Resolve once more so that handoff window cannot lose an
+	// acknowledged requeue on both sides of the migration.
+	current, resolveErr = q.selectShard(ctx, "", i)
+	if resolveErr != nil || current.Name() == source.Name() {
+		return err
+	}
+	return current.Requeue(ctx, i, at, opts...)
 }
 
 // RequeueByJobID requires scope to include account, environment, and function
@@ -52,5 +64,16 @@ func (q *queueProducer) RequeueByJobID(ctx context.Context, scope Scope, shardNa
 		}
 		return err
 	}
-	return source.RequeueByJobID(ctx, jobID, at)
+	err = source.RequeueByJobID(ctx, jobID, at)
+	if err == nil || !errors.Is(err, ErrQueueItemNotFound) {
+		return err
+	}
+
+	// The routing handoff may have committed between the destination and source
+	// attempts. One re-resolution closes that single-transaction race window.
+	current, resolveErr = q.shards.Resolve(ctx, scope, nil)
+	if resolveErr != nil || current.Name() == source.Name() {
+		return err
+	}
+	return current.RequeueByJobID(ctx, jobID, at)
 }

--- a/pkg/execution/queue/requeue_test.go
+++ b/pkg/execution/queue/requeue_test.go
@@ -18,15 +18,23 @@ type requeueRoutingShard struct {
 	requeueByIDErr   error
 	requeueCalls     int
 	requeueByIDCalls int
+	onRequeue        func()
+	onRequeueByID    func()
 }
 
 func (s *requeueRoutingShard) Name() string { return s.name }
 func (s *requeueRoutingShard) Requeue(context.Context, QueueItem, time.Time, ...RequeueOptionFn) error {
 	s.requeueCalls++
+	if s.onRequeue != nil {
+		s.onRequeue()
+	}
 	return s.requeueErr
 }
 func (s *requeueRoutingShard) RequeueByJobID(context.Context, string, time.Time) error {
 	s.requeueByIDCalls++
+	if s.onRequeueByID != nil {
+		s.onRequeueByID()
+	}
 	return s.requeueByIDErr
 }
 
@@ -147,4 +155,57 @@ func TestProducerRequeueByJobIDUsesCurrentShardWithSourceFallback(t *testing.T) 
 			require.Equal(t, tt.wantDestCalls, destination.requeueByIDCalls)
 		})
 	}
+}
+
+func TestProducerRequeueRetriesCurrentShardAfterMigrationHandoff(t *testing.T) {
+	functionID := uuid.New()
+	item := QueueItem{
+		ID:         "job-1",
+		FunctionID: functionID,
+		Data: Item{Identifier: state.Identifier{
+			WorkflowID:  functionID,
+			WorkspaceID: uuid.New(),
+			AccountID:   uuid.New(),
+		}},
+	}
+
+	source := &requeueRoutingShard{name: "source", requeueErr: ErrQueueItemNotFound}
+	destination := &requeueRoutingShard{name: "destination", requeueErr: ErrQueueItemNotFound}
+	source.onRequeue = func() {
+		// The migration handoff commits after the destination miss and before the
+		// source miss returns. The item is now available only at the destination.
+		destination.requeueErr = nil
+	}
+	registry := mustShardRegistry(t,
+		map[string]QueueShard{"source": source, "destination": destination},
+		WithShardSelector(func(context.Context, Scope, *string) (QueueShard, error) {
+			return destination, nil
+		}),
+	)
+	producer := &queueProducer{shards: registry}
+
+	require.NoError(t, producer.Requeue(context.Background(), source.Name(), item, time.Now()))
+	require.Equal(t, 1, source.requeueCalls)
+	require.Equal(t, 2, destination.requeueCalls)
+}
+
+func TestProducerRequeueByJobIDRetriesCurrentShardAfterMigrationHandoff(t *testing.T) {
+	scope := Scope{AccountID: uuid.New(), EnvID: uuid.New(), FunctionID: uuid.New()}
+	source := &requeueRoutingShard{name: "source", requeueByIDErr: ErrQueueItemNotFound}
+	destination := &requeueRoutingShard{name: "destination", requeueByIDErr: ErrQueueItemNotFound}
+	source.onRequeueByID = func() {
+		// Simulate the atomic ownership flip completing between the two misses.
+		destination.requeueByIDErr = nil
+	}
+	registry := mustShardRegistry(t,
+		map[string]QueueShard{"source": source, "destination": destination},
+		WithShardSelector(func(context.Context, Scope, *string) (QueueShard, error) {
+			return destination, nil
+		}),
+	)
+	producer := &queueProducer{shards: registry}
+
+	require.NoError(t, producer.RequeueByJobID(context.Background(), scope, source.Name(), "job-1", time.Now()))
+	require.Equal(t, 1, source.requeueByIDCalls)
+	require.Equal(t, 2, destination.requeueByIDCalls)
 }


### PR DESCRIPTION
## Description

A queue migration can commit its ownership handoff between the producer’s current-shard attempt and its source-shard fallback. Both attempts then return `ErrQueueItemNotFound` even though the item now exists on the destination with its old schedule.

Requeue and RequeueByJobID now resolve and try the current shard once more after both initial attempts miss. The ownership handoff is a single transaction, so this bounded third attempt closes the reproduced routing window without changing shard error contracts.

The same retry is applied to both requeue variants because they have identical routing behavior. A distinct migrated-item error would provide a stronger shard-level signal, but it would require coordinated interface and downstream changes across repositories; the bounded producer retry fixes the demonstrated correctness hole directly.

The monorepo vendor follow-up must invert `TestProducerRequeueByJobIDReportsLostUpdateAcrossMigrationWindow` to assert that the requested schedule is applied.

## Release note

Fixed a queue migration race that could lose a requeue schedule update.

## Migration note

None

## Testing

- `go test -count=1 -run 'TestProducerRequeue' ./pkg/execution/queue`