### PR TITLE
fix(dashboard): allow bulk cancellation when run count fails

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/CancelFunction/CancelFunctionModal.tsx
+++ b/ui/apps/dashboard/src/components/Functions/CancelFunction/CancelFunctionModal.tsx
@@ -71,6 +71,7 @@ export function CancelFunctionModal(props: Props) {
   }
 
   const countRes = useRunCount(runCountInput);
+  const functionNotFound = countRes.kind === 'function-not-found';
 
   return (
     <Modal className="w-[800px]" isOpen={isOpen} onClose={onClose}>
@@ -134,7 +135,15 @@ export function CancelFunctionModal(props: Props) {
 
           {countRes.error && (
             <Alert severity="error" className="text-sm">
-              Failed to query run count: {countRes.error.message}
+              {functionNotFound ? (
+                <>Function not found, unable to create cancellation.</>
+              ) : (
+                <>
+                  Failed to fetch an accurate run count. Select a shorter time
+                  range for an accurate estimate, or submit anyway to create the
+                  bulk cancellation.
+                </>
+              )}
             </Alert>
           )}
 
@@ -159,7 +168,12 @@ export function CancelFunctionModal(props: Props) {
           onClick={onClose}
         />
         <Button
-          disabled={isCreating || !timeRange || (countRes.data ?? 0) === 0}
+          disabled={
+            isCreating ||
+            !timeRange ||
+            functionNotFound ||
+            (!countRes.error && (countRes.data ?? 0) === 0)
+          }
           kind="danger"
           label="Submit"
           onClick={onSubmit}

--- a/ui/apps/dashboard/src/components/Functions/CancelFunction/useRunCount.test.ts
+++ b/ui/apps/dashboard/src/components/Functions/CancelFunction/useRunCount.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useRunCount } from './useRunCount';
+
+const mocks = vi.hoisted(() => ({
+  useSkippableGraphQLQuery: vi.fn(),
+}));
+
+vi.mock('@/gql', () => ({
+  graphql: vi.fn(() => ({})),
+}));
+
+vi.mock('@/utils/useGraphQLQuery', () => ({
+  useSkippableGraphQLQuery: mocks.useSkippableGraphQLQuery,
+}));
+
+describe('useRunCount', () => {
+  beforeEach(() => {
+    mocks.useSkippableGraphQLQuery.mockReset();
+  });
+
+  it('preserves a GraphQL count error when null bubbling removes the function', () => {
+    const error = new Error('error counting active runs');
+    mocks.useSkippableGraphQLQuery.mockReturnValue({
+      data: { environment: { function: null } },
+      error,
+      isLoading: false,
+      isSkipped: false,
+      refetch: vi.fn(),
+    });
+
+    const result = useRunCount();
+
+    expect(result.kind).toBe('count-error');
+    expect(result.error).toBe(error);
+    expect(result.data).toBeUndefined();
+  });
+
+  it('reports a missing function when the query itself succeeded', () => {
+    mocks.useSkippableGraphQLQuery.mockReturnValue({
+      data: { environment: { function: null } },
+      error: undefined,
+      isLoading: false,
+      isSkipped: false,
+      refetch: vi.fn(),
+    });
+
+    const result = useRunCount();
+
+    expect(result.kind).toBe('function-not-found');
+    expect(result.error?.message).toBe('function not found');
+  });
+
+  it('returns the cancellation run count after a successful query', () => {
+    mocks.useSkippableGraphQLQuery.mockReturnValue({
+      data: { environment: { function: { cancellationRunCount: 42 } } },
+      error: undefined,
+      isLoading: false,
+      isSkipped: false,
+      refetch: vi.fn(),
+    });
+
+    const result = useRunCount();
+
+    expect(result.kind).toBe('success');
+    expect(result.data).toBe(42);
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/ui/apps/dashboard/src/components/Functions/CancelFunction/useRunCount.ts
+++ b/ui/apps/dashboard/src/components/Functions/CancelFunction/useRunCount.ts
@@ -38,19 +38,33 @@ export function useRunCount(input?: RunCountInput) {
     },
   });
 
+  if (res.error) {
+    return {
+      ...baseInitialFetchFailed,
+      error: res.error,
+      kind: 'count-error' as const,
+      refetch: res.refetch,
+    };
+  }
+
   if (res.data) {
     if (!res.data.environment.function) {
       return {
         ...baseInitialFetchFailed,
         error: new Error('function not found'),
+        kind: 'function-not-found' as const,
       };
     }
 
     return {
       ...res,
       data: res.data.environment.function.cancellationRunCount,
+      kind: 'success' as const,
     };
   }
 
-  return res;
+  return {
+    ...res,
+    kind: res.isSkipped ? ('skipped' as const) : ('loading' as const),
+  };
 }


### PR DESCRIPTION
## Description

Preserve GraphQL run-count errors instead of misreporting them as a missing function. Suggest a shorter time range for an accurate estimate and allow cancellation submission without a count.

<img width="2560" height="1800" alt="image" src="https://github.com/user-attachments/assets/634c96de-438d-4edc-9654-5cf1ae8f51c6" />

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
