### PR TITLE
fix(api): REST v1 GET requests should keep their error codes

### DIFF
--- a/pkg/api/apiv1/cache.go
+++ b/pkg/api/apiv1/cache.go
@@ -73,6 +73,8 @@ func (c cacheMiddleware[T]) Middleware(next http.Handler) http.Handler {
 					PkgName: pkgName,
 					Tags:    map[string]any{"route": route},
 				})
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write(data)
 				return
 			}
@@ -83,23 +85,26 @@ func (c cacheMiddleware[T]) Middleware(next http.Handler) http.Handler {
 		// Record the response from the handler itself.
 		rec := httptest.NewRecorder()
 		next.ServeHTTP(rec, r)
+		result := rec.Result()
+		defer result.Body.Close()
 
 		// Write headers to the actual response, inspecting the max-age HTTP
 		// header which determines cacheability in the result itself.
 		maxAge := int32(0)
-		for key, result := range rec.Result().Header {
-			if key == "Cache-Control" && len(result) == 1 {
-				if res, err := cacheobject.ParseResponseCacheControl(result[0]); err == nil {
+		for key, values := range result.Header {
+			if key == "Cache-Control" && len(values) == 1 {
+				if res, err := cacheobject.ParseResponseCacheControl(values[0]); err == nil {
 					maxAge = int32(res.MaxAge)
 				}
 			}
-			for _, item := range result {
+			for _, item := range values {
 				w.Header().Add(key, item)
 			}
 		}
+		w.WriteHeader(result.StatusCode)
 
-		if maxAge == 0 {
-			// If there's no max-age header, we cannot cache the response.
+		if maxAge == 0 || result.StatusCode != http.StatusOK {
+			// If there's no max-age header or the response is not OK, we cannot cache it.
 			// Ignore.
 			if _, err := io.Copy(w, rec.Body); err != nil {
 				logger.StdlibLogger(ctx).Error("error writing api response", "error", err)

--- a/pkg/api/apiv1/cache_test.go
+++ b/pkg/api/apiv1/cache_test.go
@@ -1,0 +1,194 @@
+package apiv1_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coocood/freecache"
+	"github.com/eko/gocache/lib/v4/cache"
+	"github.com/eko/gocache/lib/v4/store"
+	freecachestore "github.com/eko/gocache/store/freecache/v4"
+	"github.com/go-chi/chi/v5"
+	"github.com/golang/mock/gomock"
+	"github.com/inngest/inngest/pkg/api/apiv1"
+	"github.com/stretchr/testify/require"
+)
+
+func newCacheTestHandler(t *testing.T, next http.Handler) http.Handler {
+	t.Helper()
+	c := cache.New[[]byte](freecachestore.NewFreecache(freecache.NewCache(1024 * 1024)))
+	return apiv1.NewCacheMiddleware(c).Middleware(next)
+}
+
+func newCacheTestRequest(method, target, authorization string) *http.Request {
+	req := httptest.NewRequest(method, target, nil)
+	req.Header.Set("Authorization", authorization)
+	routeCtx := chi.NewRouteContext()
+	routeCtx.RoutePatterns = append(routeCtx.RoutePatterns, "/v1/test")
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+}
+
+func TestCacheMiddlewareForwardsUncachedResponse(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{name: "OK", status: http.StatusOK},
+		{name: "bad request", status: http.StatusBadRequest},
+		{name: "not found", status: http.StatusNotFound},
+		{name: "rate limited", status: http.StatusTooManyRequests},
+		{name: "internal server error", status: http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := newCacheTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("X-Test-Header", "preserved")
+				w.WriteHeader(tt.status)
+				_, err := w.Write([]byte("response body"))
+				require.NoError(t, err)
+			}))
+
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, newCacheTestRequest(http.MethodGet, "/v1/test", "key"))
+
+			require.Equal(t, tt.status, rec.Code)
+			require.Equal(t, "preserved", rec.Header().Get("X-Test-Header"))
+			require.Equal(t, "response body", rec.Body.String())
+		})
+	}
+}
+
+func TestCacheMiddlewareCachesOnlyOKResponses(t *testing.T) {
+	t.Run("caches an OK response", func(t *testing.T) {
+		calls := 0
+		handler := newCacheTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.Header().Set("Cache-Control", "private, max-age=60")
+			w.Header().Set("Content-Type", "application/json")
+			_, err := fmt.Fprintf(w, `{"call":%d}`, calls)
+			require.NoError(t, err)
+		}))
+
+		first := httptest.NewRecorder()
+		handler.ServeHTTP(first, newCacheTestRequest(http.MethodGet, "/v1/test", "key"))
+		second := httptest.NewRecorder()
+		handler.ServeHTTP(second, newCacheTestRequest(http.MethodGet, "/v1/test", "key"))
+
+		require.Equal(t, 1, calls)
+		require.Equal(t, http.StatusOK, first.Code)
+		require.Equal(t, `{"call":1}`, first.Body.String())
+		require.Equal(t, "application/json", first.Header().Get("Content-Type"))
+		require.Equal(t, http.StatusOK, second.Code)
+		require.Equal(t, `{"call":1}`, second.Body.String())
+		require.Equal(t, "application/json", second.Header().Get("Content-Type"))
+		require.Empty(t, second.Header().Get("Cache-Control"))
+	})
+
+	for _, status := range []int{http.StatusCreated, http.StatusNotFound} {
+		t.Run(fmt.Sprintf("does not cache status %d", status), func(t *testing.T) {
+			calls := 0
+			handler := newCacheTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				w.Header().Set("Cache-Control", "private, max-age=60")
+				w.WriteHeader(status)
+				_, err := fmt.Fprintf(w, "call %d", calls)
+				require.NoError(t, err)
+			}))
+
+			first := httptest.NewRecorder()
+			handler.ServeHTTP(first, newCacheTestRequest(http.MethodGet, "/v1/test", "key"))
+			second := httptest.NewRecorder()
+			handler.ServeHTTP(second, newCacheTestRequest(http.MethodGet, "/v1/test", "key"))
+
+			require.Equal(t, 2, calls)
+			require.Equal(t, status, first.Code)
+			require.Equal(t, "call 1", first.Body.String())
+			require.Equal(t, status, second.Code)
+			require.Equal(t, "call 2", second.Body.String())
+		})
+	}
+}
+
+func TestCacheMiddlewareSupportsStringCacheValues(t *testing.T) {
+	cacheStore := store.NewMockStoreInterface(gomock.NewController(t))
+	cacheStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, store.NotFound{})
+	cacheStore.EXPECT().Set(gomock.Any(), gomock.Any(), `{"cached":true}`, gomock.Any()).Return(nil)
+	cacheStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return(`{"cached":true}`, nil)
+	handler := apiv1.NewCacheMiddleware(cache.New[string](cacheStore)).Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Cache-Control", "private, max-age=60")
+		_, err := w.Write([]byte(`{"cached":true}`))
+		require.NoError(t, err)
+	}))
+
+	handler.ServeHTTP(httptest.NewRecorder(), newCacheTestRequest(http.MethodGet, "/v1/test", "key"))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, newCacheTestRequest(http.MethodGet, "/v1/test", "key"))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	require.Equal(t, `{"cached":true}`, rec.Body.String())
+}
+
+func TestCacheMiddlewareDoesNotCacheWithoutMaxAge(t *testing.T) {
+	calls := 0
+	handler := newCacheTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, err := fmt.Fprintf(w, "call %d", calls)
+		require.NoError(t, err)
+	}))
+
+	for range 2 {
+		handler.ServeHTTP(httptest.NewRecorder(), newCacheTestRequest(http.MethodGet, "/v1/test", "key"))
+	}
+
+	require.Equal(t, 2, calls)
+}
+
+func TestCacheMiddlewareBypassesNonGETRequests(t *testing.T) {
+	calls := 0
+	handler := newCacheTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Cache-Control", "private, max-age=60")
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	for range 2 {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, newCacheTestRequest(http.MethodPost, "/v1/test", "key"))
+		require.Equal(t, http.StatusCreated, rec.Code)
+	}
+
+	require.Equal(t, 2, calls)
+}
+
+func TestCacheMiddlewareKeyIncludesURLAndAuthorization(t *testing.T) {
+	calls := 0
+	handler := newCacheTestHandler(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Cache-Control", "private, max-age=60")
+		_, err := fmt.Fprintf(w, "call %d", calls)
+		require.NoError(t, err)
+	}))
+
+	tests := []struct {
+		target        string
+		authorization string
+		wantBody      string
+	}{
+		{target: "/v1/test?value=a", authorization: "key-a", wantBody: "call 1"},
+		{target: "/v1/test?value=a", authorization: "key-a", wantBody: "call 1"},
+		{target: "/v1/test?value=b", authorization: "key-a", wantBody: "call 2"},
+		{target: "/v1/test?value=a", authorization: "key-b", wantBody: "call 3"},
+	}
+
+	for _, tt := range tests {
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, newCacheTestRequest(http.MethodGet, tt.target, tt.authorization))
+		require.Equal(t, tt.wantBody, rec.Body.String())
+	}
+	require.Equal(t, 3, calls)
+}

--- a/pkg/api/apiv1/cache_test.go
+++ b/pkg/api/apiv1/cache_test.go
@@ -6,16 +6,56 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/coocood/freecache"
 	"github.com/eko/gocache/lib/v4/cache"
 	"github.com/eko/gocache/lib/v4/store"
 	freecachestore "github.com/eko/gocache/store/freecache/v4"
 	"github.com/go-chi/chi/v5"
-	"github.com/golang/mock/gomock"
 	"github.com/inngest/inngest/pkg/api/apiv1"
 	"github.com/stretchr/testify/require"
 )
+
+type cacheTestStore struct {
+	data map[any]any
+}
+
+func (s *cacheTestStore) Get(_ context.Context, key any) (any, error) {
+	value, ok := s.data[key]
+	if !ok {
+		return nil, store.NotFound{}
+	}
+	return value, nil
+}
+
+func (s *cacheTestStore) GetWithTTL(ctx context.Context, key any) (any, time.Duration, error) {
+	value, err := s.Get(ctx, key)
+	return value, 0, err
+}
+
+func (s *cacheTestStore) Set(_ context.Context, key, value any, _ ...store.Option) error {
+	s.data[key] = value
+	return nil
+}
+
+func (s *cacheTestStore) Delete(_ context.Context, key any) error {
+	delete(s.data, key)
+	return nil
+}
+
+func (s *cacheTestStore) Invalidate(ctx context.Context, _ ...store.InvalidateOption) error {
+	return s.Clear(ctx)
+}
+
+func (s *cacheTestStore) Clear(context.Context) error {
+	clear(s.data)
+	return nil
+}
+
+func (*cacheTestStore) GetType() string {
+	return "test"
+}
 
 func newCacheTestHandler(t *testing.T, next http.Handler) http.Handler {
 	t.Helper()
@@ -114,10 +154,7 @@ func TestCacheMiddlewareCachesOnlyOKResponses(t *testing.T) {
 }
 
 func TestCacheMiddlewareSupportsStringCacheValues(t *testing.T) {
-	cacheStore := store.NewMockStoreInterface(gomock.NewController(t))
-	cacheStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, store.NotFound{})
-	cacheStore.EXPECT().Set(gomock.Any(), gomock.Any(), `{"cached":true}`, gomock.Any()).Return(nil)
-	cacheStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return(`{"cached":true}`, nil)
+	cacheStore := &cacheTestStore{data: map[any]any{}}
 	handler := apiv1.NewCacheMiddleware(cache.New[string](cacheStore)).Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Cache-Control", "private, max-age=60")
 		_, err := w.Write([]byte(`{"cached":true}`))


### PR DESCRIPTION
<img width="563" height="544" alt="student passing 200 request to next student who sees it's actually an error" src="https://github.com/user-attachments/assets/fa043ab6-d177-40d4-a9a3-3accb8de0418" />

## Description

- We receive a customer report of 200 requests with error bodies. Part of this is due to our REST v1 caching semantics. Let's minimally tighten them to ensure proper status codes
- Previously, we could cache errors and then serve them with non-matching 200 statuses




Define and enforce the REST v1 response-cache contract:

- Forward the recorded status, headers, and body for uncached responses instead of allowing body writes to implicitly produce HTTP 200.
- Cache only HTTP 200 responses that explicitly set a positive `max-age`.
- Return cached response bodies explicitly as HTTP 200 JSON without extending client-side cache lifetime.
- Preserve the existing URL-and-authorization cache-key isolation and non-GET bypass behavior.

### Behavior changes

| Scenario | Before | After |
| --- | --- | --- |
| Uncached handler returns 400, 404, 429, or 500 | Client receives HTTP 200 with the original error body | Client receives the handler's original status, headers, and body |
| HTTP 200 response with positive `max-age` | Response body is cached | Response body remains cached |
| Cache hit for a successful response | Body is returned with an implicit HTTP 200 and may be detected as `text/plain` | Body is returned with an explicit HTTP 200 and `Content-Type: application/json` |
| Non-200 response with positive `max-age` | Body is cached and a later hit returns it as HTTP 200 | Response is forwarded with its original status and is not cached |
| Response without positive `max-age` | Not cached | Remains uncached |
| Non-GET request | Bypasses the cache | Continues to bypass the cache |

The commits follow TDD: the first commit captures both existing behavior and the intended changes, and fails against the old middleware; the second makes the suite green. Coverage includes 200, 201, 400, 404, 429, and 500 responses, cache hits, missing `max-age`, non-GET requests, key isolation, and both byte and string cache values.

## Release note

REST v1 endpoints now preserve non-200 HTTP statuses through the response cache, and only successful HTTP 200 responses are cached.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
