### PR TITLE
fix(dashboard): allow replay when run counts fail

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/ReplayList.tsx
+++ b/ui/apps/dashboard/src/components/Functions/ReplayList.tsx
@@ -96,11 +96,16 @@ const columns = [
 ];
 
 type Props = {
+  functionID?: string;
   functionSlug: string;
   disableNewReplay?: boolean;
 };
 
-export function ReplayList({ functionSlug, disableNewReplay = false }: Props) {
+export function ReplayList({
+  functionID,
+  functionSlug,
+  disableNewReplay = false,
+}: Props) {
   const environment = useEnvironment();
   const navigate = useNavigate();
   const [replayOpen, setReplayOpen] = useState(false);
@@ -135,7 +140,7 @@ export function ReplayList({ functionSlug, disableNewReplay = false }: Props) {
                 <Button
                   label="New replay"
                   onClick={() => setReplayOpen(true)}
-                  disabled={disableNewReplay}
+                  disabled={disableNewReplay || !functionID}
                   icon={<IconReplay />}
                   iconSide="left"
                 />
@@ -152,9 +157,10 @@ export function ReplayList({ functionSlug, disableNewReplay = false }: Props) {
           />
         }
       />
-      {replayOpen && (
+      {replayOpen && functionID && (
         <NewReplayModal
           isOpen={replayOpen}
+          functionID={functionID}
           functionSlug={functionSlug}
           onClose={() => setReplayOpen(false)}
         />

--- a/ui/apps/dashboard/src/components/Replay/NewReplayButton.tsx
+++ b/ui/apps/dashboard/src/components/Replay/NewReplayButton.tsx
@@ -3,10 +3,12 @@ import { useState } from 'react';
 import NewReplayModal from '@/components/Replay/NewReplayModal';
 
 type NewReplayButtonProps = {
+  functionID: string;
   functionSlug: string;
 };
 
 export default function NewReplayButton({
+  functionID,
   functionSlug,
 }: NewReplayButtonProps) {
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -14,6 +16,7 @@ export default function NewReplayButton({
   return (
     <NewReplayModal
       isOpen={isModalVisible}
+      functionID={functionID}
       functionSlug={functionSlug}
       onClose={() => setIsModalVisible(false)}
     />

--- a/ui/apps/dashboard/src/components/Replay/NewReplayModal.tsx
+++ b/ui/apps/dashboard/src/components/Replay/NewReplayModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { Alert } from '@inngest/components/Alert';
 import { Button } from '@inngest/components/Button';
 import { InlineCode } from '@inngest/components/Code';
 import { RangePicker } from '@inngest/components/DatePicker';
@@ -81,6 +82,7 @@ type SelectableStatuses =
   | ReplayRunStatus.SkippedPaused;
 
 type NewReplayModalProps = {
+  functionID: string;
   functionSlug: string;
   isOpen: boolean;
   onClose: () => void;
@@ -92,7 +94,20 @@ export type DateRange = {
   key?: string;
 };
 
+function hasReplayableSelection({
+  runCountsFailed,
+  selectedRunsCount,
+}: {
+  runCountsFailed: boolean;
+  selectedRunsCount: number;
+}) {
+  // The count is only a preview, so a failed request shouldn't block replay
+  // creation. Only block when the request succeeds with a confirmed zero count.
+  return runCountsFailed || selectedRunsCount > 0;
+}
+
 export default function NewReplayModal({
+  functionID,
   functionSlug,
   isOpen,
   onClose,
@@ -112,7 +127,11 @@ export default function NewReplayModal({
   const logRetention = planData?.account.entitlements.history.limit || 7;
   const upgradeCutoff = subtractDuration(new Date(), { days: logRetention });
 
-  const { data, isLoading } = useSkippableGraphQLQuery({
+  const {
+    data,
+    error: runCountsError,
+    isLoading,
+  } = useSkippableGraphQLQuery({
     query: GetReplayRunCountsDocument,
     variables: {
       environmentID: environment.id,
@@ -133,6 +152,10 @@ export default function NewReplayModal({
     data?.environment.function?.replayCounts.completedCount ?? 0;
   const pausedRunsCount =
     data?.environment.function?.replayCounts.skippedPausedCount ?? 0;
+  const functionNotFound = Boolean(
+    timeRange && !isLoading && !runCountsError && !data?.environment.function,
+  );
+  const runCountsUnavailable = Boolean(runCountsError || functionNotFound);
 
   const statusCounts: Record<SelectableStatuses, number> = {
     [ReplayRunStatus.Failed]: failedRunsCount,
@@ -153,16 +176,19 @@ export default function NewReplayModal({
       return;
     }
 
-    if (selectedRunsCount === 0) {
+    if (
+      !hasReplayableSelection({
+        runCountsFailed: Boolean(runCountsError),
+        selectedRunsCount,
+      })
+    ) {
       toast.error(
         'No runs selected. Please specify a filter with at least one run.',
       );
       return;
     }
 
-    const functionID = data?.environment.function?.id;
-
-    if (!functionID) {
+    if (functionNotFound) {
       toast.error('Could not find function. Please try again later.');
       return;
     }
@@ -310,19 +336,36 @@ export default function NewReplayModal({
                     >
                       {isLoading ? (
                         <span>Loading</span>
+                      ) : runCountsUnavailable ? (
+                        <span>Unavailable</span>
                       ) : (
                         count.toLocaleString(undefined, {
                           notation: 'compact',
                           compactDisplay: 'short',
                         })
                       )}{' '}
-                      runs {isLoading ? '...' : undefined}
+                      {!runCountsUnavailable && (
+                        <> runs {isLoading ? '...' : undefined}</>
+                      )}
                     </p>
                   )}
                 </ToggleGroup.Item>
               </div>
             ))}
           </ToggleGroup.Root>
+
+          {runCountsError && (
+            <Alert severity="error" className="text-sm">
+              Failed to fetch run counts. Select a shorter time range for an
+              accurate estimate, or replay anyway using the selected statuses.
+            </Alert>
+          )}
+
+          {functionNotFound && (
+            <Alert severity="error" className="text-sm">
+              Could not find function. Please try again later.
+            </Alert>
+          )}
         </div>
         <div className="px-6 py-4">
           <div className="text-muted bg-canvasSubtle rounded-md px-6 py-4 text-sm">
@@ -342,7 +385,7 @@ export default function NewReplayModal({
         </div>
         <div className="border-subtle flex items-center justify-between gap-2 border-t px-5 py-4">
           {!timeRange && <p></p>}
-          {timeRange && !isLoading && (
+          {timeRange && !isLoading && !runCountsUnavailable && (
             <div className="flex items-center gap-2">
               <p className="text-muted inline-flex items-center gap-1.5 text-sm">
                 <RiInformationLine className="h-5 w-5" />A total of{' '}
@@ -368,7 +411,15 @@ export default function NewReplayModal({
               label="Replay Function"
               kind="primary"
               type="submit"
-              disabled={isCreatingFunctionReplay}
+              disabled={
+                isCreatingFunctionReplay ||
+                isLoading ||
+                functionNotFound ||
+                !hasReplayableSelection({
+                  runCountsFailed: Boolean(runCountsError),
+                  selectedRunsCount,
+                })
+              }
             />
           </div>
         </div>

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/replays/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/replays/index.tsx
@@ -35,16 +35,21 @@ function RouteComponent() {
     },
   });
   const functionIsPaused = data?.environment.function?.isPaused || false;
+  const functionID = data?.environment.function?.id;
 
   return (
     <>
-      {!env.isArchived && !functionIsPaused && (
+      {!env.isArchived && !functionIsPaused && functionID && (
         <div className="flex items-center justify-end px-5">
-          <NewReplayButton functionSlug={functionSlug} />
+          <NewReplayButton
+            functionID={functionID}
+            functionSlug={functionSlug}
+          />
         </div>
       )}
       <div className="h-full overflow-y-auto">
         <ReplayList
+          functionID={functionID}
           functionSlug={functionSlug}
           disableNewReplay={env.isArchived || functionIsPaused}
         />

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/route.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/route.tsx
@@ -101,9 +101,10 @@ function FunctionComponent() {
           onClose={() => setCancelOpen(false)}
         />
       )}
-      {replayOpen && (
+      {replayOpen && fn && (
         <NewReplayModal
           isOpen={replayOpen}
+          functionID={fn.id}
           functionSlug={functionSlug}
           onClose={() => setReplayOpen(false)}
         />


### PR DESCRIPTION
## Description

### Before

The modal got both the function ID and `replayCounts` from the same nested GraphQL object:

```diagram
workflowBySlug
├── id
└── replayCounts → error
```

Because `replayCounts` is non-null in the GQL schema, a backend failure to query it bubbled upward and nulled the entire workflow. The UI then:

1. Converted missing counts to zero.
2. Blocked submission because the selected count was zero.
3. Had no function ID for the mutation anyway.

### After

Because the mutation only needs the function ID and not the count, we can work around this by passing in the function ID from the surrounding page. The estimate is now only for UI.

When count fetching fails:

- Every status displays **Unavailable**, not zero.
- No aggregate or partial count is shown.
- An alert suggests selecting a shorter range or replaying anyway.
- The mutation uses the retained function ID, selected statuses, and time range.

When count fetching succeeds and we legitimately see a 0, we will block the replay creation as usual


<img width="2560" height="2000" alt="image" src="https://github.com/user-attachments/assets/0d3733d2-d031-4fe5-ac04-4a714d6acbe6" />
## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
