### PR TITLE
internal(state): expose duplicate create outcome

### DIFF
--- a/proto/gen/state/v2/state.pb.go
+++ b/proto/gen/state/v2/state.pb.go
@@ -624,10 +624,14 @@ func (x *CreateStateRequest) GetStepsInputs() [][]byte {
 }
 
 type CreateStateResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Metadata      *Metadata              `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	Events        [][]byte               `protobuf:"bytes,2,rep,name=events,proto3" json:"events,omitempty"`
-	Steps         map[string][]byte      `protobuf:"bytes,3,rep,name=steps,proto3" json:"steps,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Metadata *Metadata              `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Events   [][]byte               `protobuf:"bytes,2,rep,name=events,proto3" json:"events,omitempty"`
+	Steps    map[string][]byte      `protobuf:"bytes,3,rep,name=steps,proto3" json:"steps,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// True when the idempotency key matched an existing run. The response carries
+	// that run's state so callers can handle the duplicate without carrying state
+	// in gRPC error details.
+	AlreadyExists bool `protobuf:"varint,4,opt,name=already_exists,json=alreadyExists,proto3" json:"already_exists,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -681,6 +685,13 @@ func (x *CreateStateResponse) GetSteps() map[string][]byte {
 		return x.Steps
 	}
 	return nil
+}
+
+func (x *CreateStateResponse) GetAlreadyExists() bool {
+	if x != nil {
+		return x.AlreadyExists
+	}
+	return false
 }
 
 type DeleteStateRequest struct {
@@ -2522,11 +2533,12 @@ const file_state_v2_state_proto_rawDesc = "" +
 	"\bmetadata\x18\x01 \x01(\v2\x12.state.v2.MetadataR\bmetadata\x12\x16\n" +
 	"\x06events\x18\x02 \x03(\fR\x06events\x12\x14\n" +
 	"\x05steps\x18\x03 \x03(\fR\x05steps\x12!\n" +
-	"\fsteps_inputs\x18\x04 \x03(\fR\vstepsInputs\"\xd7\x01\n" +
+	"\fsteps_inputs\x18\x04 \x03(\fR\vstepsInputs\"\xfe\x01\n" +
 	"\x13CreateStateResponse\x12.\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x12.state.v2.MetadataR\bmetadata\x12\x16\n" +
 	"\x06events\x18\x02 \x03(\fR\x06events\x12>\n" +
-	"\x05steps\x18\x03 \x03(\v2(.state.v2.CreateStateResponse.StepsEntryR\x05steps\x1a8\n" +
+	"\x05steps\x18\x03 \x03(\v2(.state.v2.CreateStateResponse.StepsEntryR\x05steps\x12%\n" +
+	"\x0ealready_exists\x18\x04 \x01(\bR\ralreadyExists\x1a8\n" +
 	"\n" +
 	"StepsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +

--- a/proto/state/v2/state.proto
+++ b/proto/state/v2/state.proto
@@ -71,6 +71,11 @@ message CreateStateResponse {
   Metadata           metadata = 1;
   repeated bytes     events   = 2;
   map<string, bytes> steps    = 3;
+
+  // True when the idempotency key matched an existing run. The response carries
+  // that run's state so callers can handle the duplicate without carrying state
+  // in gRPC error details.
+  bool already_exists = 4;
 }
 
 message DeleteStateRequest {


### PR DESCRIPTION
## Description

Adds an `already_exists` outcome to `CreateStateResponse`. This lets state-proxy clients distinguish duplicate creates while receiving the existing state through the normal response body instead of gRPC error details.

Today, we send the existing state back as an ErrorDetail in the header which has a limit of 16MiB.

See https://linear.app/inngest/issue/SYS-1308/state-proxy-duplicate-create-responses-cause-grpc-compression-error for more details

Follow up Cloud PRs to fix clients and servers respectively:
- https://github.com/inngest/monorepo/pull/8610
- https://github.com/inngest/monorepo/pull/8611

## Release note

None.

## Migration note

The field is backward compatible. Cloud clients must support this field before state-proxy servers begin returning duplicate creates as successful responses.
