### PR TITLE
fix(components): NewCodeBlock drag-to-select breaks when a mid-drag resize hits the editor

### DIFF
--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -440,15 +440,20 @@ export const NewCodeBlock = ({
                       </span>
                     )}
                   </code>
-                  {cursorPath && (
+                  {/* Always mounted, hidden via `invisible` instead of
+                      conditional rendering -- mounting it on the first
+                      cursor move resizes this bar, which resizes the
+                      editor (a flex sibling) mid-drag and permanently
+                      breaks Monaco's drag-selection tracking. */}
+                  <div className={cn(!cursorPath && 'invisible')}>
                     <CopyButton
                       size="small"
-                      code={cursorPath}
+                      code={cursorPath ?? ''}
                       isCopying={isPathCopying}
                       handleCopyClick={handlePathCopyClick}
                       appearance="outlined"
                     />
-                  )}
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

The JSON helper at the bottom of the NewCodeBlock component breaks editor drag-selecting when it resizes. Currently it resizes when a json path is selected/deselected

<img width="387" height="1046" alt="image" src="https://github.com/user-attachments/assets/702b0583-dd9b-4867-a29f-7809f1bc2132" />

This just makes the JSON helper not resize by unconditionally rendering the copy button (but hiding it when no path is selected)


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
